### PR TITLE
Change batch export to use initials and last name

### DIFF
--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -139,7 +139,7 @@ class BatchExportAdminView(View):
             bankaccount = member.bank_accounts.last()
             writer.writerow(
                 [
-                    member.get_full_name(),
+                    bankaccount.name,
                     bankaccount.iban,
                     bankaccount.mandate_no,
                     f"{row['total']:.2f}",

--- a/website/payments/tests/test_admin_views.py
+++ b/website/payments/tests/test_admin_views.py
@@ -294,6 +294,8 @@ class BatchExportAdminViewTest(TestCase):
             iban="DE75512108001245126199",
             mandate_no="2",
             valid_from=timezone.now(),
+            initials="T.E.S.T.",
+            last_name="ersssss",
         )
         BankAccount.objects.create(
             last_used=timezone.now(),
@@ -301,6 +303,8 @@ class BatchExportAdminViewTest(TestCase):
             iban="NL02ABNA0123456789",
             mandate_no="1",
             valid_from=timezone.now(),
+            initials="T.E.S.T.",
+            last_name="ersssss2",
         )
 
         Payment.objects.bulk_create(
@@ -325,8 +329,8 @@ class BatchExportAdminViewTest(TestCase):
         self.assertEqual(
             response.content,
             b"Account holder,IBAN,Mandate Reference,Amount,Description,Mandate Date\r\n"
-            b"Test1 Example,DE75512108001245126199,2,3.00,Thalia Pay payments for 2020-1,2020-01-01\r\n"
-            b"Test2 Example,NL02ABNA0123456789,1,6.00,Thalia Pay payments for 2020-1,2020-01-01\r\n",
+            b"T.E.S.T. ersssss,DE75512108001245126199,2,3.00,Thalia Pay payments for 2020-1,2020-01-01\r\n"
+            b"T.E.S.T. ersssss2,NL02ABNA0123456789,1,6.00,Thalia Pay payments for 2020-1,2020-01-01\r\n",
         )
 
 


### PR DESCRIPTION
### Summary
When a batch is exported the added initials and lastname should be used not the full name of the user.

### How to test
Steps to test the changes you made:
1. Export a batch
2. The accont names are correct
