### PR TITLE
Added API endpoints for slides

### DIFF
--- a/docs/announcements.api.rst
+++ b/docs/announcements.api.rst
@@ -1,0 +1,34 @@
+announcements.api package
+=========================
+
+.. automodule:: announcements.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+announcements.api.serializers module
+------------------------------------
+
+.. automodule:: announcements.api.serializers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+announcements.api.urls module
+-----------------------------
+
+.. automodule:: announcements.api.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+announcements.api.viewsets module
+---------------------------------
+
+.. automodule:: announcements.api.viewsets
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/announcements.rst
+++ b/docs/announcements.rst
@@ -6,6 +6,14 @@ announcements package
    :undoc-members:
    :show-inheritance:
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   announcements.api
+
 Submodules
 ----------
 

--- a/website/announcements/api/serializers.py
+++ b/website/announcements/api/serializers.py
@@ -1,0 +1,20 @@
+"""DRF serializers defined by the announcements package."""
+from rest_framework import serializers
+
+from announcements.models import Slide
+
+
+class SlideSerializer(serializers.ModelSerializer):
+    """MemberGroup serializer."""
+
+    class Meta:
+        """Meta class for the serializer."""
+
+        model = Slide
+        fields = (
+            "pk",
+            "title",
+            "content",
+            "order",
+            "url",
+        )

--- a/website/announcements/api/serializers.py
+++ b/website/announcements/api/serializers.py
@@ -2,6 +2,8 @@
 from rest_framework import serializers
 
 from announcements.models import Slide
+from thaliawebsite.settings import settings
+from utils.media.services import get_thumbnail_url
 
 
 class SlideSerializer(serializers.ModelSerializer):
@@ -17,4 +19,11 @@ class SlideSerializer(serializers.ModelSerializer):
             "content",
             "order",
             "url",
+        )
+
+    content = serializers.SerializerMethodField("_file")
+
+    def _file(self, obj):
+        return self.context["request"].build_absolute_uri(
+            get_thumbnail_url(obj.content, settings.THUMBNAIL_SIZES["slide"])
         )

--- a/website/announcements/api/serializers.py
+++ b/website/announcements/api/serializers.py
@@ -5,7 +5,7 @@ from announcements.models import Slide
 
 
 class SlideSerializer(serializers.ModelSerializer):
-    """MemberGroup serializer."""
+    """Slide serializer."""
 
     class Meta:
         """Meta class for the serializer."""

--- a/website/announcements/api/urls.py
+++ b/website/announcements/api/urls.py
@@ -4,5 +4,5 @@ from rest_framework import routers
 from announcements.api import viewsets
 
 router = routers.SimpleRouter()
-router.register(r"announcements/slide", viewsets.SlideViewset)
+router.register(r"announcements/slides", viewsets.SlideViewset)
 urlpatterns = router.urls

--- a/website/announcements/api/urls.py
+++ b/website/announcements/api/urls.py
@@ -1,0 +1,8 @@
+"""DRF routes defined by the announcements package."""
+from rest_framework import routers
+
+from announcements.api import viewsets
+
+router = routers.SimpleRouter()
+router.register(r"announcements/slide", viewsets.SlideViewset)
+urlpatterns = router.urls

--- a/website/announcements/api/viewsets.py
+++ b/website/announcements/api/viewsets.py
@@ -17,10 +17,6 @@ class SlideViewset(viewsets.ReadOnlyModelViewSet):
         if not self.request.member:
             queryset = queryset.filter(members_only=False)
 
-        ids = (
-            slide.pk
-            for slide in queryset
-            if slide.event_set.exists() or slide.is_visible
-        )
+        ids = (slide.pk for slide in queryset if slide.is_visible)
 
         return Slide.objects.filter(pk__in=ids)

