### PR TITLE
Add feature flag to renewal accepted email disabling Thalia Pay

### DIFF
--- a/website/registrations/emails.py
+++ b/website/registrations/emails.py
@@ -102,6 +102,7 @@ def send_renewal_accepted_message(renewal: Renewal) -> None:
             {
                 "name": renewal.member.get_full_name(),
                 "fees": floatformat(renewal.contribution, 2),
+                "thalia_pay_enabled": settings.THALIA_PAY_ENABLED_PAYMENT_METHOD,
                 "url": (settings.BASE_URL + reverse("registrations:renew",)),
             },
         )

--- a/website/registrations/templates/registrations/email/renewal_accepted.txt
+++ b/website/registrations/templates/registrations/email/renewal_accepted.txt
@@ -1,20 +1,22 @@
-{% load i18n %}{% blocktrans %}Dear {{ name }},
-
+{% load i18n %}{% blocktrans %}Dear {{ name }},{% endblocktrans %}
+{% blocktrans %}
 We have some wonderful news for you: your membership renewal has been accepted!
 
 Unfortunately there is still one little thing that we have to take care of before
 you get access to everything Thalia has to offer once again: paying your membership fees.
 
 The membership fees are €{{ fees }}. Those can be paid in a few ways:
-
-1. You can let us withdraw the money from your bank account via Thalia Pay. For this, you
+{% endblocktrans %}
+{% if thalia_pay_enabled %}{% blocktrans %}
+- You can let us withdraw the money from your bank account via Thalia Pay. For this, you
 will need to have a bank account added to your account and have signed a direct debit mandate.
 To pay with Thalia Pay, go to {{ url }}.
-
-2. You can transfer the amount of €{{ fees }} to NL 23 INGB 0006 2341 84 with the description "Contribution {{ name }}".
+{% endblocktrans %}{% endif %}
+{% blocktrans %}
+- You can transfer the amount of €{{ fees }} to NL 23 INGB 0006 2341 84 with the description "Contribution {{ name }}".
 Once your payment is processed by us, you will receive a confirmation email.
 
-3. You can pay using debit card or cash by visiting the Thalia board room (M1.0.08) during the lunch break (12:15-13:15).
+- You can pay using debit card or cash by visiting the Thalia board room (M1.0.08) during the lunch break (12:15-13:15).
 
 If you have any questions, then don't hesitate and send an email to info@thalia.nu.
 

--- a/website/registrations/tests/test_emails.py
+++ b/website/registrations/tests/test_emails.py
@@ -127,6 +127,7 @@ class EmailsTest(TestCase):
                 {
                     "name": renewal.member.get_full_name(),
                     "fees": floatformat(renewal.contribution, 2),
+                    "thalia_pay_enabled": settings.THALIA_PAY_ENABLED_PAYMENT_METHOD,
                     "url": (settings.BASE_URL + reverse("registrations:renew",)),
                 },
             )


### PR DESCRIPTION
### Summary
Add feature flag to renewal accepted email for when we do not enable this method yet.

### How to test
Steps to test the changes you made:
1. Do a renewal
2. Try to use Thalia Pay when it is disabled
