### PR TITLE
Make the list in the summaries text properly unstyled

### DIFF
--- a/website/education/templates/education/courses.html
+++ b/website/education/templates/education/courses.html
@@ -27,7 +27,7 @@
                     You can submit your own exams and summaries!<br />
                     Better even, you might even get a monetary reward if you submit a summary:
                 {% endblocktrans %}
-                <ul class="text-center list-style-none">
+                <ul class="text-center list-unstyled">
                     <li>{% trans "In the current language of the course" %}</li>
                     <li>{% trans "Adds significant information that was not already present in the summary overview" %}</li>
                     <li>{% trans "Corresponds to the current course" %}</li>


### PR DESCRIPTION
Closes #1096

### Summary
This fixes the list added in the original PR and is no longer styled with bullet points.

### How to test
Steps to test the changes you made:
1. Go to the course overview in the education section

Before:
![Screenshot 2020-06-06 at 20 22 10](https://user-images.githubusercontent.com/1799914/83951729-ee1e8f00-a833-11ea-9b1b-b9c1dde2561b.png)

After:
![Screenshot 2020-06-06 at 20 24 46](https://user-images.githubusercontent.com/1799914/83951734-f1197f80-a833-11ea-85d1-07817c6411f6.png)


