### PR TITLE
Make thabloids private

### DIFF
--- a/website/thabloid/migrations/0006_make_thabloids_private.py
+++ b/website/thabloid/migrations/0006_make_thabloids_private.py
@@ -5,28 +5,30 @@ from django.db import migrations
 
 
 def make_public_thabloids_private(apps, schema_editor):
-    if not os.path.exists(os.path.join(settings.MEDIA_ROOT, "private/thabloids/")):
-        os.makedirs(os.path.join(settings.MEDIA_ROOT, "private/thabloids/"))
+    if os.path.exists(os.path.join(settings.MEDIA_ROOT, "public/thabloids/")):
+        if not os.path.exists(os.path.join(settings.MEDIA_ROOT, "private/thabloids/")):
+            os.makedirs(os.path.join(settings.MEDIA_ROOT, "private/thabloids/"))
 
-    os.rename(os.path.join(settings.MEDIA_ROOT, "public/thabloids/"),os.path.join(settings.MEDIA_ROOT, "private/thabloids/"))
+        os.rename(os.path.join(settings.MEDIA_ROOT, "public/thabloids/"),os.path.join(settings.MEDIA_ROOT, "private/thabloids/"))
 
-    Thabloid = apps.get_model('thabloid', 'Thabloid')
-    db_alias = schema_editor.connection.alias
-    for thabloid in Thabloid.objects.using(db_alias).all():
-        thabloid.file.name = os.path.join("private/thabloids", os.path.basename(thabloid.file.name))
-        thabloid.save()
+        Thabloid = apps.get_model('thabloid', 'Thabloid')
+        db_alias = schema_editor.connection.alias
+        for thabloid in Thabloid.objects.using(db_alias).all():
+            thabloid.file.name = os.path.join("private/thabloids", os.path.basename(thabloid.file.name))
+            thabloid.save()
 
 def make_public_thabloids_public(apps, schema_editor):
-    if not os.path.exists(os.path.join(settings.MEDIA_ROOT, "public/thabloids/")):
-        os.makedirs(os.path.join(settings.MEDIA_ROOT, "public/thabloids/"))
+    if os.path.exists(os.path.join(settings.MEDIA_ROOT, "private/thabloids/")):
+        if not os.path.exists(os.path.join(settings.MEDIA_ROOT, "public/thabloids/")):
+            os.makedirs(os.path.join(settings.MEDIA_ROOT, "public/thabloids/"))
 
-    os.rename(os.path.join(settings.MEDIA_ROOT, "private/thabloids/"),os.path.join(settings.MEDIA_ROOT, "public/thabloids/"))
+        os.rename(os.path.join(settings.MEDIA_ROOT, "private/thabloids/"),os.path.join(settings.MEDIA_ROOT, "public/thabloids/"))
 
-    Thabloid = apps.get_model('thabloid', 'Thabloid')
-    db_alias = schema_editor.connection.alias
-    for thabloid in Thabloid.objects.using(db_alias).all():
-        thabloid.file.name = os.path.join("public/thabloids", os.path.basename(thabloid.file.name))
-        thabloid.save()
+        Thabloid = apps.get_model('thabloid', 'Thabloid')
+        db_alias = schema_editor.connection.alias
+        for thabloid in Thabloid.objects.using(db_alias).all():
+            thabloid.file.name = os.path.join("public/thabloids", os.path.basename(thabloid.file.name))
+            thabloid.save()
 
 
 class Migration(migrations.Migration):

--- a/website/thabloid/migrations/0006_make_thabloids_private.py
+++ b/website/thabloid/migrations/0006_make_thabloids_private.py
@@ -1,0 +1,40 @@
+import os
+
+from django.conf import settings
+from django.db import migrations
+
+
+def make_public_thabloids_private(apps, schema_editor):
+    if not os.path.exists(os.path.join(settings.MEDIA_ROOT, "private/thabloids/")):
+        os.makedirs(os.path.join(settings.MEDIA_ROOT, "private/thabloids/"))
+
+    os.rename(os.path.join(settings.MEDIA_ROOT, "public/thabloids/"),os.path.join(settings.MEDIA_ROOT, "private/thabloids/"))
+
+    Thabloid = apps.get_model('thabloid', 'Thabloid')
+    db_alias = schema_editor.connection.alias
+    for thabloid in Thabloid.objects.using(db_alias).all():
+        thabloid.file.name = os.path.join("private/thabloids", os.path.basename(thabloid.file.name))
+        thabloid.save()
+
+def make_public_thabloids_public(apps, schema_editor):
+    if not os.path.exists(os.path.join(settings.MEDIA_ROOT, "public/thabloids/")):
+        os.makedirs(os.path.join(settings.MEDIA_ROOT, "public/thabloids/"))
+
+    os.rename(os.path.join(settings.MEDIA_ROOT, "private/thabloids/"),os.path.join(settings.MEDIA_ROOT, "public/thabloids/"))
+
+    Thabloid = apps.get_model('thabloid', 'Thabloid')
+    db_alias = schema_editor.connection.alias
+    for thabloid in Thabloid.objects.using(db_alias).all():
+        thabloid.file.name = os.path.join("public/thabloids", os.path.basename(thabloid.file.name))
+        thabloid.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('thabloid', '0005_auto_20190516_1536'),
+    ]
+
+    operations = [
+        migrations.RunPython(make_public_thabloids_private, make_public_thabloids_public)
+    ]

