### PR TITLE
Add general payment api endpoint

### DIFF
--- a/docs/payments.api.rst
+++ b/docs/payments.api.rst
@@ -1,0 +1,35 @@
+payments.api package
+====================
+
+.. automodule:: payments.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   payments.api.serializers
+   payments.api.viewsets
+
+Submodules
+----------
+
+payments.api.fields module
+--------------------------
+
+.. automodule:: payments.api.fields
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+payments.api.urls module
+------------------------
+
+.. automodule:: payments.api.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/payments.api.serializers.rst
+++ b/docs/payments.api.serializers.rst
@@ -1,0 +1,26 @@
+payments.api.serializers package
+================================
+
+.. automodule:: payments.api.serializers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+payments.api.serializers.payment\_create module
+-----------------------------------------------
+
+.. automodule:: payments.api.serializers.payment_create
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+payments.api.serializers.payments module
+----------------------------------------
+
+.. automodule:: payments.api.serializers.payments
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/payments.api.viewsets.rst
+++ b/docs/payments.api.viewsets.rst
@@ -1,0 +1,18 @@
+payments.api.viewsets package
+=============================
+
+.. automodule:: payments.api.viewsets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+payments.api.viewsets.payments module
+-------------------------------------
+
+.. automodule:: payments.api.viewsets.payments
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/payments.rst
+++ b/docs/payments.rst
@@ -12,6 +12,7 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   payments.api
    payments.management
    payments.templatetags
 

--- a/docs/thaliawebsite.settings.rst
+++ b/docs/thaliawebsite.settings.rst
@@ -9,6 +9,14 @@ thaliawebsite.settings package
 Submodules
 ----------
 
+thaliawebsite.settings.localsettings module
+-------------------------------------------
+
+.. automodule:: thaliawebsite.settings.localsettings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 thaliawebsite.settings.production module
 ----------------------------------------
 

--- a/docs/thaliawebsite.settings.rst
+++ b/docs/thaliawebsite.settings.rst
@@ -9,14 +9,6 @@ thaliawebsite.settings package
 Submodules
 ----------
 
-thaliawebsite.settings.localsettings module
--------------------------------------------
-
-.. automodule:: thaliawebsite.settings.localsettings
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 thaliawebsite.settings.production module
 ----------------------------------------
 

--- a/website/payments/api/serializers/__init__.py
+++ b/website/payments/api/serializers/__init__.py
@@ -1,0 +1,1 @@
+from .payments import *

--- a/website/payments/api/serializers/__init__.py
+++ b/website/payments/api/serializers/__init__.py
@@ -1,1 +1,2 @@
 from .payments import *
+from .payment_create import *

--- a/website/payments/api/serializers/payment_create.py
+++ b/website/payments/api/serializers/payment_create.py
@@ -1,0 +1,10 @@
+from rest_framework.fields import CharField
+from rest_framework.serializers import Serializer
+
+
+class PaymentCreateSerializer(Serializer):
+    """Serializer for create payments data."""
+
+    app_label = CharField()
+    model_name = CharField()
+    payable_pk = CharField()  # A pk can be either a UUID or an integer

--- a/website/payments/api/serializers/payments.py
+++ b/website/payments/api/serializers/payments.py
@@ -1,0 +1,9 @@
+from rest_framework.serializers import ModelSerializer
+
+from payments.models import Payment
+
+
+class PaymentSerializer(ModelSerializer):
+    class Meta:
+        model = Payment
+        fields = ['pk', 'get_type_display', 'amount', 'created_at', 'topic', 'notes']

--- a/website/payments/api/serializers/payments.py
+++ b/website/payments/api/serializers/payments.py
@@ -6,4 +6,4 @@ from payments.models import Payment
 class PaymentSerializer(ModelSerializer):
     class Meta:
         model = Payment
-        fields = ['pk', 'get_type_display', 'amount', 'created_at', 'topic', 'notes']
+        fields = ["pk", "get_type_display", "amount", "created_at", "topic", "notes"]

--- a/website/payments/api/urls.py
+++ b/website/payments/api/urls.py
@@ -1,0 +1,8 @@
+"""Defines the API routes of the payments package"""
+from rest_framework import routers
+
+from payments.api import viewsets
+
+router = routers.SimpleRouter()
+router.register(r"payments", viewsets.PaymentViewset)
+urlpatterns = router.urls

--- a/website/payments/api/viewsets/__init__.py
+++ b/website/payments/api/viewsets/__init__.py
@@ -1,0 +1,1 @@
+from .payments import *

