### PR TITLE
added utf-8 meta tag for newsletters

### DIFF
--- a/website/newsletters/templates/newsletters/email.html
+++ b/website/newsletters/templates/newsletters/email.html
@@ -5,6 +5,7 @@
 
 {% with primary_color="#EE227A" item_h2_style="color:#EE227A;font-family:Calibri, 'Trebuchet MS', sans-serif; font-size: 18px; margin-bottom: 10px; margin-top: 30px;" item_tr_style="padding-left: 30px; padding-right: 30px; padding-bottom: 10px; margin: 0px; vertical-align: top;" %}
 <html style="background-color: #F0F0F0;">
+<meta charset="utf-8">
 <head>
     <title>{{ newsletter.title }}</title>
     <style type="text/css">

--- a/website/newsletters/templates/newsletters/email.html
+++ b/website/newsletters/templates/newsletters/email.html
@@ -5,7 +5,6 @@
 
 {% with primary_color="#EE227A" item_h2_style="color:#EE227A;font-family:Calibri, 'Trebuchet MS', sans-serif; font-size: 18px; margin-bottom: 10px; margin-top: 30px;" item_tr_style="padding-left: 30px; padding-right: 30px; padding-bottom: 10px; margin: 0px; vertical-align: top;" %}
 <html style="background-color: #F0F0F0;">
-<meta charset="utf-8">
 <head>
     <title>{{ newsletter.title }}</title>
     <style type="text/css">
@@ -18,6 +17,7 @@
             line-height: inherit !important;
         }
     </style>
+    <meta charset="utf-8">
 </head>
 <body>
 


### PR DESCRIPTION
Closes #1176

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
In some previous newsletters "CafÃ© Van Ouds" was shown instead of "Café van Ouds". An added meta tag to the html template should fix this.

### How to test
Steps to test the changes you made:
1. View a newsletter that has an event at location "Café van Ouds".
2. See if it shows "Café" correctly in different browsers.
