### PR TITLE
Change partner banner filters

### DIFF
--- a/website/partners/static/partners/css/style.scss
+++ b/website/partners/static/partners/css/style.scss
@@ -15,7 +15,7 @@
                 max-height: 100%;
                 height: 100%;
                 text-align: center;
-                padding: 2rem 1rem;
+                padding: 2rem;
             }
         }
 
@@ -23,33 +23,30 @@
             display: block;
             max-height: 100%;
             height: 100%;
-            -moz-transition: 0.2s ease-in-out 0s;
-            -o-transition: 0.2s ease-in-out 0s;
-            -webkit-transition: 0.2s ease-in-out 0s;
-            -ms-transition: 0.2s ease-in-out 0s;
-            transition: 0.2s ease-in-out 0s;
+            transition: .4s ease-in-out 0s;
 
             .image {
                 height: 100%;
                 width: 100%;
-                -moz-transition: 0.2s ease-in-out 0s;
-                -o-transition: 0.2s ease-in-out 0s;
-                -webkit-transition: 0.2s ease-in-out 0s;
-                -ms-transition: 0.2s ease-in-out 0s;
-                transition: 0.2s ease-in-out 0s;
 
-                -webkit-filter: grayscale(1);
-                filter: grayscale(1);
+                opacity: 0.4;
+                filter: brightness(0);
+                @media (prefers-color-scheme: dark) {
+                    filter: contrast(0) brightness(100);
+                }
 
                 object-fit: contain;
             }
 
             &:hover {
-                padding: 2px;
+                padding: .2rem;
 
                 .image {
-                    -webkit-filter: grayscale(0);
-                    filter: grayscale(0);
+                    filter: brightness(1);
+                    @media (prefers-color-scheme: dark) {
+                        filter: contrast(1) brightness(1);
+                    }
+                    opacity: 1;
                 }
             }
         }

--- a/website/partners/templates/partners/banners.html
+++ b/website/partners/templates/partners/banners.html
@@ -5,7 +5,7 @@
             {% for partner in partners %}
                 <div class="banner col-6 col-md-4 col-lg-3">
                     <a href="{% url "partners:partner" partner.slug %}">
-                        <img class="animated zoomIn image text-hide"
+                        <img class="image text-hide"
                              alt="Logo {{ partner.name }}"
                              src="{% thumbnail partner.logo thumb_size fit=False %}"/>
                     </a>


### PR DESCRIPTION
Closes #1021 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I have changed the filter used on the partner banners to differentiate between light and dark mode. Different filters for the different modes.

They should look like this:
<img width="1228" alt="Screenshot 2020-03-29 at 16 22 35" src="https://user-images.githubusercontent.com/1799914/77851605-57ea3f00-71da-11ea-9480-1fd13a59e19e.png">
![Screenshot 2020-03-29 at 16 22 46](https://user-images.githubusercontent.com/1799914/77851609-5ae52f80-71da-11ea-9f0a-daeaad18703c.png)


### How to test
Steps to test the changes you made:
1. Open the homepage