--- a/website/payments/api/viewsets/payments.py
+++ b/website/payments/api/viewsets/payments.py
@@ -1,0 +1,16 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ModelViewSet
+
+from payments.api.serializers import PaymentSerializer
+from payments.models import Payment
+
+
+class PaymentViewset(ModelViewSet):
+
+    queryset = Payment.objects.all()
+    serializer_class = PaymentSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        user = self.request.user
+        return Payment.objects.filter(paid_by=user)

--- a/website/payments/api/viewsets/payments.py
+++ b/website/payments/api/viewsets/payments.py
@@ -1,16 +1,66 @@
+from django.apps import apps
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
 
-from payments.api.serializers import PaymentSerializer
-from payments.models import Payment
+from payments import services
+from payments.api.serializers import PaymentSerializer, PaymentCreateSerializer
+from payments.exceptions import PaymentError
+from payments.models import Payment, PaymentUser
 
 
-class PaymentViewset(ModelViewSet):
+class PaymentViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+    """The viewset to list retrieve and create payments."""
 
     queryset = Payment.objects.all()
-    serializer_class = PaymentSerializer
     permission_classes = [IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return PaymentCreateSerializer
+        return PaymentSerializer
 
     def get_queryset(self):
         user = self.request.user
         return Payment.objects.filter(paid_by=user)
+
+    def create(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        app_label = serializer.data["app_label"]
+        model_name = serializer.data["model_name"]
+        payable_pk = serializer.data["payable_pk"]
+
+        payable_model = apps.get_model(app_label=app_label, model_name=model_name)
+        payable = payable_model.objects.get(pk=payable_pk)
+
+        if (
+            payable.payment_payer.pk
+            != PaymentUser.objects.get(pk=self.request.user.pk).pk
+        ):
+            raise PermissionDenied(
+                detail="You are not allowed to process this payment."
+            )
+
+        if payable.payment:
+            return Response(
+                data={"detail": "This object has already been paid for."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        try:
+            services.create_payment(
+                payable, PaymentUser.objects.get(pk=request.user.pk), Payment.TPAY,
+            )
+            payable.save()
+        except PaymentError as e:
+            raise ValidationError(detail=str(e))
+
+        headers = {"Location": reverse(payable.payment)}
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )

--- a/website/payments/api/viewsets/payments.py
+++ b/website/payments/api/viewsets/payments.py
@@ -60,7 +60,9 @@ class PaymentViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         except PaymentError as e:
             raise ValidationError(detail=str(e))
 
-        headers = {"Location": reverse(payable.payment)}
+        headers = {
+            "Location": reverse("payment-detail", kwargs={"pk": payable.payment.pk})
+        }
         return Response(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
         )

--- a/website/payments/tests/api/test_viewsets_payments.py
+++ b/website/payments/tests/api/test_viewsets_payments.py
@@ -1,0 +1,116 @@
+from unittest import mock
+from unittest.mock import MagicMock, Mock
+
+from django.apps import apps
+from django.test import TestCase, override_settings, Client
+from django.urls import reverse
+from freezegun import freeze_time
+from rest_framework.test import APIClient
+
+from members.models import Member
+from payments.exceptions import PaymentError
+from payments.models import BankAccount, PaymentUser, Payment
+from payments.tests.__mocks__ import MockPayable
+
+
+@freeze_time("2020-09-01")
+@override_settings(SUSPEND_SIGNALS=True, THALIA_PAY_ENABLED_PAYMENT_METHOD=True)
+class PaymentProcessViewTest(TestCase):
+    """
+    Test for the PaymentProcessView
+    """
+
+    fixtures = ["members.json"]
+
+    test_body = {
+        "app_label": "mock_app",
+        "model_name": "mock_model",
+        "payable_pk": "mock_payable_pk",
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = Member.objects.filter(last_name="Wiggers").first()
+        cls.account1 = BankAccount.objects.create(
+            owner=cls.user,
+            initials="J1",
+            last_name="Test",
+            iban="NL91ABNA0417164300",
+            valid_from="2019-03-01",
+            signature="sig",
+            mandate_no="11-2",
+        )
+        cls.user = PaymentUser.objects.get(pk=cls.user.pk)
+
+    def setUp(self):
+        self.account1.refresh_from_db()
+        self.client = APIClient()
+        self.client.force_login(self.user)
+
+        self.payable = MockPayable(payer=self.user)
+
+        self.original_get_model = apps.get_model
+        mock_get_model = mock_get_model = MagicMock()
+
+        def side_effect(*args, **kwargs):
+            if "app_label" in kwargs and kwargs["app_label"] == "mock_app":
+                return mock_get_model
+            return self.original_get_model(*args, **kwargs)
+
+        apps.get_model = Mock(side_effect=side_effect)
+        mock_get_model.objects.get.return_value = self.payable
+
+    def tearDown(self):
+        apps.get_model = self.original_get_model
+
+    def test_not_logged_in(self):
+        """
+        If there is no logged-in user they should redirect
+        to the authentication page
+        """
+        self.client.logout()
+
+        response = self.client.post(reverse("payment-list"))
+        self.assertEqual(401, response.status_code)
+
+    @override_settings(THALIA_PAY_ENABLED_PAYMENT_METHOD=False)
+    def test_member_has_tpay_enabled(self):
+        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+        self.assertEqual(403, response.status_code)
+
+    def test_different_member(self):
+        self.payable.payer = PaymentUser()
+
+        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+
+        self.assertEqual(403, response.status_code)
+        self.assertEqual(
+            {"detail": "You are not allowed to process this payment."}, response.data
+        )
+
+    def test_already_paid(self):
+        self.payable.payment = Payment(amount=8)
+
+        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+
+        self.assertEqual(403, response.status_code)
+        self.assertEqual(
+            {"detail": "This object has already been paid for."}, response.data
+        )
+
+    @mock.patch("payments.services.create_payment")
+    def test_creates_payment(self, create_payment):
+        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+
+        create_payment.assert_called_with(self.payable, self.user, Payment.TPAY)
+
+        self.assertEqual(201, response.status_code)
+        self.assertEqual({"Location": reverse(self.payable.payment)}, response.headers)
+
+    @mock.patch("payments.services.create_payment")
+    def test_payment_create_error(self, create_payment):
+        create_payment.side_effect = PaymentError("Test error")
+
+        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+
+        self.assertEqual(400, response.status_code)

--- a/website/payments/tests/api/test_viewsets_payments.py
+++ b/website/payments/tests/api/test_viewsets_payments.py
@@ -75,13 +75,17 @@ class PaymentProcessViewTest(TestCase):
 
     @override_settings(THALIA_PAY_ENABLED_PAYMENT_METHOD=False)
     def test_member_has_tpay_enabled(self):
-        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+        response = self.client.post(
+            reverse("payment-list"), self.test_body, format="json"
+        )
         self.assertEqual(403, response.status_code)
 
     def test_different_member(self):
         self.payable.payer = PaymentUser()
 
-        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+        response = self.client.post(
+            reverse("payment-list"), self.test_body, format="json"
+        )
 
         self.assertEqual(403, response.status_code)
         self.assertEqual(
@@ -91,7 +95,9 @@ class PaymentProcessViewTest(TestCase):
     def test_already_paid(self):
         self.payable.payment = Payment(amount=8)
 
-        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+        response = self.client.post(
+            reverse("payment-list"), self.test_body, format="json"
+        )
 
         self.assertEqual(403, response.status_code)
         self.assertEqual(
@@ -100,7 +106,9 @@ class PaymentProcessViewTest(TestCase):
 
     @mock.patch("payments.services.create_payment")
     def test_creates_payment(self, create_payment):
-        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+        response = self.client.post(
+            reverse("payment-list"), self.test_body, format="json"
+        )
 
         create_payment.assert_called_with(self.payable, self.user, Payment.TPAY)
 
@@ -111,6 +119,8 @@ class PaymentProcessViewTest(TestCase):
     def test_payment_create_error(self, create_payment):
         create_payment.side_effect = PaymentError("Test error")
 
-        response = self.client.post(reverse("payment-list"), self.test_body, format='json')
+        response = self.client.post(
+            reverse("payment-list"), self.test_body, format="json"
+        )
 
         self.assertEqual(400, response.status_code)

--- a/website/thaliawebsite/api/v1/urls.py
+++ b/website/thaliawebsite/api/v1/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path("", include("pizzas.api.urls")),
     path("", include("photos.api.urls")),
     path("", include("pushnotifications.api.urls")),
+    path("", include("payments.api.urls")),
 ]


### PR DESCRIPTION
Closes #1241 

### Summary
Add a payment api endpoint that supports adding new Thalia Pay payments and listing current ones. This will make the api feature complete with the frontend of the website.

### How to test
Steps to test the changes you made:
1. Go to /api/v1/payments
2. Create a new Thalia pay payment
3. I don't know, haven't gotten that far yet
