### PR TITLE
Remove dependency of pizzas app on Payment.NONE in API

### DIFF
--- a/website/payments/api/fields.py
+++ b/website/payments/api/fields.py
@@ -1,10 +1,15 @@
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
-
-from payments.models import Payment
 
 
 class PaymentTypeField(serializers.ChoiceField):
+    NO_PAYMENT = "no_payment"
+
+    def __init__(self, choices, **kwargs):
+        choices = choices + (self.NO_PAYMENT, _("No payment"))
+        super().__init__(choices, **kwargs)
+
     def get_attribute(self, instance):
         if not instance.payment:
-            return Payment.NONE
+            return self.NO_PAYMENT
         return super().get_attribute(instance)

--- a/website/pizzas/api/viewsets.py
+++ b/website/pizzas/api/viewsets.py
@@ -7,7 +7,7 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
-from payments.models import Payment
+from payments.api.fields import PaymentTypeField
 from payments.services import delete_payment, create_payment
 from pizzas.api import serializers
 from pizzas.models import Product, PizzaEvent, Order
@@ -84,7 +84,7 @@ class OrderViewset(ModelViewSet):
                     if "payment" in serializer.validated_data:
                         payment_type = serializer.validated_data["payment"]["type"]
                     else:
-                        payment_type = Payment.NONE
+                        payment_type = PaymentTypeField.NO_PAYMENT
 
                     self._update_payment(order, payment_type, self.request.user)
                 else:
@@ -105,13 +105,8 @@ class OrderViewset(ModelViewSet):
 
     @staticmethod
     def _update_payment(order, payment_type=None, processed_by=None):
-        if order.payment and payment_type == Payment.NONE:
+        if order.payment and payment_type == PaymentTypeField.NO_PAYMENT:
             delete_payment(order)
-        elif order.payment:
-            if payment_type is None:
-                payment_type = order.payment.type
-            order.payment = create_payment(order, processed_by, payment_type)
-            order.payment.save()
         else:
             order.payment = create_payment(order, processed_by, payment_type)
             order.save()

--- a/website/pizzas/templates/pizzas/admin/orders.html
+++ b/website/pizzas/templates/pizzas/admin/orders.html
@@ -105,9 +105,9 @@
                                 </td>
                                 <td>
                                     <select name="payment"
-                                            data-none="{{ payment.NONE }}"
+                                            data-none="no_payment"
                                             {% if order.payment is not None %}class="paid"{% endif %}>
-                                        <option value="{{ payment.NONE }}"
+                                        <option value="no_payment"
                                                 {% if order.payment is None %}selected{% endif %}>{% trans 'None' %}</option>
                                         <option value="{{ payment.CARD }}"
                                                 {% if order.payment.type == payment.CARD %}selected{% endif %}>{% trans 'Card' %}</option>

--- a/website/pizzas/templates/pizzas/index.html
+++ b/website/pizzas/templates/pizzas/index.html
@@ -19,7 +19,7 @@
 
 {% block header_image_container %}
     {% if event.just_ended and order %}
-        <div class="image pizza-header {% if order.payment.processed == order.payment.NONE %}unpaid{% else %}paid{% endif %}">
+        <div class="image pizza-header {% if not order.payment %}unpaid{% else %}paid{% endif %}">
             <h1>
                 {{ order.product.name }}
             </h1>
@@ -90,7 +90,7 @@
                         </h3>
                     {% endif %}
                     {% if order %}
-                        {% if order.payment.processed %}
+                        {% if order.payment %}
                             {% trans "The order has been paid for." as success_text %}
                             {% alert 'success' success_text extra_classes="mt-3" %}
                         {% else %}
@@ -133,7 +133,7 @@
                                                        onclick="return confirm('{% trans "Are you sure you want to cancel your order?" %}')"/>
                                             </form>
                                         {% endif %}
-                                        {% if order.member.tpay_enabled and not order.payment.processed %}
+                                        {% if order.member.tpay_enabled and not order.payment %}
                                             <form
                                                     class="d-inline-block"
                                                     method="post"


### PR DESCRIPTION
### Summary

To be able to completely remove Payment.NONE in the future the pizzas API should not rely on this constant any more. Furthermore,  the processed value is no longer used because the 

### How to test
Steps to test the changes you made:
1. Test that the pizzas orders in the backend still work
2. Test that the values in the user-facing pizza pages are still correct
