### PR TITLE
Save newsletter to disk when sending

### DIFF
--- a/website/newsletters/emails.py
+++ b/website/newsletters/emails.py
@@ -62,8 +62,6 @@ def send_newsletter(newsletter):
         html_message = html_template.render(context)
         text_message = text_template.render(context)
 
-        services.write_to_file(newsletter.pk, language[0], html_message)
-
         msg = EmailMultiAlternatives(
             subject=subject,
             body=text_message,

--- a/website/newsletters/management/commands/createnewsletterhtml.py
+++ b/website/newsletters/management/commands/createnewsletterhtml.py
@@ -26,9 +26,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        request = HttpRequest()
-        request.META["SERVER_NAME"] = options["server-name"]
-        request.META["SERVER_PORT"] = options["server-port"]
         for n in models.Newsletter.objects.all():
             if n.sent or options["include-unsent"]:
-                services.save_to_disk(n, request)
+                services.save_to_disk(n)

--- a/website/newsletters/management/commands/createnewsletterhtml.py
+++ b/website/newsletters/management/commands/createnewsletterhtml.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.http import HttpRequest
 
 from newsletters import models, services
 
@@ -12,17 +11,6 @@ class Command(BaseCommand):
             dest="include-unsent",
             default=False,
             help="Include newsletters that haven't been sent yet",
-        )
-        parser.add_argument(
-            "server-name",
-            help="The server name for the request "
-            "to generate the html (typically thalia.nu)",
-        )
-        parser.add_argument(
-            "server-port",
-            type=int,
-            help="The server port for the request "
-            "to generate the html (typically 80)",
         )
 
     def handle(self, *args, **options):

--- a/website/newsletters/services.py
+++ b/website/newsletters/services.py
@@ -23,7 +23,7 @@ def write_to_file(pk, lang, html_message):
         cache_file.write(html_message)
 
 
-def save_to_disk(newsletter, request):
+def save_to_disk(newsletter):
     """
     Writes the newsletter as HTML to file (in all languages)
     """
@@ -45,7 +45,6 @@ def save_to_disk(newsletter, request):
             "main_partner": main_partner,
             "local_partner": local_partner,
             "lang_code": language[0],
-            "request": request,
         }
 
         html_message = html_template.render(context)
@@ -77,3 +76,5 @@ def send_newsletter(newsletter):
     )
     message.users.set(Member.current_members.all())
     message.send()
+
+    save_to_disk(newsletter)


### PR DESCRIPTION
Closes #1256 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The newsletter was saved by the email sending code which for some reason doesn't actually work. The newsletter is now saved by the newsletter services itself, which does work.

### How to test
Steps to test the changes you made:
1. Create a newsletter
2. Send it to the members
3. Notice that the newsletter got saved to disk
