### PR TITLE
Refactor logging and make logfile optional

### DIFF
--- a/website/manage.py
+++ b/website/manage.py
@@ -8,6 +8,7 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "thaliawebsite.settings")
+    os.environ.setdefault("ENABLE_LOGFILE", "0")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
### Summary
Refactor logging and make logfile optional. This is the last thing needed to make [concrexit-nix](/pingiun/concrexit-nix) run without patches

### How to test
Everything should still work as before, only logging to console is now enabled in production