### PR TITLE
Fix automatic event fill in newsletter

### DIFF
--- a/website/newsletters/static/admin/newsletters/js/forms.js
+++ b/website/newsletters/static/admin/newsletters/js/forms.js
@@ -79,25 +79,12 @@ django.jQuery(function () {
     }
 
     function getEvent(pk, success) {
-        var originalLang = $('html').attr('lang');
-        switchLanguage('nl', function () {
-            $.ajax({
-                url: '/api/v1/events/' + pk,
-                type: 'GET',
-                dataType: 'json'
-            }).done(function(data) {
-                success(data, 'nl');
-                switchLanguage('en', function () {
-                    $.ajax({
-                        url: '/api/v1/events/' + pk,
-                        type: 'GET',
-                        dataType: 'json'
-                    }).done(function(data) {
-                        success(data, 'en');
-                        switchLanguage(originalLang, function() {});
-                    });
-                });
-            });
+        $.ajax({
+            url: '/api/v1/events/' + pk,
+            type: 'GET',
+            dataType: 'json'
+        }).done(function(data) {
+            success(data, 'en');
         });
     }
 

--- a/website/newsletters/static/admin/newsletters/js/forms.js
+++ b/website/newsletters/static/admin/newsletters/js/forms.js
@@ -1,28 +1,6 @@
 django.jQuery(function () {
     var $ = django.jQuery;
 
-    function switchLanguage(newLang, success) {
-        var currentLang = $('html').attr('lang');
-        if (currentLang === newLang) {
-            success();
-            return;
-        }
-        django.jQuery.ajax({
-            url: '/i18n/setlang/',
-            type: 'POST',
-            data: {
-                'language': newLang
-            },
-            headers: {
-                "X-CSRFToken": Cookies.get('csrftoken')
-            },
-            dataType: 'json'
-        }).done(function () {
-            $('html').attr('lang', newLang);
-            success();
-        });
-    }
-
     function pad(num, size) {
         var s = "0" + num;
         return s.substr(s.length-size);


### PR DESCRIPTION
Closes #1315 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The newsletter now fills in the events automatically again.

### How to test
Steps to test the changes you made:
1. Create a new newsletter
2. Click on 'Add newsletter event'
3. Select an event in the dropdown menu
