### PR TITLE
Thalia Pay for renewals

### DIFF
--- a/website/payments/tests/test_views.py
+++ b/website/payments/tests/test_views.py
@@ -58,17 +58,6 @@ class BankAccountCreateViewTest(TestCase):
             response.redirect_chain,
         )
 
-    def test_not_a_current_member(self):
-        """
-        If the logged-in user is not a member they should not be able to visit
-        this page
-        """
-        self.client.logout()
-        self.client.force_login(self.new_user)
-
-        response = self.client.get(reverse("payments:bankaccount-add"))
-        self.assertEqual(403, response.status_code)
-
     def test_shows_correct_reference(self):
         """
         The page should show the reference that will be used to identify

--- a/website/payments/views.py
+++ b/website/payments/views.py
@@ -28,7 +28,6 @@ from payments.models import BankAccount, Payment
 
 
 @method_decorator(login_required, name="dispatch")
-@method_decorator(membership_required, name="dispatch")
 class BankAccountCreateView(SuccessMessageMixin, CreateView):
     model = BankAccount
     form_class = BankAccountForm

--- a/website/payments/views.py
+++ b/website/payments/views.py
@@ -20,7 +20,6 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView
 from django.views.generic.edit import CreateView, UpdateView, FormView
 
-from members.decorators import membership_required
 from payments import services
 from payments.exceptions import PaymentError
 from payments.forms import BankAccountForm, PaymentCreateForm

--- a/website/registrations/emails.py
+++ b/website/registrations/emails.py
@@ -102,6 +102,7 @@ def send_renewal_accepted_message(renewal: Renewal) -> None:
             {
                 "name": renewal.member.get_full_name(),
                 "fees": floatformat(renewal.contribution, 2),
+                "url": (settings.BASE_URL + reverse("registrations:renew",)),
             },
         )
 

--- a/website/registrations/templates/registrations/email/renewal_accepted.txt
+++ b/website/registrations/templates/registrations/email/renewal_accepted.txt
@@ -14,8 +14,7 @@ To pay with Thalia Pay, go to {{ url }}.
 2. You can transfer the amount of €{{ fees }} to NL 23 INGB 0006 2341 84 with the description "Contribution {{ name }}".
 Once your payment is processed by us, you will receive a confirmation email.
 
-3. You can pay by card or cash 'in real life' by coming to the Thalia board room, during the lunch break (12:15-13:15)
-in M1.0.08.
+3. You can pay using debit card or cash by visiting the Thalia board room (M1.0.08) during the lunch break (12:15-13:15).
 
 If you have any questions, then don't hesitate and send an email to info@thalia.nu.
 

--- a/website/registrations/templates/registrations/email/renewal_accepted.txt
+++ b/website/registrations/templates/registrations/email/renewal_accepted.txt
@@ -9,7 +9,7 @@ The membership fees are €{{ fees }}. Those can be paid in a few ways:
 
 1. You can let us withdraw the money from your bank account via Thalia Pay. For this, you
 will need to have a bank account added to your account and have signed a direct debit mandate.
-To pay with Thalia Pay, go to https://thalia.nu/user/membership/.
+To pay with Thalia Pay, go to {{ url }}.
 
 2. You can transfer the amount of €{{ fees }} to NL 23 INGB 0006 2341 84 with the description "Contribution {{ name }}".
 Once your payment is processed by us, you will receive a confirmation email.

--- a/website/registrations/templates/registrations/email/renewal_accepted.txt
+++ b/website/registrations/templates/registrations/email/renewal_accepted.txt
@@ -5,12 +5,17 @@ We have some wonderful news for you: your membership renewal has been accepted!
 Unfortunately there is still one little thing that we have to take care of before
 you get access to everything Thalia has to offer once again: paying your membership fees.
 
-The membership fees are €{{ fees }} and can be paid using cash, a debit card or via wire transfer.
-You can transfer the amount of €{{ fees }} to NL 23 INGB 0006 2341 84 with the description "Contribution {{ name }}".
+The membership fees are €{{ fees }}. Those can be paid in a few ways:
+
+1. You can let us withdraw the money from your bank account via Thalia Pay. For this, you
+will need to have a bank account added to your account and have signed a direct debit mandate.
+To pay with Thalia Pay, go to https://thalia.nu/user/membership/.
+
+2. You can transfer the amount of €{{ fees }} to NL 23 INGB 0006 2341 84 with the description "Contribution {{ name }}".
 Once your payment is processed by us, you will receive a confirmation email.
 
-If possible, please visit us during lunch break (12:15-13:15) in M1.0.08 so that we can
-make sure your membership renewal is completed.
+3. You can pay by card or cash 'in real life' by coming to the Thalia board room, during the lunch break (12:15-13:15)
+in M1.0.08.
 
 If you have any questions, then don't hesitate and send an email to info@thalia.nu.
 

--- a/website/registrations/templates/registrations/renewal.html
+++ b/website/registrations/templates/registrations/renewal.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n bootstrap4 alert compress static %}
+{% load i18n bootstrap4 alert compress static payments %}
 
 {% block title %}{% trans "renewal"|capfirst %} — {{ block.super }}{% endblock %}
 
@@ -99,8 +99,25 @@
             </div>
 
             <hr/>
-
-            {% if latest_membership is None %}
+            {% if latest_renewal and latest_renewal.status == latest_renewal.STATUS_ACCEPTED %}
+                <p class="text-center">
+                    {% blocktrans trimmed %}
+                        Congratulations, your renewal request has been approved!
+                        The renewal will be completed once you have paid your contribution.
+                    {% endblocktrans %}
+                </p>
+                <div class="text-center">
+                    {% url 'registrations:renewal-completed' as renewal_completed %}
+                    {% payment_button latest_renewal renewal_completed %}
+                </div>
+            {% elif latest_renewal and latest_renewal.status == latest_renewal.STATUS_REVIEW %}
+                  <p class="text-center">
+                      {% blocktrans trimmed %}
+                          You have a renewal request queued for review.
+                          You will receive an email once your request has been reviewed.
+                      {% endblocktrans %}
+                  </p>
+            {% elif latest_membership is None %}
                 <p class="text-center">
                     {% blocktrans trimmed %}
                         We do not have any previous memberships in our system.

--- a/website/registrations/templates/registrations/renewal_completed.html
+++ b/website/registrations/templates/registrations/renewal_completed.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "completed"|capfirst %} - {% trans "renewal"|capfirst %} — {{ block.super }}{% endblock %}
+
+{% block body %}
+  <section class="page-section">
+      <div class="container">
+          <h1 class="text-center section-title">{% trans "renewal" %}</h1>
+          <p class="text-center">
+              {% blocktrans trimmed %}
+                  Congratulations!
+                  Your payment has been processed and your renewal is now complete.
+              {% endblocktrans %}
+          </p>
+      </div>
+  </section>
+{% endblock %}

--- a/website/registrations/tests/test_emails.py
+++ b/website/registrations/tests/test_emails.py
@@ -127,6 +127,8 @@ class EmailsTest(TestCase):
                 {
                     "name": renewal.member.get_full_name(),
                     "fees": floatformat(renewal.contribution, 2),
+                    "url": (settings.BASE_URL + reverse(
+                        "registrations:renew", )),
                 },
             )
 

--- a/website/registrations/tests/test_emails.py
+++ b/website/registrations/tests/test_emails.py
@@ -127,8 +127,7 @@ class EmailsTest(TestCase):
                 {
                     "name": renewal.member.get_full_name(),
                     "fees": floatformat(renewal.contribution, 2),
-                    "url": (settings.BASE_URL + reverse(
-                        "registrations:renew", )),
+                    "url": (settings.BASE_URL + reverse("registrations:renew",)),
                 },
             )
 

--- a/website/registrations/urls.py
+++ b/website/registrations/urls.py
@@ -54,6 +54,13 @@ urlpatterns = [
                     ),
                     name="renew-success",
                 ),
+                path(
+                    "renew/completed/",
+                    TemplateView.as_view(
+                        template_name="registrations/renewal_completed.html"
+                    ),
+                    name="renewal-completed",
+                ),
             ]
         ),
     ),

--- a/website/registrations/views.py
+++ b/website/registrations/views.py
@@ -6,6 +6,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import redirect, get_object_or_404
 from django.template.defaultfilters import floatformat
@@ -214,6 +215,13 @@ class RenewalFormView(FormView):
             settings.MEMBERSHIP_PRICES[Entry.MEMBERSHIP_STUDY], 2
         )
         context["latest_membership"] = self.request.member.latest_membership
+        context["latest_renewal"] = Renewal.objects.filter(
+            Q(member=self.request.member)
+            & (
+                Q(status=Registration.STATUS_ACCEPTED)
+                | Q(status=Registration.STATUS_REVIEW)
+            )
+        ).last()
         context["was_member"] = Membership.objects.filter(
             user=self.request.member, type=Membership.MEMBER
         ).exists()


### PR DESCRIPTION
Closes #1048 

### Summary
It is now possible to use Thalia Pay to pay for renewals.

### How to test
1. Create a renewal
2. Accept it
3. Notice the mentioning of Thalia Pay as payment option in the email
4. Pay with Thalia Pay