### PR TITLE
Event guest registration

### DIFF
--- a/website/events/migrations/0001_initial.py
+++ b/website/events/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 
-class Migration(migrations.Migration):
+class Migration(migrations.Migration): 
 
     initial = True
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -1,4 +1,4 @@
-    from collections import OrderedDict
+from collections import OrderedDict
 
 from django.utils import timezone
 from django.utils.datetime_safe import date
@@ -192,7 +192,8 @@ def update_registration(
 
     if (
         (not event_permissions(member, event, name)["update_registration"]
-        or not field_values) and is_organiser(member, event)
+        or not field_values)
+        and is_organiser(member, event)
     ):
         return
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+    from collections import OrderedDict
 
 from django.utils import timezone
 from django.utils.datetime_safe import date
@@ -194,6 +194,7 @@ def update_registration(
         (not event_permissions(member, event, name)["update_registration"]
         or not field_values) and is_organiser(member, event)
     ):
+        print("Kur")
         return
 
     for field_id, field_value in field_values:

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -193,6 +193,7 @@ def update_registration(
     if (
         (not event_permissions(member, event, name)["update_registration"]
         or not field_values) and is_organiser(member, event)
+        print("kures")
     ):
         return
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -194,7 +194,6 @@ def update_registration(
         (not event_permissions(member, event, name)["update_registration"]
         or not field_values) and is_organiser(member, event)
     ):
-        print("Kur")
         return
 
     for field_id, field_value in field_values:

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -191,8 +191,8 @@ def update_registration(
         name = registration.name
 
     if (
-        not event_permissions(member, event, name)["update_registration"]
-        or not field_values
+        (not event_permissions(member, event, name)["update_registration"]
+        or not field_values) and is_organiser(member, event)
     ):
         return
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -193,7 +193,6 @@ def update_registration(
     if (
         (not event_permissions(member, event, name)["update_registration"]
         or not field_values) and is_organiser(member, event)
-        print("kures")
     ):
         return
 


### PR DESCRIPTION
Closes #1345

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Organizers of events should be able to edit the members' fields at their events even for non-members. Now they can.

### How to test
Steps to test the changes you made:
1. Add a manual event registration.
2. Edit the information fields of the participants.
3. It works.
