### PR TITLE
Removed the translations-part from the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,10 @@ Or for macOS:
 
     brew install ghostscript
 
-Translating
+Language
 ------------------
 
 Make sure to use British English.
-
-To create translations for your app:
-
-1. `cd` into the application's directory
-2. `../manage.py makemessages --locale nl --no-obsolete`
-3. This creates or updates `locale/nl/LC_MESSAGES/django.po`
-4. Start poedit by calling `poedit locale/nl/LC_MESSAGES/django.po`
-5. `../manage.py compilemessages` (should happen automatically when saving the file in poedit)
-6. Commit both the `.po` and `.mo` file to the repository
 
 Settings
 ------------------


### PR DESCRIPTION
Part of #1200

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Removed the instructions on translating from the readme. Concrexit no longer supports Dutch, hence translations are not necessary anymore. Kept the note on using British English.

### How to test
Steps to test the changes you made:
1. Read the README.md, the 'Translating'-header has been replaced with 'Language'.

