### PR TITLE
Add presence information to the events api

### DIFF
--- a/website/events/api/serializers/events/list.py
+++ b/website/events/api/serializers/events/list.py
@@ -22,6 +22,7 @@ class EventListSerializer(serializers.ModelSerializer):
             "location",
             "price",
             "registered",
+            "present",
             "pizza",
             "registration_allowed",
         )
@@ -29,6 +30,7 @@ class EventListSerializer(serializers.ModelSerializer):
     description = serializers.SerializerMethodField("_description")
     registered = serializers.SerializerMethodField("_registered")
     pizza = serializers.SerializerMethodField("_pizza")
+    present = serializers.SerializerMethodField("_present")
 
     def _description(self, instance):
         return unescape(strip_tags(instance.description))
@@ -47,3 +49,12 @@ class EventListSerializer(serializers.ModelSerializer):
     def _pizza(self, instance):
         pizza_events = PizzaEvent.objects.filter(event=instance)
         return pizza_events.exists()
+
+    def _present(self, instance):
+        try:
+            present = services.is_user_present(self.context["request"].user, instance,)
+            if present is None:
+                return False
+            return present
+        except AttributeError:
+            return False

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -26,6 +26,18 @@ def is_user_registered(member, event):
     return event.registrations.filter(member=member, date_cancelled=None).count() > 0
 
 
+def is_user_present(member, event):
+    if not event.registration_required or not member.is_authenticated:
+        return None
+
+    return (
+        event.registrations.filter(
+            member=member, date_cancelled=None, present=True
+        ).count()
+        > 0
+    )
+
+
 def event_permissions(member, event, name=None):
     """
     Returns a dictionary with the available event permissions of the user


### PR DESCRIPTION
### Summary
Add presence information to the events api

This change supports a feature in [Thalia Voting](https://github.com/pingiun/helios-server)

### How to test
1. Register for an event
2. Change presence to present
3. View events list api
4. Check present = true