--- a/website/announcements/api/viewsets.py
+++ b/website/announcements/api/viewsets.py
@@ -1,0 +1,22 @@
+from rest_framework import viewsets
+
+from announcements.api.serializers import SlideSerializer
+from announcements.models import Slide
+
+
+class SlideViewset(viewsets.ReadOnlyModelViewSet):
+    queryset = Slide.objects.all()
+    serializer_class = SlideSerializer
+
+    def get_queryset(self):
+        queryset = Slide.objects.all()
+        if not self.request.member:
+            queryset = queryset.filter(members_only=False)
+
+        ids = (
+            slide.pk
+            for slide in queryset
+            if slide.event_set.exists() or slide.is_visible
+        )
+
+        return Slide.objects.filter(pk__in=ids)

--- a/website/announcements/api/viewsets.py
+++ b/website/announcements/api/viewsets.py
@@ -5,6 +5,10 @@ from announcements.models import Slide
 
 
 class SlideViewset(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for slides
+    """
+
     queryset = Slide.objects.all()
     serializer_class = SlideSerializer
 

--- a/website/events/api/serializers/events/list.py
+++ b/website/events/api/serializers/events/list.py
@@ -3,6 +3,7 @@ from html import unescape
 from django.utils.html import strip_tags
 from rest_framework import serializers
 
+from announcements.api.serializers import SlideSerializer
 from events import services
 from events.models import Event
 from pizzas.models import PizzaEvent
@@ -25,12 +26,14 @@ class EventListSerializer(serializers.ModelSerializer):
             "present",
             "pizza",
             "registration_allowed",
+            "slide",
         )
 
     description = serializers.SerializerMethodField("_description")
     registered = serializers.SerializerMethodField("_registered")
     pizza = serializers.SerializerMethodField("_pizza")
     present = serializers.SerializerMethodField("_present")
+    slide = SlideSerializer()
 
     def _description(self, instance):
         return unescape(strip_tags(instance.description))

--- a/website/events/api/serializers/events/retrieve.py
+++ b/website/events/api/serializers/events/retrieve.py
@@ -1,6 +1,7 @@
 from django.utils.html import strip_spaces_between_tags
 from rest_framework import serializers
 
+from announcements.api.serializers import SlideSerializer
 from events import services
 from events.api.serializers.event_registrations.list import (
     EventRegistrationAdminListSerializer,
@@ -41,6 +42,7 @@ class EventRetrieveSerializer(serializers.ModelSerializer):
             "is_pizza_event",
             "google_maps_url",
             "is_admin",
+            "slide",
         )
 
     description = serializers.SerializerMethodField("_description")
@@ -51,6 +53,7 @@ class EventRetrieveSerializer(serializers.ModelSerializer):
     is_pizza_event = serializers.SerializerMethodField("_is_pizza_event")
     google_maps_url = serializers.SerializerMethodField("_google_maps_url")
     is_admin = serializers.SerializerMethodField("_is_admin")
+    slide = SlideSerializer()
 
     def _description(self, instance):
         return strip_spaces_between_tags(bleach(instance.description))

--- a/website/thaliawebsite/api/v1/urls.py
+++ b/website/thaliawebsite/api/v1/urls.py
@@ -6,6 +6,7 @@ from members.views import ObtainThaliaAuthToken
 urlpatterns = [
     path("token-auth/", ObtainThaliaAuthToken.as_view()),
     path("", include("activemembers.api.urls")),
+    path("", include("announcements.api.urls")),
     path("", include("events.api.urls")),
     path("", include("members.api.urls")),
     path("", include("partners.api.urls")),


### PR DESCRIPTION
Closes #1318 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The API now has support for slide, both event slides and global slides

### How to test
Steps to test the changes you made:
1. Add a slide (don't fill in the dates such that it isn't a global slide)
2. Add the slide to an event
3. Go to `/api/v1/events/{id}` and see that the slide is returned
4. Go to `/api/v1/announcements/slides`
5. See that the slide isn't there
6. Add a new slide and now fill in the `Display since`
7. Go to `/api/v1/announcements/slides` and see that the slide is there
