### PR TITLE
Refactor events API code into separate files

### DIFF
--- a/docs/events.api.rst
+++ b/docs/events.api.rst
@@ -6,6 +6,14 @@ events.api package
    :undoc-members:
    :show-inheritance:
 
+Subpackages
+-----------
+
+.. toctree::
+
+   events.api.serializers
+   events.api.viewsets
+
 Submodules
 ----------
 
@@ -17,26 +25,10 @@ events.api.permissions module
    :undoc-members:
    :show-inheritance:
 
-events.api.serializers module
------------------------------
-
-.. automodule:: events.api.serializers
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 events.api.urls module
 ----------------------
 
 .. automodule:: events.api.urls
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-events.api.viewsets module
---------------------------
-
-.. automodule:: events.api.viewsets
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/events.api.serializers.base.rst
+++ b/docs/events.api.serializers.base.rst
@@ -1,0 +1,19 @@
+events.api.serializers.base package
+===================================
+
+.. automodule:: events.api.serializers.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+events.api.serializers.base.calendarjs module
+---------------------------------------------
+
+.. automodule:: events.api.serializers.base.calendarjs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/events.api.serializers.event_registrations.rst
+++ b/docs/events.api.serializers.event_registrations.rst
@@ -1,0 +1,19 @@
+events.api.serializers.event\_registrations package
+===================================================
+
+.. automodule:: events.api.serializers.event_registrations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+events.api.serializers.event\_registrations.list module
+-------------------------------------------------------
+
+.. automodule:: events.api.serializers.event_registrations.list
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/events.api.serializers.events.rst
+++ b/docs/events.api.serializers.events.rst
@@ -1,0 +1,35 @@
+events.api.serializers.events package
+=====================================
+
+.. automodule:: events.api.serializers.events
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+events.api.serializers.events.calendarjs module
+-----------------------------------------------
+
+.. automodule:: events.api.serializers.events.calendarjs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+events.api.serializers.events.list module
+-----------------------------------------
+
+.. automodule:: events.api.serializers.events.list
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+events.api.serializers.events.retrieve module
+---------------------------------------------
+
+.. automodule:: events.api.serializers.events.retrieve
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/events.api.serializers.rst
+++ b/docs/events.api.serializers.rst
@@ -1,0 +1,16 @@
+events.api.serializers package
+==============================
+
+.. automodule:: events.api.serializers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+
+   events.api.serializers.base
+   events.api.serializers.event_registrations
+   events.api.serializers.events

--- a/docs/events.api.viewsets.rst
+++ b/docs/events.api.viewsets.rst
@@ -1,0 +1,27 @@
+events.api.viewsets package
+===========================
+
+.. automodule:: events.api.viewsets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+events.api.viewsets.event\_registrations module
+-----------------------------------------------
+
+.. automodule:: events.api.viewsets.event_registrations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+events.api.viewsets.events module
+---------------------------------
+
+.. automodule:: events.api.viewsets.events
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/website/events/api/serializers/__init__.py
+++ b/website/events/api/serializers/__init__.py
@@ -1,0 +1,3 @@
+from .base import *
+from .events import *
+from .event_registrations import *

--- a/website/events/api/serializers/base/__init__.py
+++ b/website/events/api/serializers/base/__init__.py
@@ -1,0 +1,1 @@
+from .calendarjs import *

--- a/website/events/api/serializers/base/calendarjs.py
+++ b/website/events/api/serializers/base/calendarjs.py
@@ -1,0 +1,65 @@
+from django.utils import timezone
+from django.utils.html import strip_tags
+from html import unescape
+from rest_framework import serializers
+from html import unescape
+
+from django.utils import timezone
+from django.utils.html import strip_tags
+from rest_framework import serializers
+
+
+class CalenderJSSerializer(serializers.ModelSerializer):
+    """
+    Serializer using the right format for CalendarJS
+    """
+
+    class Meta:
+        fields = (
+            "start",
+            "end",
+            "allDay",
+            "isBirthday",
+            "url",
+            "title",
+            "description",
+            "classNames",
+            "blank",
+        )
+
+    start = serializers.SerializerMethodField("_start")
+    end = serializers.SerializerMethodField("_end")
+    allDay = serializers.SerializerMethodField("_all_day")
+    isBirthday = serializers.SerializerMethodField("_is_birthday")
+    url = serializers.SerializerMethodField("_url")
+    title = serializers.SerializerMethodField("_title")
+    description = serializers.SerializerMethodField("_description")
+    classNames = serializers.SerializerMethodField("_class_names")
+    blank = serializers.SerializerMethodField("_target_blank")
+
+    def _start(self, instance):
+        return timezone.localtime(instance.start)
+
+    def _end(self, instance):
+        return timezone.localtime(instance.end)
+
+    def _all_day(self, instance):
+        return False
+
+    def _is_birthday(self, instance):
+        return False
+
+    def _url(self, instance):
+        raise NotImplementedError
+
+    def _title(self, instance):
+        return instance.title
+
+    def _description(self, instance):
+        return unescape(strip_tags(instance.description))
+
+    def _class_names(self, instance):
+        pass
+
+    def _target_blank(self, instance):
+        return False

