### PR TITLE
Fix newsletter showing unpublished events

### DIFF
--- a/website/newsletters/services.py
+++ b/website/newsletters/services.py
@@ -55,11 +55,12 @@ def save_to_disk(newsletter, request):
 
 def get_agenda(start_date):
     end_date = start_date + timezone.timedelta(weeks=2)
-    base_events = Event.objects.filter(
-        start__gte=start_date, end__lt=end_date, published=True
+    published_events = Event.objects.filter(published=True)
+    base_events = published_events.filter(
+        start__gte=start_date, end__lt=end_date
     ).order_by("start")
     if base_events.count() < 10:
-        more_events = Event.objects.filter(end__gte=end_date).order_by("start")
+        more_events = published_events.filter(end__gte=end_date).order_by("start")
         return [*base_events, *more_events][:10]
     return base_events
 


### PR DESCRIPTION
Closes #1089

### Summary
Fix newsletter showing unpublished events. They should not show anymore.

### How to test
Steps to test the changes you made:
1. Create a test newsletter.
2. Make sure the week of the newsletter has a couple of events that does not exceed 10. And that some are unpublished in said week.
3. Send the newsletter and check the results.
