### PR TITLE
Add activemembers:read to scopes

### DIFF
--- a/website/thaliawebsite/settings/settings.py
+++ b/website/thaliawebsite/settings/settings.py
@@ -161,6 +161,7 @@ OAUTH2_PROVIDER = {
         "read": "Authenticated read access to the website",
         "write": "Authenticated write access to the website",
         "members:read": "Read access to your member profile",
+        "activemembers:read": "Read access to committee, society and board groups",
     },
 }
 


### PR DESCRIPTION
### Summary

Add activemembers:read to scopes, without this scopes a `client_credentials` user cannot use the API

### How to test
Steps to test the changes you made:
1. Do a call to the activemembers API with a token that has these permissions
2. Get access
