### PR TITLE
Replace pizzas payment button for Thalia Pay with templatetag

### DIFF
--- a/website/payments/admin.py
+++ b/website/payments/admin.py
@@ -143,14 +143,14 @@ class PaymentAdmin(admin.ModelAdmin):
 
         return super().has_delete_permission(request, obj)
 
-    def formfield_for_foreignkey(self, db_field, request, queryset=None, **kwargs):
-        return super().formfield_for_foreignkey(
-            db_field, request, queryset=Batch.objects.filter(processed=False), **kwargs
-        )
+    def get_field_queryset(self, db, db_field, request):
+        if str(db_field) == "payments.Payment.batch":
+            return Batch.objects.filter(processed=False)
+        return super().get_field_queryset(db, db_field, request)
 
     def get_readonly_fields(self, request: HttpRequest, obj: Payment = None):
         if not obj:
-            return "created_at", "type", "processed_by", "batch"
+            return "created_at", "processed_by", "batch"
         if obj.type == Payment.TPAY and not (obj.batch and obj.batch.processed):
             return (
                 "created_at",
@@ -159,6 +159,7 @@ class PaymentAdmin(admin.ModelAdmin):
                 "paid_by",
                 "processed_by",
                 "notes",
+                "topic",
             )
         return super().get_readonly_fields(request, obj)
 

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -59,6 +59,8 @@ def delete_payment(payable: Payable):
         seconds=settings.PAYMENT_CHANGE_WINDOW
     ):
         raise PaymentError(_("You are not authorized to delete this payment."))
+    if payment.batch and payment.batch.processed:
+        raise PaymentError(_("This payment has already been processed."))
 
     payable.payment = None
     payable.save()

