### PR TITLE
Remove download button for unauthorized users and make thabloids private

### DIFF
--- a/website/thabloid/models.py
+++ b/website/thabloid/models.py
@@ -15,7 +15,7 @@ from utils.threading import PopenAndCall
 
 def thabloid_filename(instance, filename):
     ext = os.path.splitext(filename)[1]
-    return os.path.join("public/thabloids/", slugify(instance) + ext)
+    return os.path.join("private/thabloids/", slugify(instance) + ext)
 
 
 class Thabloid(models.Model):

--- a/website/thabloid/templatetags/thabloid_cards.py
+++ b/website/thabloid/templatetags/thabloid_cards.py
@@ -2,25 +2,36 @@ from django import template
 from django.urls import reverse
 
 from thaliawebsite.templatetags.grid_item import grid_item
-from utils.media.services import get_thumbnail_url
+from utils.media.services import get_thumbnail_url, get_media_url
 
 register = template.Library()
 
 
-@register.inclusion_tag("includes/grid_item.html")
-def thabloid_card(year, thabloid):
+@register.inclusion_tag("includes/grid_item.html", takes_context=True)
+def thabloid_card(context, year, thabloid):
+    request = context["request"]
     view_url = reverse("thabloid:pages", args=[thabloid.year, thabloid.issue])
-    buttons = (
-        '<div class="text-center mt-2">'
-        '<a href="{}" class="btn btn-secondary d-inline-flex open mr-1">'
-        '<i class="fas fa-book-open"></i>'
-        "</a>"
-        '<a href="{}" download '
-        'class="btn btn-secondary d-inline-flex download ml-1">'
-        '<i class="fas fa-download"></i>'
-        "</a>"
-        "</div>"
-    ).format(view_url, thabloid.file.url)
+
+    if request.member and request.member.current_membership is not None:
+        buttons = (
+            '<div class="text-center mt-2">'
+            '<a href="{}" class="btn btn-secondary d-inline-flex open mr-1">'
+            '<i class="fas fa-book-open"></i>'
+            "</a>"
+            '<a href="{}" download '
+            'class="btn btn-secondary d-inline-flex download ml-1">'
+            '<i class="fas fa-download"></i>'
+            "</a>"
+            "</div>"
+        ).format(view_url, get_media_url(thabloid.file.path, attachment=True))
+    else:
+        buttons = (
+            '<div class="text-center mt-2">'
+            '<a href="{}" class="btn btn-secondary d-inline-flex open mr-1">'
+            '<i class="fas fa-book-open"></i>'
+            "</a>"
+            "</div>"
+        ).format(view_url)
 
     return grid_item(
         title="{}-{}, #{}".format(thabloid.year, thabloid.year + 1, thabloid.issue),


### PR DESCRIPTION
Closes #965

### Summary
Thabloids are not accessible anymore if you are not logged in (so Google can't crawl them)

### How to test
Steps to test the changes you made:
1. Upload a thabloid
2. Try to download the thabloid as logged in user, this should work
3. Try to download the thabloid as AnonymousUser, this should not work

Note the migration for the media url!