### PR TITLE
Set better defaults for database variables

### DIFF
--- a/website/thaliawebsite/settings/production.py
+++ b/website/thaliawebsite/settings/production.py
@@ -35,9 +35,9 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "USER": os.environ.get("POSTGRES_USER", "postgres"),
-        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", ""),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", None),
         "NAME": os.environ.get("POSTGRES_DB"),
-        "HOST": os.environ.get("DJANGO_POSTGRES_HOST"),
+        "HOST": os.environ.get("DJANGO_POSTGRES_HOST", ""),
         "PORT": 5432,
     }
 }


### PR DESCRIPTION
## Summary

Set better defaults for database variables. Now when the environment variables are not specified, the database will try local authentication (this means that the postgres socket on the localhost is used, and authentication is based on the username)