### PR TITLE
Fix admin payment widget for payables without payers

### DIFF
--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -43,9 +43,7 @@ class PaymentAdminView(View):
         payable_obj = payable_model.objects.get(pk=payable)
 
         result = services.create_payment(
-            payable_obj,
-            PaymentUser.objects.get(pk=self.request.member.pk),
-            request.POST["type"],
+            payable_obj, self.request.member, request.POST["type"],
         )
         payable_obj.save()
 

--- a/website/payments/widgets.py
+++ b/website/payments/widgets.py
@@ -22,8 +22,8 @@ class PaymentWidget(Widget):
             context["obj"] = self.obj
             context["payable_payer"] = (
                 PaymentUser.objects.get(pk=self.obj.payment_payer.pk)
-                if hasattr(self.obj, "payment_payer")
-                else self.obj.paid_by
+                if getattr(self.obj, "payment_payer", None) is not None
+                else None
             )
             context["content_type"] = ContentType.objects.get_for_model(self.obj)
         elif value:


### PR DESCRIPTION
Closes #1331


### Summary
The payment admin widget now also works (again) for payables such as registrations that return `None` as payment_payer

### How to test
Check that the payment widget does not crash 

- registrations
- events
