### PR TITLE
Add extra information in the member and membergroup serializer

### DIFF
--- a/website/activemembers/api/serializers.py
+++ b/website/activemembers/api/serializers.py
@@ -1,17 +1,49 @@
 """DRF serializers defined by the activemembers package"""
 from rest_framework import serializers
 
-from activemembers.models import MemberGroup
+from activemembers.models import MemberGroup, MemberGroupMembership
 from members.api.serializers import MemberListSerializer
 
 
 class MemberGroupSerializer(serializers.ModelSerializer):
     """MemberGroup serializer"""
 
-    members = MemberListSerializer(many=True)
-
     class Meta:
         """Meta class for the serializer"""
 
         model = MemberGroup
-        fields = ("pk", "name", "since", "until", "contact_address", "photo", "members")
+        fields = (
+            "pk",
+            "name",
+            "type",
+            "since",
+            "until",
+            "contact_address",
+            "photo",
+            "chair",
+            "members",
+        )
+
+    members = MemberListSerializer(many=True)
+    chair = serializers.SerializerMethodField("_chair")
+    type = serializers.SerializerMethodField("_type")
+
+    def _chair(self, instance):
+        membership = (
+            MemberGroupMembership.objects.filter(chair=True, group=instance)
+            .select_related("member")
+            .first()
+        )
+        if membership:
+            return MemberListSerializer(context=self.context).to_representation(
+                membership.member
+            )
+        return None
+
+    def _type(self, instance):
+        if hasattr(instance, "board"):
+            return "board"
+        if hasattr(instance, "committee"):
+            return "committee"
+        if hasattr(instance, "society"):
+            return "society"

--- a/website/members/api/serializers.py
+++ b/website/members/api/serializers.py
@@ -110,13 +110,18 @@ class MemberListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Member
-        fields = ("pk", "display_name", "avatar")
+        fields = ("pk", "starting_year", "display_name", "membership_type", "avatar")
 
     display_name = serializers.SerializerMethodField("_display_name")
+    starting_year = serializers.SerializerMethodField("_starting_year")
     avatar = serializers.SerializerMethodField("_avatar")
+    membership_type = serializers.SerializerMethodField("_membership_type")
 
     def _display_name(self, instance):
         return instance.profile.display_name()
+
+    def _starting_year(self, instance):
+        return instance.profile.starting_year
 
     def _avatar(self, instance):
         placeholder = self.context["request"].build_absolute_uri(
@@ -128,6 +133,12 @@ class MemberListSerializer(serializers.ModelSerializer):
         return create_image_thumbnail_dict(
             self.context["request"], file, placeholder=placeholder, size_large="800x800"
         )
+
+    def _membership_type(self, instance):
+        membership = instance.current_membership
+        if membership:
+            return membership.type
+        return None
 
 
 class ProfileEditSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### Summary
Add extra information in the member and membergroup serializers. This would allow a Discord bot to sync this information without having to query every single user separately.

### How to test
Steps to test the changes you made:
1. Visit `/api/v1/members/`
2. Visit `/api/v1/activemembers/groups/`