--- a/website/events/api/serializers/event_registrations/__init__.py
+++ b/website/events/api/serializers/event_registrations/__init__.py
@@ -1,0 +1,1 @@
+from .list import *

--- a/website/events/api/serializers/events/__init__.py
+++ b/website/events/api/serializers/events/__init__.py
@@ -1,0 +1,3 @@
+from .calendarjs import *
+from .list import *
+from .retrieve import *

--- a/website/events/api/serializers/events/calendarjs.py
+++ b/website/events/api/serializers/events/calendarjs.py
@@ -1,0 +1,36 @@
+from django.urls import reverse
+
+from events import services
+from events.api.serializers.base.calendarjs import CalenderJSSerializer
+from events.models import Event
+
+
+class EventsCalenderJSSerializer(CalenderJSSerializer):
+    class Meta(CalenderJSSerializer.Meta):
+        model = Event
+
+    def _url(self, instance):
+        return reverse("events:event", kwargs={"pk": instance.id})
+
+    def _class_names(self, instance):
+        class_names = ["regular-event"]
+        if self.context["member"] and services.is_user_registered(
+            self.context["member"], instance
+        ):
+            class_names.append("has-registration")
+        return class_names
+
+
+class UnpublishedEventsCalenderJSSerializer(CalenderJSSerializer):
+    """
+    See CalenderJSSerializer, customised classes
+    """
+
+    class Meta(CalenderJSSerializer.Meta):
+        model = Event
+
+    def _class_names(self, instance):
+        return ["unpublished-event"]
+
+    def _url(self, instance):
+        return reverse("admin:events_event_details", kwargs={"pk": instance.id})

--- a/website/events/api/serializers/events/list.py
+++ b/website/events/api/serializers/events/list.py
@@ -1,0 +1,49 @@
+from html import unescape
+
+from django.utils.html import strip_tags
+from rest_framework import serializers
+
+from events import services
+from events.models import Event
+from pizzas.models import PizzaEvent
+
+
+class EventListSerializer(serializers.ModelSerializer):
+    """Custom list serializer for events"""
+
+    class Meta:
+        model = Event
+        fields = (
+            "pk",
+            "title",
+            "description",
+            "start",
+            "end",
+            "location",
+            "price",
+            "registered",
+            "pizza",
+            "registration_allowed",
+        )
+
+    description = serializers.SerializerMethodField("_description")
+    registered = serializers.SerializerMethodField("_registered")
+    pizza = serializers.SerializerMethodField("_pizza")
+
+    def _description(self, instance):
+        return unescape(strip_tags(instance.description))
+
+    def _registered(self, instance):
+        try:
+            registered = services.is_user_registered(
+                self.context["request"].user, instance,
+            )
+            if registered is None:
+                return False
+            return registered
+        except AttributeError:
+            return False
+
+    def _pizza(self, instance):
+        pizza_events = PizzaEvent.objects.filter(event=instance)
+        return pizza_events.exists()

