### PR TITLE
Add tpay_balance property to users

### DIFF
--- a/website/payments/admin.py
+++ b/website/payments/admin.py
@@ -575,24 +575,23 @@ class PaymentInline(admin.TabularInline):
 
 
 class ThaliaPayEnabledFilter(admin.SimpleListFilter):
-    title = "Thalia Pay enabled"
+    title = _("Thalia Pay enabled")
     parameter_name = "tpay_enabled"
 
     def lookups(self, request, model_admin):
-        return ("Yes", "Yes"), ("No", "No")
+        return ("1", _("Yes")), ("0", _("No"))
 
     def queryset(self, request, queryset):
-        value = self.value()
-        tpay_enabled = [x.id for x in PaymentUser.objects.all() if x.tpay_enabled]
-        if value == "Yes":
-            return PaymentUser.objects.filter(id__in=tpay_enabled)
-        if value == "No":
-            return PaymentUser.objects.exclude(id__in=tpay_enabled)
-        return None
+        tpay_enabled = [x.id for x in queryset.all() if x.tpay_enabled]
+        if self.value() == "1":
+            return queryset.filter(id__in=tpay_enabled)
+        if self.value() == "0":
+            return queryset.exclude(id__in=tpay_enabled)
+        return queryset
 
 
 class ThaliaPayBalanceFilter(admin.SimpleListFilter):
-    title = "Thalia Pay balance"
+    title = _("Thalia Pay balance")
     parameter_name = "tpay_balance"
 
     def lookups(self, request, model_admin):
@@ -602,13 +601,12 @@ class ThaliaPayBalanceFilter(admin.SimpleListFilter):
         )
 
     def queryset(self, request, queryset):
-        value = self.value()
-        tpay_balance = [x.id for x in PaymentUser.objects.all() if x.tpay_balance != 0]
-        if value == "0":
-            return PaymentUser.objects.exclude(id__in=tpay_balance)
-        if value == "1":
-            return PaymentUser.objects.filter(id__in=tpay_balance)
-        return None
+        tpay_balance = [x.id for x in queryset.all() if x.tpay_balance != 0]
+        if self.value() == "0":
+            return queryset.exclude(id__in=tpay_balance)
+        if self.value() == "1":
+            return queryset.filter(id__in=tpay_balance)
+        return queryset
 
 
 @admin.register(PaymentUser)
@@ -645,12 +643,12 @@ class PaymentUserAdmin(admin.ModelAdmin):
     def get_tpay_balance(self, obj):
         return f"€ {obj.tpay_balance:.2f}"
 
-    get_tpay_balance.short_description = "Balance"
+    get_tpay_balance.short_description = _("balance")
 
     def get_tpay_enabled(self, obj):
         return obj.tpay_enabled
 
-    get_tpay_enabled.short_description = "Thalia Pay enabled"
+    get_tpay_enabled.short_description = _("Thalia Pay enabled")
     get_tpay_enabled.boolean = True
 
     def user_link(self, obj):

--- a/website/payments/admin.py
+++ b/website/payments/admin.py
@@ -531,12 +531,147 @@ class BankAccountAdmin(admin.ModelAdmin):
     export_csv.short_description = _("Export")
 
 
+class BankAccountInline(admin.TabularInline):
+    model = BankAccount
+    fields = (
+        "iban",
+        "bic",
+        "mandate_no",
+        "valid_from",
+        "valid_until",
+        "last_used",
+    )
+    show_change_link = True
+
+    can_delete = False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+
+class PaymentInline(admin.TabularInline):
+    model = Payment
+    fields = (
+        "created_at",
+        "type",
+        "amount",
+        "topic",
+        "notes",
+        "batch",
+    )
+
+    show_change_link = True
+
+    can_delete = False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+
+class ThaliaPayEnabledFilter(admin.SimpleListFilter):
+    title = "Thalia Pay enabled"
+    parameter_name = "tpay_enabled"
+
+    def lookups(self, request, model_admin):
+        return ("Yes", "Yes"), ("No", "No")
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        tpay_enabled = [x.id for x in PaymentUser.objects.all() if x.tpay_enabled]
+        if value == "Yes":
+            return PaymentUser.objects.filter(id__in=tpay_enabled)
+        if value == "No":
+            return PaymentUser.objects.exclude(id__in=tpay_enabled)
+        return None
+
+
+class ThaliaPayBalanceFilter(admin.SimpleListFilter):
+    title = "Thalia Pay balance"
+    parameter_name = "tpay_balance"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("0", "€0,00"),
+            ("1", ">€0.00"),
+        )
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        tpay_balance = [x.id for x in PaymentUser.objects.all() if x.tpay_balance != 0]
+        if value == "0":
+            return PaymentUser.objects.exclude(id__in=tpay_balance)
+        if value == "1":
+            return PaymentUser.objects.filter(id__in=tpay_balance)
+        return None
+
+
 @admin.register(PaymentUser)
 class PaymentUserAdmin(admin.ModelAdmin):
