### PR TITLE
Prevent event registration cancelling after payment

### DIFF
--- a/website/events/services.py
+++ b/website/events/services.py
@@ -150,7 +150,7 @@ def cancel_registration(member, event):
         registration.date_cancelled = timezone.now()
         registration.save()
     else:
-        if registration.payment is not None:
+        if registration is not None and registration.payment is not None:
             raise RegistrationError(
                 _("You can't cancel a registration after having payed.")
             )

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -150,12 +150,7 @@ def cancel_registration(member, event):
         registration.date_cancelled = timezone.now()
         registration.save()
     else:
-        if registration is not None and registration.payment is not None:
-            raise RegistrationError(
-                _("You can't cancel a registration after having payed.")
-            )
-        else:
-            raise RegistrationError(_("You are not registered for this event."))
+        raise RegistrationError(_("You are not allowed to deregister for this event."))
 
 
 def update_registration(

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -137,7 +137,9 @@ def cancel_registration(member, event):
 
     if event_permissions(member, event)["cancel_registration"] and registration:
         if registration.payment is not None:
-            raise RegistrationError(_("You can't cancel a registration after having payed."))
+            raise RegistrationError(
+                _("You can't cancel a registration after having payed.")
+            )
         if registration.queue_position == 0:
             emails.notify_first_waiting(event)
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -137,7 +137,7 @@ def cancel_registration(member, event):
 
     if event_permissions(member, event)["cancel_registration"] and registration:
         if registration.payment is not None:
-            delete_payment(registration)
+            raise RegistrationError(_("You can't cancel a registration after having payed."))
         if registration.queue_position == 0:
             emails.notify_first_waiting(event)
 

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -175,22 +175,18 @@
                                         {% endif %}
                                     </form>
                                 {% elif permissions.cancel_registration %}
-                                    {% if registration.payment %}
-                                        <i>{% trans "You can't cancel a registration after having payed." %}</i>
-                                    {% else %}
-                                        {# Special message to accept costs when cancelling after the deadline, unless member is on the waiting list #}
-                                        <form action="{% url 'events:cancel' event.id %}" method="post">{% csrf_token %}
-                                            {% if registration.would_cancel_after_deadline %}
-                                                <input type="submit" class="btn btn-primary"
-                                                       value="{% trans "Cancel registration" %}"
-                                                       onclick="return confirm('{% blocktrans trimmed with costs=event.fine %}The deadline has passed, are you sure you want to cancel your registration and pay the estimated full costs of €{{ costs }}? You will not be able to undo this!{% endblocktrans %} {% blocktrans trimmed %}Note: If you have any COVID-19 symptoms you will not have to pay these fees. Let us know via info@thalia.nu that this is this reason for your cancellation.{% endblocktrans %}');"/>
-                                            {% else %}
-                                                <input type="submit" class="btn btn-primary"
-                                                       value="{% trans "Cancel registration" %}"
-                                                       onclick="return confirm('{% trans 'Are you sure you want to cancel your registration?' %}');"/>
-                                            {% endif %}
-                                        </form>
-                                    {% endif %}
+                                    {# Special message to accept costs when cancelling after the deadline, unless member is on the waiting list #}
+                                    <form action="{% url 'events:cancel' event.id %}" method="post">{% csrf_token %}
+                                        {% if registration.would_cancel_after_deadline %}
+                                            <input type="submit" class="btn btn-primary"
+                                                   value="{% trans "Cancel registration" %}"
+                                                   onclick="return confirm('{% blocktrans trimmed with costs=event.fine %}The deadline has passed, are you sure you want to cancel your registration and pay the estimated full costs of €{{ costs }}? You will not be able to undo this!{% endblocktrans %} {% blocktrans trimmed %}Note: If you have any COVID-19 symptoms you will not have to pay these fees. Let us know via info@thalia.nu that this is this reason for your cancellation.{% endblocktrans %}');"/>
+                                        {% else %}
+                                            <input type="submit" class="btn btn-primary"
+                                                   value="{% trans "Cancel registration" %}"
+                                                   onclick="return confirm('{% trans 'Are you sure you want to cancel your registration?' %}');"/>
+                                        {% endif %}
+                                    </form>
                                 {% elif not request.user.is_authenticated and event.registration_required %}
                                     <a class="btn btn-primary"
                                        href="{% url 'login' %}?next={{ request.path }}">{% trans "Login" %}</a>

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -175,18 +175,22 @@
                                         {% endif %}
                                     </form>
                                 {% elif permissions.cancel_registration %}
-                                    {# Special message to accept costs when cancelling after the deadline, unless member is on the waiting list #}
-                                    <form action="{% url 'events:cancel' event.id %}" method="post">{% csrf_token %}
-                                        {% if registration.would_cancel_after_deadline %}
-                                            <input type="submit" class="btn btn-primary"
-                                                   value="{% trans "Cancel registration" %}"
-                                                   onclick="return confirm('{% blocktrans trimmed with costs=event.fine %}The deadline has passed, are you sure you want to cancel your registration and pay the estimated full costs of €{{ costs }}? You will not be able to undo this!{% endblocktrans %} {% blocktrans trimmed %}Note: If you have any COVID-19 symptoms you will not have to pay these fees. Let us know via info@thalia.nu that this is this reason for your cancellation.{% endblocktrans %}');"/>
-                                        {% else %}
-                                            <input type="submit" class="btn btn-primary"
-                                                   value="{% trans "Cancel registration" %}"
-                                                   onclick="return confirm('{% trans 'Are you sure you want to cancel your registration?' %}');"/>
-                                        {% endif %}
-                                    </form>
+                                    {% if registration.payment %}
+                                        <i>{% trans "You can't cancel a registration after having payed." %}</i>
+                                    {% else %}
+                                        {# Special message to accept costs when cancelling after the deadline, unless member is on the waiting list #}
+                                        <form action="{% url 'events:cancel' event.id %}" method="post">{% csrf_token %}
+                                            {% if registration.would_cancel_after_deadline %}
+                                                <input type="submit" class="btn btn-primary"
+                                                       value="{% trans "Cancel registration" %}"
+                                                       onclick="return confirm('{% blocktrans trimmed with costs=event.fine %}The deadline has passed, are you sure you want to cancel your registration and pay the estimated full costs of €{{ costs }}? You will not be able to undo this!{% endblocktrans %} {% blocktrans trimmed %}Note: If you have any COVID-19 symptoms you will not have to pay these fees. Let us know via info@thalia.nu that this is this reason for your cancellation.{% endblocktrans %}');"/>
+                                            {% else %}
+                                                <input type="submit" class="btn btn-primary"
+                                                       value="{% trans "Cancel registration" %}"
+                                                       onclick="return confirm('{% trans 'Are you sure you want to cancel your registration?' %}');"/>
+                                            {% endif %}
+                                        </form>
+                                    {% endif %}
                                 {% elif not request.user.is_authenticated and event.registration_required %}
                                     <a class="btn btn-primary"
                                        href="{% url 'login' %}?next={{ request.path }}">{% trans "Login" %}</a>


### PR DESCRIPTION
Closes #1256 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
An user can no longer cancel it's registration after having payed

### How to test
1. Register for an event with a payment
2. Pay for the event
3. Try to cancel the registration
