### PR TITLE
Change the review host template to version 7

### DIFF
--- a/resources/continuous-integration/review/review-host-create.sh
+++ b/resources/continuous-integration/review/review-host-create.sh
@@ -21,7 +21,7 @@ fi
 new_instance_id=$(
     aws ec2 run-instances \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=concrexit-review-${COMMIT_SHA}}]" \
-    --launch-template "LaunchTemplateId=lt-03762fc23450c2471,Version=5" \
+    --launch-template "LaunchTemplateId=lt-03762fc23450c2471,Version=7" \
     --user-data file://resources/continuous-integration/review/ec2-bootstrap.sh | 
         jq --raw-output ".Instances[0].InstanceId"
     )


### PR DESCRIPTION
### Summary
Change the review host template to version 7. This template in AWS contains tags to identify review environments.

### How to test
Steps to test the changes you made:
1. Run the script