### PR TITLE
Remove need of proxy server from review environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,31 @@
+---
+
 version: '3.5'
 
 services:
-    postgres:
-        image: postgres:11.1
-        volumes:
-            - /var/lib/postgresql/
-        environment: &postgresvars
-            POSTGRES_DB: thalia
-    web:
-        image: docker.pkg.github.com/svthalia/concrexit/local
-        build: .
-        command: runserver 0.0.0.0:8000
+    nginx-proxy:
+        image: jwilder/nginx-proxy
         ports:
-            - 8000:8000
-        depends_on:
-            - postgres
+            - 80:80
+            - 443:443
+        environment:
+            DHPARAM_GENERATION: "false"
+            DHPARAM_BITS: 2048
         volumes:
-            - ./website:/usr/src/app/website/
-            - concrexit:/concrexit/
-        environment: &webvars
-            <<: *postgresvars
-            DJANGO_DEBUG: 'True'
-            DJANGO_POSTGRES_HOST: postgres
-            DJANGO_SECRET: 'do_not_use_in_prod'
+            - /var/run/docker.sock:/tmp/docker.sock:ro
+            - /tmp/certs/:/etc/nginx/certs/
 
-volumes:
-    concrexit:
-        driver: local
+    web:
+        image: docker.pkg.github.com/svthalia/concrexit/commit:2a00a9be4b558c5d5877320e3046f89fe1fd9c34
+        entrypoint: /bin/bash
+        depends_on:
+            - nginx-proxy
+        ports:
+            - 127.0.0.1:8000:8000
+        command: >-
+          -c "python manage.py migrate
+          && python manage.py createreviewuser --username user --password pass
+          && python manage.py createfixtures -a
+          && python manage.py runserver 0.0.0.0:8000"
+        environment:
+            VIRTUAL_HOST: "test.local"

--- a/resources/continuous-integration/review/review-host-create.sh
+++ b/resources/continuous-integration/review/review-host-create.sh
@@ -3,7 +3,7 @@
 set -o errexit -o verbose 
 
 if [ -z "${GITHUB_ACTIONS}" ]; then
-    echo "Not running in Gitlab CI"
+    echo "Not running in GitHub Actions."
     exit 1;
 fi
 

--- a/resources/continuous-integration/review/review-host-remove.sh
+++ b/resources/continuous-integration/review/review-host-remove.sh
@@ -3,7 +3,7 @@
 set -o errexit -o verbose 
 
 if [ -z "${GITHUB_ACTIONS}" ]; then
-    echo "Not running in Gitlab CI"
+    echo "Not running in GitHub Actions."
     exit 1;
 fi
 

--- a/resources/entrypoint_production.sh
+++ b/resources/entrypoint_production.sh
@@ -4,7 +4,7 @@ set -e
 
 chown -R www-data:www-data /concrexit/
 
-until psql -h "$DJANGO_POSTGRES_HOST" -U "postgres" -c '\l' "$POSTGRES_DB"; do
+until PGPASSWORD="${POSTGRES_PASSWORD}" psql -h "$DJANGO_POSTGRES_HOST" -U "${POSTGRES_USER}"  -c '\l' "${POSTGRES_DB}"; do
     >&2 echo "PostgreSQL is unavailable: Sleeping"
     sleep 5
 done


### PR DESCRIPTION
### Description
Currently, the review environment sets up EC2 instances in a private subnet. A proxy server redirects all HTTP(s) traffic to `x.public.review.technicie.nl` to the correct instance. Although, this works great, it does have a few points that can be improved:
- We need to maintain (and pay for) a proxy server running 24/7.
- The config of the proxy server needs to be automated using Ansible (harder than it sounds, because of some specific networking needs).
- DNS records are created, but never removed (if someone doesn't use the **remove review** command).
- Two days of uptime is too long in my opinion.

In this PR I address these issues with the following changes:
- [ ] Login to GitHub Packages to download the correct Docker image. This needs to happen regardless of any other changes, because of #1174.
- [ ] Setup EC2 instances in a public subnet (with a public ip)
- [ ] Use the public EC2 subdomain instead of setting up our own DNS records.
- [ ] Use self-signed certificates for HTTPs.
- [ ] Add the (amazing) [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) Docker image to handle HTTPs.
- [ ] Reduce the shutdown timer to 1 day.
- [ ] Remove the **remove review** command, because the server shuts everything down automatically.
- [ ] Setup all instance settings in `review-host-create.sh` (i.e. replace the EC2 launch template),  to make it clear with what settings the instance is started.

These changes might feel like removing some of the nicer features of the review environment (e.g. a `x.technicie.nl` domain and valid certificates). That is why I added the `request-for-comments` label. We can always decide to setup specific domains and/or add [certificates](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion).