### PR TITLE
Fix PaymentWidget for payables without payer

### DIFF
--- a/website/payments/widgets.py
+++ b/website/payments/widgets.py
@@ -22,8 +22,8 @@ class PaymentWidget(Widget):
             context["obj"] = self.obj
             context["payable_payer"] = (
                 PaymentUser.objects.get(pk=self.obj.payment_payer.pk)
-                if hasattr(self.obj, "payment_payer")
-                else self.obj.paid_by
+                if self.obj and self.obj.payment_payer
+                else None
             )
             context["content_type"] = ContentType.objects.get_for_model(self.obj)
         elif value:


### PR DESCRIPTION
### Summary
After #1320, the admin payment widget could crash under certain circumstances

### How to test
Steps to test the changes you made:
1. Create a registration from the admin
2. The payment widget doesn't crash anymore