### PR TITLE
grep the last commit hash

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get commit hash
-        run: echo ::set-env name=COMMIT_SHA::$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | head --lines 1 | cut --delimiter " " --fields 2)
+        run: echo ::set-env name=COMMIT_SHA::$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | grep --perl-regexp '^From [a-z0-9]{40} ' | tail --lines 1 | cut --delimiter " " --fields 2)
 
       - name: Generate username
         run: echo ::set-env name=username::$(head /dev/urandom | tr -dc 'a-z' | head -c 10)
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get commit hash
-        run: echo ::set-env name=COMMIT_SHA::$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | head --lines 1 | cut --delimiter " " --fields 2)
+        run: echo ::set-env name=COMMIT_SHA::$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | grep --perl-regexp '^From [a-z0-9]{40} ' | tail --lines 1 | cut --delimiter " " --fields 2)
 
       - name: Run script to remove review environment
         run: resources/continuous-integration/review/review-host-remove.sh


### PR DESCRIPTION
### Summary
Currently, the review environment configuration takes the first commit hash of a pull request. However, the last commit hash should be used and when there are multiple commits, the first and the last are of course not the same.

This PR fixes that by taking the last commit.
