### PR TITLE
Only show the second address if it exists

### DIFF
--- a/website/members/templates/members/email/information_check.html
+++ b/website/members/templates/members/email/information_check.html
@@ -27,7 +27,7 @@
                   </tr>
                   <tr>
                     <td>{% trans "address"|capfirst %}</td>
-                    <td>{{ address_street }}<br>{{ address_street2 }}<br>{{ address_postal_code }}<br>{{ address_city }}<br>{{ address_country }}</td>
+                    <td>{{ address_street }}{% if address_street2 %}<br>{{ address_street2 }}{% endif %}<br>{{ address_postal_code }}<br>{{ address_city }}<br>{{ address_country }}</td>
                   </tr>
                   <tr>
                     <td>{% trans "phone"|capfirst %}</td>


### PR DESCRIPTION
<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
A second address was always shown in the information check email, even if it didn't exist for that member. This resulted in a weird format, where it looks like your street belongs to your name and not to your address.

### How to test
1. Run `./manage.py sendinformationcheck`
2. Check the email which was sent
3. Notice that the gap between the address and the postal code is now gone

### Images
Before:
![](https://i.gyazo.com/77b2f6c47da2fc16bd47160d8d46d0ea.png)

After (without second address):
![](https://i.gyazo.com/f705fd93b45cc9df794113466d01a4e9.png)

After (with second address):
![](https://i.gyazo.com/dc0e3c5138402929444a85d69fe540c7.png)
