### PR TITLE
Remove NL preview button from newsletters admin

### DIFF
--- a/website/newsletters/templates/admin/newsletters/change_form.html
+++ b/website/newsletters/templates/admin/newsletters/change_form.html
@@ -12,8 +12,7 @@
     {% if newsletter %}
     <div class="submit-row newsletters-row">
         <a href="{% url 'newsletters:admin-send' pk=newsletter.pk %}" class="default button">{% trans "Send newsletter to members" %}</a>
-        <a target="_blank" href="{% url 'newsletters:preview-localised' pk=newsletter.pk lang='en' %}" class="button">{% trans "Show preview" %} (EN)</a>
-        <a target="_blank" href="{% url 'newsletters:preview-localised' pk=newsletter.pk lang='nl' %}" class="button">{% trans "Show preview" %} (NL)</a>
+        <a target="_blank" href="{% url 'newsletters:preview' pk=newsletter.pk %}" class="button">{% trans "Show preview" %}</a>
     </div>
     {% endif %}
 {% endblock %}
@@ -24,8 +23,7 @@
     {% if newsletter %}
     <div class="submit-row newsletters-row">
         <a href="{% url 'newsletters:admin-send' pk=newsletter.pk %}" class="default button">{% trans "Send newsletter to members" %}</a>
-        <a target="_blank" href="{% url 'newsletters:preview-localised' pk=newsletter.pk lang='en' %}" class="button">{% trans "Show preview" %} (EN)</a>
-        <a target="_blank" href="{% url 'newsletters:preview-localised' pk=newsletter.pk lang='nl' %}" class="button">{% trans "Show preview" %} (NL)</a>
+        <a target="_blank" href="{% url 'newsletters:preview' pk=newsletter.pk %}" class="button">{% trans "Show preview" %}</a>
     </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
### Summary

Remove NL preview button from newsletters admin. Because clicking them results in an error.

### How to test
Steps to test the changes you made:
1. Create a newsletter
2. Check that there is only the default preview button