+    list_display = (
+        "__str__",
+        "email",
+        "get_tpay_enabled",
+        "get_tpay_balance",
+    )
+    list_filter = [ThaliaPayEnabledFilter, ThaliaPayBalanceFilter]
+
+    inlines = [BankAccountInline, PaymentInline]
+
+    fields = (
+        "user_link",
+        "get_tpay_enabled",
+        "get_tpay_balance",
+    )
+
+    readonly_fields = (
+        "user_link",
+        "get_tpay_enabled",
+        "get_tpay_balance",
+    )
 
     search_fields = (
         "first_name",
         "last_name",
-        "email",
         "username",
+        "email",
     )
+
+    def get_tpay_balance(self, obj):
+        return f"€ {obj.tpay_balance:.2f}"
+
+    get_tpay_balance.short_description = "Balance"
+
+    def get_tpay_enabled(self, obj):
+        return obj.tpay_enabled
+
+    get_tpay_enabled.short_description = "Thalia Pay enabled"
+    get_tpay_enabled.boolean = True
+
+    def user_link(self, obj):
+        return (
+            format_html(
+                "<a href='{}'>{}</a>",
+                reverse("admin:auth_user_change", args=[obj.pk]),
+                obj.get_full_name(),
+            )
+            if obj
+            else ""
+        )
+
+    user_link.admin_order_field = "user"
+    user_link.short_description = _("user")
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/website/payments/templates/payments/payment_form.html
+++ b/website/payments/templates/payments/payment_form.html
@@ -34,6 +34,10 @@
                 {% endblocktrans %}
             </p>
 
+            <p class="text-center">
+                 After this payment, your Thalia Pay balance will be € {{ new_debt|floatformat:2 }}.
+            </p>
+
             <form class="form-horizontal row" method="post" class="row">
                 {% csrf_token %}
 

--- a/website/payments/templates/payments/payment_form.html
+++ b/website/payments/templates/payments/payment_form.html
@@ -35,7 +35,7 @@
             </p>
 
             <p class="text-center">
-                 After this payment, your Thalia Pay balance will be € {{ new_debt|floatformat:2 }}.
+                 {% trans "After this payment, your Thalia Pay balance will be" %} € {{ new_balance|floatformat:2 }}.
             </p>
 
             <form class="form-horizontal row" method="post" class="row">

--- a/website/payments/templates/payments/payment_list.html
+++ b/website/payments/templates/payments/payment_list.html
@@ -17,6 +17,12 @@
                 {% endfor %}
             {% endif %}
 
+            {% if tpay_balance and tpay_balance != 0 %}
+                 <h5 class="text-center mb-4">
+                    Your current Thalia Pay balance is: € {{ tpay_balance|floatformat:2 }}
+                 </h5>
+            {% endif %}
+
             <ul class="nav nav-tabs justify-content-center mb-4">
                 {% for filter in filters|slice:':6' %}
                     <li class="nav-item">

--- a/website/payments/templates/payments/payment_list.html
+++ b/website/payments/templates/payments/payment_list.html
@@ -19,7 +19,7 @@
 
             {% if tpay_balance and tpay_balance != 0 %}
                  <h5 class="text-center mb-4">
-                    Your current Thalia Pay balance is: € {{ tpay_balance|floatformat:2 }}
+                    {% trans "Your current Thalia Pay balance is" %}: € {{ tpay_balance|floatformat:2 }}
                  </h5>
             {% endif %}
 

--- a/website/payments/tests/test_admin.py
+++ b/website/payments/tests/test_admin.py
@@ -897,20 +897,26 @@ class PaymentUserAdminTest(TestCase):
         filter_all = admin.ThaliaPayEnabledFilter(
             None, {}, PaymentUser, admin.PaymentUserAdmin
         )
