### PR TITLE
Go back to Docker hub

### DIFF
--- a/.github/workflows/build-dependencies-docker.yaml
+++ b/.github/workflows/build-dependencies-docker.yaml
@@ -15,13 +15,13 @@ jobs:
     name: Build Dependencies Docker Image
     runs-on: ubuntu-18.04
     env:
-      DOCKER_DEPENDENCIES_LATEST: docker.pkg.github.com/svthalia/concrexit/dependencies:latest
+      DOCKER_DEPENDENCIES_LATEST: thalia/concrexit-dependencies:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Login to GitHub Packages
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com --username "{{ github.repository }}" --password-stdin
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_REGISTRY_PASSWORD }}" | docker login --username "thaliawww" --password-stdin
 
       - name: Build dependencies Docker image
         run:  docker build --file Dockerfile.dependencies --quiet --build-arg "install_dev_requirements=1" --tag "${DOCKER_DEPENDENCIES_LATEST}" .

--- a/.github/workflows/build-production-docker.yaml
+++ b/.github/workflows/build-production-docker.yaml
@@ -11,9 +11,9 @@ jobs:
         name: Build Production Docker Image
         runs-on: ubuntu-18.04
         env:
-            DOCKER_PREFIX: docker.pkg.github.com/svthalia/concrexit/production
-            DOCKER_LATEST: docker.pkg.github.com/svthalia/concrexit/production:latest
-            DOCKER_DEPENDENCIES_LATEST: docker.pkg.github.com/svthalia/concrexit/dependencies:latest
+            DOCKER_PREFIX: thalia/concrexit
+            DOCKER_LATEST: thalia/concrexit:latest
+            DOCKER_DEPENDENCIES_LATEST: thalia/concrexit-dependencies:latest
         steps:
             - name: Get version
               run: echo ::set-env name=DOCKER_VERSION::${GITHUB_REF/refs\/tags\//}
@@ -21,8 +21,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Login to GitHub Packages
-              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com --username "{{ github.repository }}" --password-stdin
+            - name: Login to Docker Hub
+              run: echo "${{ secrets.DOCKER_REGISTRY_PASSWORD }}" | docker login --username "thaliawww" --password-stdin
 
             - name: Build Docker images
               run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -156,13 +156,13 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [codestyle, tests, documentation-tests]
     env:
-      DOCKER_TAG: docker.pkg.github.com/svthalia/concrexit/commit:${{ github.sha }}
+      DOCKER_TAG: thalia/concrexit:${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Login to GitHub Packages
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com --username "{{ github.repository }}" --password-stdin
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_REGISTRY_PASSWORD }}" | docker login --username "thaliawww" --password-stdin
 
       - name: Build new Docker image
         run: docker build --quiet --build-arg "source_commit=${{ github.sha }}" --tag "${DOCKER_TAG}" .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.pkg.github.com/svthalia/concrexit/dependencies
+FROM thalia/concrexit-dependencies
 MAINTAINER Thalia Technicie <www@thalia.nu>
 LABEL description="Contains the Thaliawebsite Django application"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         environment: &postgresvars
             POSTGRES_DB: thalia
     web:
-        image: docker.pkg.github.com/svthalia/concrexit/local
+        image: registry.hub.docker.com/thalia/concrexit
         build: .
         command: runserver 0.0.0.0:8000
         ports:


### PR DESCRIPTION
### Summary
Go back to Docker hub because it is not possible to use our dependencies image as container for our tests when running on Github Packages.

### How to test
Steps to test the changes you made:
1. You basically cannot test this.
