### PR TITLE
Fix renewal form

### DIFF
--- a/website/registrations/migrations/0024_auto_20200325_2045.py
+++ b/website/registrations/migrations/0024_auto_20200325_2045.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='entry',
             name='contribution',
-            field=models.FloatField(validators=[django.core.validators.MinValueValidator(7.5)], verbose_name='contribution'),
+            field=models.FloatField(validators=[django.core.validators.MinValueValidator(7.5)], default=7.5, verbose_name='contribution'),
         ),
         migrations.AlterField(
             model_name='entry',

--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -69,6 +69,7 @@ class Entry(models.Model, Payable):
     contribution = models.FloatField(
         verbose_name=_("contribution"),
         validators=[MinValueValidator(settings.MEMBERSHIP_PRICES["year"])],
+        default=settings.MEMBERSHIP_PRICES["year"],
         blank=False,
         null=False,
     )


### PR DESCRIPTION
The renewal form had a required `contribution` field after #1054, which made it impossible to create regular membership renewals