### PR TITLE
Fixed deleting of registration information fields

### DIFF
--- a/website/events/admin.py
+++ b/website/events/admin.py
@@ -214,6 +214,7 @@ class EventAdmin(DoNextTranslatedModelAdmin):
             x
             for x in formset.forms
             if isinstance(x, forms.RegistrationInformationFieldForm)
+            and "DELETE" not in x.changed_data
         )
         form.instance.set_registrationinformationfield_order(
             [


### PR DESCRIPTION
Closes #1195 

### Summary
Event information fields couldn't be removed. This was because the backend was trying to order the information fields, including the ones which were marked to be deleted. This is fixed by making sure these fields don't get sorted.

### How to test
1. Create an event
2. Add a registration information field
3. Remove it again

### Additional context
Adding the following code before [line 218](https://github.com/svthalia/concrexit/blob/0c7132dde6937d2d78d5a344671cc14c348024ef/website/events/admin.py#L218) also seemed to fix it, although I prefer the implemented solution.
```python
for x in informationfield_forms:
    print(x)
```