--- a/website/payments/tests/test_admin.py
+++ b/website/payments/tests/test_admin.py
@@ -403,7 +403,7 @@ class PaymentAdminTest(TestCase):
         """
         with self.subTest("No object"):
             urls = self.admin.get_readonly_fields(HttpRequest(), None)
-            self.assertEqual(urls, ("created_at", "type", "processed_by", "batch"))
+            self.assertEqual(urls, ("created_at", "processed_by", "batch"))
 
         with self.subTest("With object"):
             urls = self.admin.get_readonly_fields(HttpRequest(), Payment())
@@ -452,9 +452,9 @@ class PaymentAdminTest(TestCase):
             response.content.decode("utf-8"),
         )
 
-    def test_formfield_for_foreignkey(self) -> None:
+    def test_get_field_queryset(self) -> None:
         b1 = Batch.objects.create(id=1)
-        b2 = Batch.objects.create(id=2, processed=True)
+        Batch.objects.create(id=2, processed=True)
         p1 = Payment.objects.create(
             amount=5, paid_by=self.user, processed_by=self.user, type=Payment.TPAY
         )
@@ -470,6 +470,8 @@ class PaymentAdminTest(TestCase):
             ],
             [b1.id],
         )
+
+        self.client.get(reverse("admin:payments_payment_add"))
 
 
 @freeze_time("2019-01-01")

--- a/website/payments/tests/test_services.py
+++ b/website/payments/tests/test_services.py
@@ -69,14 +69,20 @@ class ServicesTest(TestCase):
             existing_payment.created_at = timezone.now() - timezone.timedelta(
                 seconds=settings.PAYMENT_CHANGE_WINDOW + 60
             )
-            with self.assertRaises(PaymentError):
+            with self.assertRaisesMessage(
+                PaymentError, "You are not authorized to delete this payment."
+            ):
                 services.delete_payment(payable)
             self.assertIsNotNone(payable.payment)
+
+        existing_payment.created_at = timezone.now()
 
         with self.subTest("Already processed"):
             payable.payment = existing_payment
             existing_payment.batch = Batch.objects.create(processed=True)
-            with self.assertRaises(PaymentError):
+            with self.assertRaisesMessage(
+                PaymentError, "This payment has already been processed."
+            ):
                 services.delete_payment(payable)
             self.assertIsNotNone(payable.payment)
 

--- a/website/payments/tests/test_services.py
+++ b/website/payments/tests/test_services.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from members.models import Member
 from payments import services
 from payments.exceptions import PaymentError
-from payments.models import BankAccount, Payment
+from payments.models import BankAccount, Payment, Batch
 from payments.tests.__mocks__ import MockPayable
 
 
@@ -52,7 +52,7 @@ class ServicesTest(TestCase):
                 )
 
     def test_delete_payment(self):
-        existing_payment = MagicMock()
+        existing_payment = MagicMock(batch=None)
         payable = MockPayable(payer=self.member, payment=existing_payment)
         payable.save.reset_mock()
 
@@ -69,6 +69,13 @@ class ServicesTest(TestCase):
             existing_payment.created_at = timezone.now() - timezone.timedelta(
                 seconds=settings.PAYMENT_CHANGE_WINDOW + 60
             )
+            with self.assertRaises(PaymentError):
+                services.delete_payment(payable)
+            self.assertIsNotNone(payable.payment)
+
+        with self.subTest("Already processed"):
+            payable.payment = existing_payment
+            existing_payment.batch = Batch.objects.create(processed=True)
             with self.assertRaises(PaymentError):
                 services.delete_payment(payable)
             self.assertIsNotNone(payable.payment)

--- a/website/pizzas/models.py
+++ b/website/pizzas/models.py
@@ -10,6 +10,7 @@ from events.models import Event
 import members
 from members.models import Member
 from payments.models import Payment, Payable
+from payments.services import delete_payment
 from pushnotifications.models import ScheduledMessage, Category
 from utils.translation import ModelTranslateMeta, MultilingualField
 
@@ -255,6 +256,11 @@ class Order(models.Model, Payable):
             ) and not self.pizza_event.has_ended
         except ObjectDoesNotExist:
             return False
+
+    def delete(self, using=None, keep_parents=False):
+        if self.payment is not None and self.can_be_changed:
+            delete_payment(self)
+        return super().delete(using, keep_parents)
 
     class Meta:
         unique_together = (

--- a/website/pizzas/templates/pizzas/index.html
+++ b/website/pizzas/templates/pizzas/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static alert %}
+{% load i18n static alert payments %}
 
 {% block title %}{% if event %}{{ event.title }}
     — {% endif %}{% trans "pizzas"|capfirst %} —
@@ -105,7 +105,7 @@
                                     <th>{% trans "Name" %}</th>
                                     <th class="d-none d-md-table d-none d-md-table-cell">{% trans "Description" %}</th>
                                     <th>{% trans "Price" %}</th>
-                                    <th>{% trans "Cancel" %}</th>
+                                    <th></th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -120,7 +120,7 @@
                                             {% trans "You can no longer cancel." %}
                                         {% else %}
                                             <form
-                                                class="d-inline-block"
+                                                class="d-inline-block p-1"
                                                 method="post"
                                                 action="{% url 'pizzas:cancel-order' %}">
                                                 {% csrf_token %}
@@ -133,19 +133,10 @@
                                                        onclick="return confirm('{% trans "Are you sure you want to cancel your order?" %}')"/>
                                             </form>
                                         {% endif %}
-                                        {% if order.member.tpay_enabled and not order.payment %}
-                                            <form
-                                                    class="d-inline-block"
-                                                    method="post"
-                                                    action="{% url 'pizzas:pay-order' %}">
-                                                {% csrf_token %}
-                                                <input type="hidden"
-                                                       name="order"
-                                                       value="{{ order.pk }}"/>
-                                                <input type="submit"
-                                                       value="{% trans "Pay with Thalia Pay" %}"
-                                                       class="btn btn-primary"/>
-                                            </form>
+                                        {% if not order.payment %}
+                                            <div class="d-inline-block p-1">
+                                                {% payment_button order request.path %}
+                                            </div>
                                         {% endif %}
                                     </td>
                                 </tr>

--- a/website/pizzas/urls.py
+++ b/website/pizzas/urls.py
@@ -11,7 +11,6 @@ urlpatterns = [
         include(
             [
                 path("order/cancel/", views.cancel_order, name="cancel-order"),
-                path("order/pay/", views.pay_order, name="pay-order"),
                 path("order/", views.order, name="order"),
                 path("", views.index, name="index"),
             ]

--- a/website/pizzas/views.py
+++ b/website/pizzas/views.py
@@ -42,22 +42,6 @@ def cancel_order(request):
     return redirect("pizzas:index")
 
 
-@require_http_methods(["POST"])
-def pay_order(request):
-    """ View that marks the order as paid using Thalia Pay """
-    if "order" in request.POST:
-        try:
-            order = get_object_or_404(Order, pk=int(request.POST["order"]))
-            if order.member == request.member:
-                create_payment(order, Payment.TPAY, order.member)
-                messages.success(
-                    request, _("Your order has been paid with Thalia Pay.")
-                )
-        except Http404:
-            messages.error(request, _("Your order could not be found."))
-    return redirect("pizzas:index")
-
-
 @login_required
 def order(request):
     """ View that shows the detail of the current order """


### PR DESCRIPTION
Closes #1240

### Summary

Replace pizzas payment button for Thalia Pay with templatetag. Among others this PR also adds:
- Checks when saving a payment so that an admin cannot create Thalia Pay payments for users who don't have it enabled
- Blocks deletion of payments in a processed batch

### How to test
Steps to test the changes you made:
1. Place a pizza order
2. Make sure your can pay with Thalia Pay
