### PR TITLE
Add password to psql in production entrypoint

### DIFF
--- a/resources/entrypoint_production.sh
+++ b/resources/entrypoint_production.sh
@@ -4,7 +4,7 @@ set -e
 
 chown -R www-data:www-data /concrexit/
 
-until psql -h "$DJANGO_POSTGRES_HOST" -U "postgres" -c '\l' "$POSTGRES_DB"; do
+until PGPASSWORD="${POSTGRES_PASSWORD}" psql -h "${DJANGO_POSTGRES_HOST}" -U "${POSTGRES_USER}" -c '\l' "${POSTGRES_DB}"; do
     >&2 echo "PostgreSQL is unavailable: Sleeping"
     sleep 5
 done


### PR DESCRIPTION
### Summary

The Postgres Docker has a [recent change](https://github.com/docker-library/postgres/pull/658) that requires to either disable password authentication (using `POSTGRES_HOST_AUTH_METHOD=trust`) or set a superuser password.

Although, this is not an immediate problem for us, because the password settings are only checked when the database is created, we should support the new behaviour.

This PR lets Concrexit check the connectivity to the Postgres database using the `thalia` database credentials instead of the superuser (`postgres`). This way, the connectivity check is not dependent on the specific superuser password settings.

