### PR TITLE
Fix activemembers API

### DIFF
--- a/website/activemembers/views.py
+++ b/website/activemembers/views.py
@@ -22,9 +22,9 @@ class _MemberGroupDetailView(DetailView):
     def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)
 
-        memberships = self._get_memberships(context["membergroup"]).prefetch_related(
-            "member__membergroupmembership_set"
-        )
+        memberships = MemberGroupMembership.active_objects.filter(
+            group=group
+        ).prefetch_related("member__membergroupmembership_set")
         members = [
             {
                 "member": x.member,


### PR DESCRIPTION
### Summary

Fix activemembers API

### How to test
Steps to test the changes you made:
1. Check that the API no longer shows EVERY SINGLE MEMBER EVER for a committee
2. http://localhost:8000/api/v1/activemembers/groups/
