### PR TITLE
Set SECURE_CONTENT_TYPE_NOSNIFF to False

### DIFF
--- a/website/thaliawebsite/settings/production.py
+++ b/website/thaliawebsite/settings/production.py
@@ -76,6 +76,8 @@ if os.environ.get("DJANGO_SSLONLY"):
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
+SECURE_CONTENT_TYPE_NOSNIFF = False
+
 # Use caching template loader
 TEMPLATES = [
     {


### PR DESCRIPTION
### Summary
In production we set the HTTP security headers (e.g. `X-Content-Type-Options`). Django could also set some of those headers. Since Django 3, setting `X-Content-Type-Options` has become [default in Django](https://docs.djangoproject.com/en/dev/ref/settings/#secure-content-type-nosniff).

This means that currently, both Nginx and Django are setting the `X-Content-Type-Options` header:
```
$ curl --silent -I https://thalia.nu/ | grep -i "x-content-type-options"
x-content-type-options: nosniff
x-content-type-options: nosniff
```

This PR disables setting the  `X-Content-Type-Options` header in Django.

### How to test
Look at the output of `curl --silent -I https://thalia.nu/ | grep -i "x-content-type-options"`.

