### PR TITLE
Add install_dev_requirements ARG to Dockerfile

### DIFF
--- a/.github/workflows/build-production-docker.yaml
+++ b/.github/workflows/build-production-docker.yaml
@@ -27,7 +27,7 @@ jobs:
             - name: Build Docker images
               run: |
                   docker build --file Dockerfile.dependencies --quiet --build-arg "install_dev_requirements=0" --tag "${DOCKER_DEPENDENCIES_LATEST}" .
-                  docker build --quiet --build-arg "source_commit=${{ github.sha }}" --tag "${DOCKER_LATEST}" .
+                  docker build --quiet --build-arg "install_dev_requirements=0" --build-arg "source_commit=${{ github.sha }}" --tag "${DOCKER_LATEST}" .
 
             - name: Push Docker image
               run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM thalia/concrexit-dependencies
 MAINTAINER Thalia Technicie <www@thalia.nu>
 LABEL description="Contains the Thaliawebsite Django application"
 
+ARG install_dev_requirements=1
 ARG source_commit="unknown"
 
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
### Summary
Currently the Dockerfile does not have `install_dev_requirements` (https://github.com/svthalia/concrexit/pull/1190) set, because before https://github.com/svthalia/concrexit/pull/1230 it was not used.

https://github.com/svthalia/concrexit/pull/1230 introduced a `RUN` statement that uses `install_dev_requirements`. Currently that statement generates a error (because `install_dev_requirements` is not set) and runs `poetry install --no-interaction --no-dev` removing the development packages from the image. 

If there are dependency changes, they also need to be installed in the Docker image.