-        self.assertIsNone(filter_all.queryset(None, None))
+        self.assertEqual(
+            filter_all.queryset(None, PaymentUser.objects), PaymentUser.objects
+        )
 
         filter_true = admin.ThaliaPayEnabledFilter(
-            None, {"tpay_enabled": "Yes"}, PaymentUser, admin.PaymentUserAdmin
+            None, {"tpay_enabled": "1"}, PaymentUser, admin.PaymentUserAdmin
         )
         self.assertQuerysetEqual(
-            filter_true.queryset(None, None).values_list("pk", flat=True).all(),
+            filter_true.queryset(None, PaymentUser.objects)
+            .values_list("pk", flat=True)
+            .all(),
             ["2", "1"],
         )
         filter_false = admin.ThaliaPayEnabledFilter(
-            None, {"tpay_enabled": "No"}, PaymentUser, admin.PaymentUserAdmin
+            None, {"tpay_enabled": "0"}, PaymentUser, admin.PaymentUserAdmin
         )
         self.assertQuerysetEqual(
-            filter_false.queryset(None, None).values_list("pk", flat=True).all(),
+            filter_false.queryset(None, PaymentUser.objects)
+            .values_list("pk", flat=True)
+            .all(),
             ["3", "4"],
         )
 
@@ -919,34 +925,46 @@ class PaymentUserAdminTest(TestCase):
         filter_all = admin.ThaliaPayBalanceFilter(
             None, {}, PaymentUser, admin.PaymentUserAdmin
         )
-        self.assertIsNone(filter_all.queryset(None, None))
+        self.assertEqual(
+            filter_all.queryset(None, PaymentUser.objects), PaymentUser.objects
+        )
 
         tpay_balance.return_value = Decimal(0)
         filter_true = admin.ThaliaPayBalanceFilter(
             None, {"tpay_balance": "0"}, PaymentUser, admin.PaymentUserAdmin
         )
         self.assertQuerysetEqual(
-            filter_true.queryset(None, None).values_list("pk", flat=True).all(),
+            filter_true.queryset(None, PaymentUser.objects)
+            .values_list("pk", flat=True)
+            .all(),
             ["3", "4", "2", "1"],
         )
         filter_false = admin.ThaliaPayBalanceFilter(
             None, {"tpay_balance": "1"}, PaymentUser, admin.PaymentUserAdmin
         )
         self.assertQuerysetEqual(
-            filter_false.queryset(None, None).values_list("pk", flat=True).all(), []
+            filter_false.queryset(None, PaymentUser.objects)
+            .values_list("pk", flat=True)
+            .all(),
+            [],
         )
         tpay_balance.return_value = Decimal(10)
         filter_true = admin.ThaliaPayBalanceFilter(
             None, {"tpay_balance": "0"}, PaymentUser, admin.PaymentUserAdmin
         )
         self.assertQuerysetEqual(
-            filter_true.queryset(None, None).values_list("pk", flat=True).all(), []
+            filter_true.queryset(None, PaymentUser.objects)
+            .values_list("pk", flat=True)
+            .all(),
+            [],
         )
         filter_false = admin.ThaliaPayBalanceFilter(
             None, {"tpay_balance": "1"}, PaymentUser, admin.PaymentUserAdmin
         )
         self.assertQuerysetEqual(
-            filter_false.queryset(None, None).values_list("pk", flat=True).all(),
+            filter_false.queryset(None, PaymentUser.objects)
+            .values_list("pk", flat=True)
+            .all(),
             ["3", "4", "2", "1"],
         )
 

--- a/website/payments/views.py
+++ b/website/payments/views.py
@@ -191,7 +191,7 @@ class PaymentProcessView(SuccessMessageMixin, FormView):
         context.update({"payable": self.payable})
         context.update(
             {
-                "new_debt": PaymentUser.objects.get(
+                "new_balance": PaymentUser.objects.get(
                     pk=self.payable.payment_payer.pk
                 ).tpay_balance
                 - Decimal(self.payable.payment_amount)


### PR DESCRIPTION
Closes #1260 

### Summary
The current Thalia Pay balance for a user is added

### How to test
1. Have a user with Thalia Pay payments
2. If the balance is not 0, the balance is visible on the Payment List page
3. When processing the balance, the new balance amount is shown
4. The balance is visible in the user admin