--- a/website/thabloid/models.py
+++ b/website/thabloid/models.py
@@ -16,7 +16,7 @@ from utils.threading import PopenAndCall
 def thabloid_filename(instance, filename):
     """Return path of thabloid."""
     ext = os.path.splitext(filename)[1]
-    return os.path.join("public/thabloids/", slugify(instance) + ext)
+    return os.path.join("private/thabloids/", slugify(instance) + ext)
 
 
 def pagesets(count):

--- a/website/thabloid/templatetags/thabloid_cards.py
+++ b/website/thabloid/templatetags/thabloid_cards.py
@@ -2,7 +2,7 @@ from django import template
 from django.urls import reverse
 
 from thaliawebsite.templatetags.grid_item import grid_item
-from utils.media.services import get_thumbnail_url
+from utils.media.services import get_thumbnail_url, get_media_url
 
 register = template.Library()
 
@@ -21,7 +21,7 @@ def thabloid_card(year, thabloid):
         '<i class="fas fa-download"></i>'
         "</a>"
         "</div>"
-    ).format(view_url, thabloid.file.url)
+    ).format(view_url, get_media_url(thabloid.file.path, attachment=True))
 
     return grid_item(
         title="{}-{}, #{}".format(thabloid.year, thabloid.year + 1, thabloid.issue),

--- a/website/thabloid/tests/test_thabloid.py
+++ b/website/thabloid/tests/test_thabloid.py
@@ -36,16 +36,16 @@ class TestThabloid(TestCase):
 
     def test_page_urls(self):
         self.assertEqual(
-            self.thabloid.cover, "public/thabloids/pages/thabloid-1998-1999-1/001.png"
+            self.thabloid.cover, "private/thabloids/pages/thabloid-1998-1999-1/001.png"
         )
         self.assertEqual(
             self.thabloid.page_url(2, 3),
-            "public/thabloids/pages/thabloid-1998-1999-1/002-003.png",
+            "private/thabloids/pages/thabloid-1998-1999-1/002-003.png",
         )
         # check if it's actual zeropadding and not just '00' + i
         self.assertEqual(
             self.thabloid.page_url(20),
-            "public/thabloids/pages/thabloid-1998-1999-1/020.png",
+            "private/thabloids/pages/thabloid-1998-1999-1/020.png",
         )
 
     @staticmethod

--- a/website/thabloid/views.py
+++ b/website/thabloid/views.py
@@ -1,11 +1,13 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, render
 from django.db.models import Max
-from django.conf import settings
 from django.http import JsonResponse
 
+from utils.media.services import get_media_url
 from .models import Thabloid
 
 
+@login_required
 def index(request):
     """Render Thabloid overview index page."""
     thabloids = Thabloid.objects.all()
@@ -16,8 +18,9 @@ def index(request):
     return render(request, "thabloid/index.html", context)
 
 
+@login_required
 def pages(request, year, issue):
     """Return paths of individual Thabloid pages."""
     thabloid = get_object_or_404(Thabloid, year=int(year), issue=int(issue))
-    files = [{"src": "{}{}".format(settings.MEDIA_URL, p)} for p in thabloid.pages]
+    files = [{"src": get_media_url(p)} for p in thabloid.pages]
     return JsonResponse(files, safe=False)

--- a/website/thaliawebsite/menus.py
+++ b/website/thaliawebsite/menus.py
@@ -28,7 +28,6 @@ MAIN_MENU = [
                 "name": "singlepages:sibling-associations",
             },
             {"title": _("Become a Member"), "name": "registrations:index"},
-            {"title": _("Thabloid"), "name": "thabloid:index"},
             {"title": _("Alumni"), "name": "events:alumni"},
         ],
     },
@@ -39,6 +38,7 @@ MAIN_MENU = [
             {"title": _("Photos"), "name": "photos:index"},
             {"title": _("Statistics"), "name": "members:statistics"},
             {"title": _("Styleguide"), "name": "singlepages:styleguide"},
+            {"title": _("Thabloid"), "name": "thabloid:index"},
             {"title": _("Become Active"), "name": "singlepages:become-active"},
             {
                 "title": _("G Suite Knowledge Base"),


### PR DESCRIPTION
Closes #965 

### Summary
Thabloids are only accessible by logged-in users now

### How to test
1. check all thabloid urls
2. note that also the media urls are now private

After this PR, old thabloid files must be moved on production (or we can write a migration for that if we really want that)