### PR TITLE
Starting date of honorary membership is now displayed on a users publ…

### DIFF
--- a/website/members/templates/members/user/profile.html
+++ b/website/members/templates/members/user/profile.html
@@ -40,7 +40,7 @@
                     <h4>{% trans "Personal information" %}</h4>
                     <ul class="list-unstyled">
                         <li>
-                            <strong>{% trans "Membership type" %}: </strong> {{ membership_type }}<br>
+                            <strong>{% trans "Membership type" %}: </strong> {{ membership_type }} (since {{ member.latest_membership.since }})<br>
                         </li>
 
                         {% if member.profile.starting_year %}


### PR DESCRIPTION
…ic profile page.

Closes #1155 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The public profile page of an honorary member now also shows the date at which the honorary membership started.

### How to test
Steps to test the changes you made:
1. Go to memberlist, honorary members, any honorary member
2. It should say "Membership type: Honorary Member (since  Month dd, yyyy)"
