### PR TITLE
Fix crash for personal ical feed

### DIFF
--- a/website/events/decorators.py
+++ b/website/events/decorators.py
@@ -31,7 +31,9 @@ class OrganiserOnly:
                 pass
         elif "registration" in kwargs:
             try:
-                event = Event.objects.get(registration__pk=kwargs.get("registration"))
+                event = Event.objects.get(
+                    eventregistration__pk=kwargs.get("registration")
+                )
             except Event.DoesNotExist:
                 pass
 

--- a/website/events/feeds.py
+++ b/website/events/feeds.py
@@ -40,7 +40,8 @@ class EventFeed(ICalFeed):
 
         if self.user:
             query &= Q(registration_start__isnull=True) | (
-                Q(registration__member=self.user) & Q(registration__date_cancelled=None)
+                Q(eventregistration__member=self.user)
+                & Q(eventregistration__date_cancelled=None)
             )
 
         return Event.objects.filter(query).order_by("-start")


### PR DESCRIPTION
Closes #1163

### Summary
Fixed the reference to the right field in the event, introduced in #1061

### How to test
Steps to test the changes you made:
1. Try to open the ical for the personal feed in the calendar
2. Crash
