### PR TITLE
Fix lowercasing of manual usernames in registrations

### DIFF
--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -288,7 +288,7 @@ def _create_member_from_registration(registration: Registration) -> Member:
 
     # Create user
     user = get_user_model().objects.create_user(
-        username=registration.username,
+        username=registration.username.lower(),
         email=registration.email,
         password=password,
         first_name=registration.first_name,

--- a/website/registrations/tests/test_services.py
+++ b/website/registrations/tests/test_services.py
@@ -338,7 +338,9 @@ class ServicesTest(TestCase):
 
     @mock.patch("registrations.services.check_unique_user")
     def test_create_member_from_registration(self, check_unique_user):
-        self.e1.username = "jdoe"
+        # We use capitalisation here because we want
+        # to test if the username is lowercased
+        self.e1.username = "JDoe"
         self.e1.save()
 
         check_unique_user.return_value = False


### PR DESCRIPTION
Closes #1073

### Summary
Fix lowercasing of manual usernames in registrations

### How to test
Steps to test the changes you made:
1.  Create a registration
2. Enter a manual username that is not completely lowercase
3. Complete the registration
4. Try to log-in with the new user
5. It works!

