### PR TITLE
Add Code Climate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+version: "2"
+exclude_patterns:
+  - "**/migrations/*.py"
+  - "docs/"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Thalia Website
 [![coverage](https://img.shields.io/badge/coverage-view-important)](https://thalia-coverage.s3.amazonaws.com/master/index.html)
 [![documentation](https://img.shields.io/badge/documentation-view-blueviolet)](https://thalia-documentation.s3.amazonaws.com/master/index.html)
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code Climate](https://codeclimate.com/github/svthalia/concrexit/badges/gpa.svg)](https://codeclimate.com/github/svthalia/concrexit)
 
 The latest Thalia Website built on Django.
 


### PR DESCRIPTION
### Summary
This  configuration excludes the migrations paths from the code climate analysis. And adds a badge to the readme.