### PR TITLE
Add percentage sign to parentheses to fix command substitution typo

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
           path: html
 
       - name: Create URL safe version of GITHUB_REF
-        run: echo "GITHUB_REF_SLUG=(echo \"${GITHUB_REF#refs/heads/}\"| iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_REF_SLUG=$(echo \"${GITHUB_REF#refs/heads/}\"| iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)" >> "${GITHUB_ENV}"
 
       - name: Sync files to S3
         run: aws s3 sync --only-show-errors html "s3://thalia-coverage/${GITHUB_REF_SLUG}/"


### PR DESCRIPTION
### Summary
The `GITHUB_REF_SLUG` command substitution in the `Create URL safe version of GITHUB_REF` task of the `upload-coverage` job in the GitHub Actions workflow is missing a `$`.

I must admit I have no idea why it currently works. For example in #1372 the [coverage report](https://thalia-coverage.s3.amazonaws.com/renovate-sentry-sdk-0-x/index.html) is available at the correct address. However, the [workflow log](https://github.com/svthalia/concrexit/runs/1344877743?check_suite_focus=true) says `GITHUB_REF_SLUG` is set to `(echo "renovate/sentry-sdk-0.x"| iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)` (which you would expect, because of the missing `$` in the command). 