### PR TITLE
Remove unused ARG in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM docker.pkg.github.com/svthalia/concrexit/dependencies
 MAINTAINER Thalia Technicie <www@thalia.nu>
 LABEL description="Contains the Thaliawebsite Django application"
 
-ARG install_dev_requirements=1
 ARG source_commit="unknown"
 
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
### Summary
`install_dev_requirements` is not used in the Dockerfile anymore. The dependencies Docker image is used to install development packages (if needed).