### PR TITLE
Do not show Thalia Pay buttons if master setting disabled

### DIFF
--- a/website/payments/models.py
+++ b/website/payments/models.py
@@ -48,7 +48,10 @@ class PaymentUser(Member):
     @property
     def tpay_allowed(self):
         """Does this user have permissions to use Thalia Pay (but not necessarily enabled)"""
-        return self.has_perm("payments.tpay_allowed")
+        return (
+            self.has_perm("payments.tpay_allowed")
+            and settings.THALIA_PAY_ENABLED_PAYMENT_METHOD
+        )
 
     def allow_tpay(self):
         """Give this user Thalia Pay permission"""

--- a/website/payments/tests/test_signals.py
+++ b/website/payments/tests/test_signals.py
@@ -7,7 +7,9 @@ from payments.models import PaymentUser
 
 
 class SignalsTest(TestCase):
-    @override_settings(THALIA_PAY_FOR_NEW_MEMBERS=True)
+    @override_settings(
+        THALIA_PAY_FOR_NEW_MEMBERS=True, THALIA_PAY_ENABLED_PAYMENT_METHOD=True
+    )
     def test_give_new_users_tpay_permissions(self):
         member = Member.objects.create(username="test", first_name="", last_name="")
         Profile.objects.create(


### PR DESCRIPTION
### Summary
Do not show Thalia Pay buttons if master setting disabled

### How to test
1. Disable the TPAY_ENABLED_PAYMENT_METHOD setting
2. No Tpay buttons should be visible in the user interface