### PR TITLE
Fix mistakes in the OpenAPI spec

### DIFF
--- a/website/thaliawebsite/api/openapi.py
+++ b/website/thaliawebsite/api/openapi.py
@@ -1,6 +1,7 @@
 from oauth2_provider.scopes import get_scopes_backend
 from rest_framework.reverse import reverse
 from rest_framework.schemas.openapi import SchemaGenerator, AutoSchema
+from rest_framework.schemas.utils import is_list_view
 
 
 class OAuthSchemaGenerator(SchemaGenerator):
@@ -26,5 +27,22 @@ class OAuthAutoSchema(AutoSchema):
     def get_operation(self, path, method):
         operation = super().get_operation(path, method)
         if self.view and hasattr(self.view, "required_scopes"):
-            operation["security"] = {"oauth2": self.view.required_scopes}
+            operation["security"] = [{"oauth2": self.view.required_scopes}]
+        else:
+            operation["security"] = [{"oauth2": ["read", "write"]}]
         return operation
+
+    def get_operation_id(self, path, method):
+        method_name = getattr(self.view, "action", method.lower())
+        if is_list_view(path, method, self.view):
+            action = "list"
+        elif method_name not in self.method_mapping:
+            action = self._to_camel_case(
+                f"{self.method_mapping[method.lower()]}_{method_name}"
+            )
+        else:
+            action = self.method_mapping[method.lower()]
+
+        name = self.get_operation_id_base(path, method, action)
+
+        return action + name


### PR DESCRIPTION
### Summary

After #1382 there are still a couple of bugs that I found:
1. The security items were incorrect, they apparently had to be arrays instead of objects but Swagger did not complain
2. The schema defined for the registrations endpoint was incorrect

### How to test
Steps to test the changes you made:
1. Go to 'api/docs'
2. Check that when you authenticate using oauth2 the lock icons change
3. Check that the schema of '/api/v1/events/<pk>/registrations' is not CalendarJS
4. Validate the output spec on https://editor.swagger.io/
