### PR TITLE
Fix the focus color of a dropdown nav-item

### DIFF
--- a/website/thaliawebsite/static/css/base.scss
+++ b/website/thaliawebsite/static/css/base.scss
@@ -281,6 +281,11 @@ footer {
         font-size: .8rem;
         color: $nav-link-color;
 
+        &:focus {
+            background-color: $preset-hover;
+            color: $preset-contrast-hover;
+        }
+
         &:hover, &:active, &.active {
             background-color: $preset;
             color: $preset-contrast;


### PR DESCRIPTION
Closes #1056

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This fixes the background color of the dropdown navigation items when focused.

### How to test
Steps to test the changes you made:
1. Make sure you get an item focused in the dropdown of the user menu
2. Previously it would look like this:
![Screenshot 2020-03-26 at 13 00 33](https://user-images.githubusercontent.com/1799914/77644832-fd46ae00-6f61-11ea-8b07-4fa21d773094.png)

3. Now it should look like this:
![Screenshot 2020-03-26 at 13 00 47](https://user-images.githubusercontent.com/1799914/77644841-ffa90800-6f61-11ea-941e-92254e7a114f.png)
