### PR TITLE
Refactor batch processing

### DIFF
--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -85,17 +85,7 @@ class BatchProcessAdminView(View):
                 request, _("{} already processed.").format(model_ngettext(batch, 1))
             )
         else:
-            batch.processed = True
-            payments = batch.payments_set.select_related("paid_by")
-            for payment in payments:
-                bank_account = payment.paid_by.bank_accounts.last()
-                bank_account.last_used = timezone.now()
-                bank_account.save()
-
-            batch.save()
-
-            services.send_tpay_batch_processing_emails(batch)
-
+            services.process_batch(batch)
             messages.success(
                 request,
                 _("Successfully processed {}.").format(model_ngettext(batch, 1)),

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -115,7 +115,7 @@ def process_batch(batch):
     payments = batch.payments_set.select_related("paid_by")
     for payment in payments:
         bank_account = payment.paid_by.bank_accounts.last()
-        bank_account.last_used = batch.processing_date
+        bank_account.last_used = batch.withdrawal_date
         bank_account.save()
 
     batch.save()


### PR DESCRIPTION
Closes #1364 

### Summary
If batch is processed, the withdrawal date is used to update the bankaccount 'last used' instead of the current date. Also contains a little refactor to turn batch processing into a service

### How to test
1. Process a payment batch
2. Check that emails are still being sent, the batch becomes 'processed' and the bank account 'last_used' date is the withdrawal date of the batch