### PR TITLE
Do not create payment when payment status is not changed

### DIFF
--- a/website/events/services.py
+++ b/website/events/services.py
@@ -293,11 +293,9 @@ def update_registration_by_organiser(registration, member, data):
         raise RegistrationError(_("You are not allowed to update this registration."))
 
     if "payment" in data:
-        if (
-            data["payment"]["type"] == PaymentTypeField.NO_PAYMENT
-            and registration.payment is not None
-        ):
-            delete_payment(registration)
+        if data["payment"]["type"] == PaymentTypeField.NO_PAYMENT:
+            if registration.payment is not None:
+                delete_payment(registration)
         else:
             registration.payment = create_payment(
                 payable=registration,


### PR DESCRIPTION
Closes #1198

### Summary

When only the present value changes in the API but not the status of the payment we should not create a payment object.

### How to test
Steps to test the changes you made:
1. Create an event with registrations
2. Register
3. Mark the registration as present _in the app_
You can simulate this by going to the registration using the API on `/v1/api/registrations/` and patching the body:
```
{
    "payment": "no_payment",
    "present": true
}
```
4. Note that a payment with the status 'no payment' is not created for this registration like it is supposed to

### Notes

I have included a slightly different version on the `release/32` branch so that we can release this with messy cherry-picks. It is included in the [`v32.3` release tag](https://github.com/svthalia/concrexit/releases/tag/v32.3).