### PR TITLE
Replace the deprecated set-env

### DIFF
--- a/.github/workflows/build-production-docker.yaml
+++ b/.github/workflows/build-production-docker.yaml
@@ -16,7 +16,7 @@ jobs:
             DOCKER_DEPENDENCIES_LATEST: thalia/concrexit-dependencies:latest
         steps:
             - name: Get version
-              run: echo ::set-env name=DOCKER_VERSION::${GITHUB_REF/refs\/tags\//}
+              run: echo "DOCKER_VERSION=${GITHUB_REF/refs\/tags\//}" >> "${GITHUB_ENV}"
 
             - name: Checkout repository
               uses: actions/checkout@v2

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Create URL safe version of GITHUB_REF
-        run: echo ::set-env name=GITHUB_REF_SLUG::$(echo '${{ github.event.pull_request.head.ref }}' | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)
+        run: echo "GITHUB_REF_SLUG=$(echo '${{ github.event.pull_request.head.ref }}' | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)" >> "${GITHUB_ENV}"
 
       - name: Add comment to PR with useful information
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -16,13 +16,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get commit hash
-        run: echo ::set-env name=COMMIT_SHA::$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | grep --perl-regexp '^From [a-z0-9]{40} ' | tail --lines 1 | cut --delimiter " " --fields 2)
+        run: echo "COMMIT_SHA=$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | grep --perl-regexp '^From [a-z0-9]{40} ' | tail --lines 1 | cut --delimiter " " --fields 2)" >> "${GITHUB_ENV}"
 
       - name: Generate username
-        run: echo ::set-env name=username::$(head /dev/urandom | tr -dc 'a-z' | head -c 10)
+        run: echo "username=$(head /dev/urandom | tr -dc 'a-z' | head -c 10)" >> "${GITHUB_ENV}"
 
       - name: Generate password
-        run: echo ::set-env name=password::$(head /dev/urandom | tr -dc 'a-zA-Z' | head -c 32)
+        run: echo "password=$(head /dev/urandom | tr -dc 'a-zA-Z' | head -c 32)" >> "${GITHUB_ENV}"
 
       - name: Set variables in bootstrap script
         run: >-
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get commit hash
-        run: echo ::set-env name=COMMIT_SHA::$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | grep --perl-regexp '^From [a-z0-9]{40} ' | tail --lines 1 | cut --delimiter " " --fields 2)
+        run: echo "COMMIT_SHA=$(curl --location --silent ${{ github.event.issue.pull_request.patch_url }} | grep --perl-regexp '^From [a-z0-9]{40} ' | tail --lines 1 | cut --delimiter " " --fields 2)" >> "${GITHUB_ENV}"
 
       - name: Run script to remove review environment
         run: resources/continuous-integration/review/review-host-remove.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,7 +92,7 @@ jobs:
           path: html
 
       - name: Create URL safe version of GITHUB_REF
-        run: echo ::set-env name=GITHUB_REF_SLUG::$(echo "${GITHUB_REF#refs/heads/}"| iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)
+        run: echo "GITHUB_REF_SLUG=(echo \"${GITHUB_REF#refs/heads/}\"| iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)" >> "${GITHUB_ENV}"
 
       - name: Sync files to S3
         run: aws s3 sync --only-show-errors html "s3://thalia-coverage/${GITHUB_REF_SLUG}/"
@@ -111,7 +111,7 @@ jobs:
           path: html
 
       - name: Create URL safe version of GITHUB_REF
-        run: echo ::set-env name=GITHUB_REF_SLUG::$(echo "${GITHUB_REF#refs/heads/}" | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)
+        run: echo "GITHUB_REF_SLUG=$(echo \"${GITHUB_REF#refs/heads/}\" | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)" >> "${GITHUB_ENV}"
 
       - name: Sync files to S3
         run: aws s3 sync --only-show-errors html "s3://thalia-documentation/${GITHUB_REF_SLUG}/"


### PR DESCRIPTION
### Summary
Replace [the deprecated `set-env`](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) command with `>> "${GITHUB_ENV}"`.