--- a/website/events/api/serializers/events/retrieve.py
+++ b/website/events/api/serializers/events/retrieve.py
@@ -1,0 +1,98 @@
+from django.utils.html import strip_spaces_between_tags
+from rest_framework import serializers
+
+from events import services
+from events.api.serializers.event_registrations.list import (
+    EventRegistrationAdminListSerializer,
+)
+from events.models import Event, EventRegistration
+from thaliawebsite.templatetags.bleach_tags import bleach
+from utils.snippets import create_google_maps_url
+
+
+class EventRetrieveSerializer(serializers.ModelSerializer):
+    """
+    Serializer for events
+    """
+
+    class Meta:
+        model = Event
+        fields = (
+            "pk",
+            "title",
+            "description",
+            "start",
+            "end",
+            "organiser",
+            "category",
+            "registration_start",
+            "registration_end",
+            "cancel_deadline",
+            "location",
+            "map_location",
+            "price",
+            "fine",
+            "max_participants",
+            "num_participants",
+            "user_registration",
+            "registration_allowed",
+            "no_registration_message",
+            "has_fields",
+            "is_pizza_event",
+            "google_maps_url",
+            "is_admin",
+        )
+
+    description = serializers.SerializerMethodField("_description")
+    user_registration = serializers.SerializerMethodField("_user_registration")
+    num_participants = serializers.SerializerMethodField("_num_participants")
+    registration_allowed = serializers.SerializerMethodField("_registration_allowed")
+    has_fields = serializers.SerializerMethodField("_has_fields")
+    is_pizza_event = serializers.SerializerMethodField("_is_pizza_event")
+    google_maps_url = serializers.SerializerMethodField("_google_maps_url")
+    is_admin = serializers.SerializerMethodField("_is_admin")
+
+    def _description(self, instance):
+        return strip_spaces_between_tags(bleach(instance.description))
+
+    def _num_participants(self, instance):
+        if (
+            instance.max_participants
+            and instance.participants.count() > instance.max_participants
+        ):
+            return instance.max_participants
+        return instance.participants.count()
+
+    def _user_registration(self, instance):
+        try:
+            if self.context["request"].member:
+                reg = instance.eventregistration_set.get(
+                    member=self.context["request"].member
+                )
+                return EventRegistrationAdminListSerializer(
+                    reg, context=self.context
+                ).data
+        except EventRegistration.DoesNotExist:
+            pass
+        return None
+
+    def _registration_allowed(self, instance):
+        member = self.context["request"].member
+        return (
+            self.context["request"].user.is_authenticated
+            and member.has_active_membership
+            and member.can_attend_events
+        )
+
+    def _has_fields(self, instance):
+        return instance.has_fields()
+
+    def _is_pizza_event(self, instance):
+        return instance.is_pizza_event()
+
+    def _google_maps_url(self, instance):
+        return create_google_maps_url(instance.map_location, zoom=13, size="450x250")
+
+    def _is_admin(self, instance):
+        member = self.context["request"].member
+        return services.is_organiser(member, instance)

--- a/website/events/api/urls.py
+++ b/website/events/api/urls.py
@@ -5,5 +5,5 @@ from events.api import viewsets
 
 router = routers.SimpleRouter()
 router.register(r"events", viewsets.EventViewset)
-router.register(r"registrations", viewsets.RegistrationViewSet)
+router.register(r"registrations", viewsets.EventRegistrationViewSet)
 urlpatterns = router.urls

--- a/website/events/api/viewsets/__init__.py
+++ b/website/events/api/viewsets/__init__.py
@@ -1,0 +1,2 @@
+from .events import *
+from .event_registrations import *

--- a/website/events/api/viewsets/event_registrations.py
+++ b/website/events/api/viewsets/event_registrations.py
@@ -1,0 +1,69 @@
+from rest_framework.exceptions import PermissionDenied, NotFound
+from rest_framework.mixins import RetrieveModelMixin, UpdateModelMixin
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from events import services
+from events.api.serializers import EventRegistrationSerializer
+from events.exceptions import RegistrationError
+from events.models import EventRegistration
+
+
+class EventRegistrationViewSet(GenericViewSet, RetrieveModelMixin, UpdateModelMixin):
+    """
+    Defines the viewset for registrations, requires an authenticated user.
+    Has custom update and destroy methods that use the services.
+    """
+
+    queryset = EventRegistration.objects.all()
+    serializer_class = EventRegistrationSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["request"] = self.request
+        return context
+
+    def get_object(self):
+        instance = super().get_object()
+        if (
+            instance.name or instance.member.pk != self.request.member.pk
+        ) and not services.is_organiser(self.request.member, instance.event):
+            raise NotFound()
+
+        return instance
+
+    # Always set instance so that OPTIONS call will show the info fields too
+    def get_serializer(self, *args, **kwargs):
+        if len(args) == 0 and "instance" not in kwargs:
+            kwargs["instance"] = self.get_object()
+        return super().get_serializer(*args, **kwargs)
+
+    def perform_update(self, serializer):
+        registration = serializer.instance
+
+        member = self.request.member
+        if (
+            member
+            and member.has_perm("events.change_registration")
+            and services.is_organiser(member, registration.event)
+        ):
+            services.update_registration_by_organiser(
+                registration, self.request.member, serializer.validated_data
+            )
+
+        services.update_registration(
+            registration=registration, field_values=serializer.field_values()
+        )
+        serializer.information_fields = services.registration_fields(
+            serializer.context["request"], registration=registration
+        )
+
+    def destroy(self, request, pk=None, **kwargs):
+        registration = self.get_object()
+        try:
+            services.cancel_registration(registration.member, registration.event)
+            return Response(status=204)
+        except RegistrationError as e:
+            raise PermissionDenied(detail=e)


### PR DESCRIPTION
### Summary
Refactor events API code to separate files because some files were of immense size. And there would be no reason to not make it smaller, since it is easier to navigate between the files now.

### How to test
Steps to test the changes you made:
1. Check that the events API still works
