### PR TITLE
Fix renewal form

### DIFF
--- a/website/registrations/migrations/0024_auto_20200325_2045.py
+++ b/website/registrations/migrations/0024_auto_20200325_2045.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='entry',
             name='contribution',
-            field=models.FloatField(validators=[django.core.validators.MinValueValidator(7.5)], verbose_name='contribution'),
+            field=models.FloatField(validators=[django.core.validators.MinValueValidator(7.5)], default=7.5, verbose_name='contribution'),
         ),
         migrations.AlterField(
             model_name='entry',

--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -69,6 +69,7 @@ class Entry(models.Model, Payable):
     contribution = models.FloatField(
         verbose_name=_("contribution"),
         validators=[MinValueValidator(settings.MEMBERSHIP_PRICES["year"])],
+        default=settings.MEMBERSHIP_PRICES["year"],
         blank=False,
         null=False,
     )

--- a/website/registrations/static/registrations/js/main.js
+++ b/website/registrations/static/registrations/js/main.js
@@ -21,31 +21,33 @@ $(function() {
         });
     }
 
-    var input = document.querySelector('#id_address_street');
-    var autocomplete = new google.maps.places.Autocomplete(input);
-    autocomplete.addListener('place_changed', function () {
-        var place = autocomplete.getPlace();
+    if (window.google) {
+        var input = document.querySelector('#id_address_street');
+        var autocomplete = new google.maps.places.Autocomplete(input);
+        autocomplete.addListener('place_changed', function () {
+            var place = autocomplete.getPlace();
 
-        var getAddressItem = function(type, length) {
-            var address = place.address_components;
-            var addressItem = address.find(function (item) {
-                return item.types.includes(type);
-            });
-            var key = length + '_name';
-            return addressItem && addressItem[key] ? addressItem[key] : '';
-        };
+            var getAddressItem = function (type, length) {
+                var address = place.address_components;
+                var addressItem = address.find(function (item) {
+                    return item.types.includes(type);
+                });
+                var key = length + '_name';
+                return addressItem && addressItem[key] ? addressItem[key] : '';
+            };
 
-        $('#id_address_street').val(
-            getAddressItem('route', 'long') + ' '
-            + getAddressItem('street_number', 'long'));
+            $('#id_address_street').val(
+                getAddressItem('route', 'long') + ' '
+                + getAddressItem('street_number', 'long'));
 
-        $('#id_address_city').val(
-            getAddressItem('locality', 'long'));
+            $('#id_address_city').val(
+                getAddressItem('locality', 'long'));
 
-        $('#id_address_postal_code').val(
-            getAddressItem('postal_code', 'long'));
+            $('#id_address_postal_code').val(
+                getAddressItem('postal_code', 'long'));
 
-        $('#id_address_country').val(
-            getAddressItem('country', 'short').toUpperCase());
-    });
+            $('#id_address_country').val(
+                getAddressItem('country', 'short').toUpperCase());
+        });
+    }
 });


### PR DESCRIPTION
### Summary

The renewal form had a required `contribution` field after #1054 without default, which made it impossible to create regular membership renewals

### How to test
Steps to test the changes you made:
1. Go to the membership renewal page and make sure you can renew
2. Try to renew a membership with type member
3. Try to renew a membership with type benefactor
4. Try the above but with a different value in the contribution field
