### PR TITLE
Prevent registrations table from not showing true checkbox value

### DIFF
--- a/website/events/templates/events/admin/registrations_table.html
+++ b/website/events/templates/events/admin/registrations_table.html
@@ -62,7 +62,7 @@
                 <td data-sortval="{{ registration.date_cancelled|date:'c' }}">{{ registration.date_cancelled }}</td>
                 {% endif %}
                 {% for field in registration.information_fields %}
-                    {% if not field.value %}
+                    {% if not field.value and not field.field.type == 'boolean' %}
                     <td></td>
                     {% elif field.field.type == 'checkbox' %}
                     <td>{{ field.value|yesno }}</td>

--- a/website/events/templates/events/admin/registrations_table.html
+++ b/website/events/templates/events/admin/registrations_table.html
@@ -64,7 +64,7 @@
                 {% for field in registration.information_fields %}
                     {% if not field.value and not field.field.type == 'boolean' %}
                     <td></td>
-                    {% elif field.field.type == 'checkbox' %}
+                    {% elif field.field.type == 'boolean' %}
                     <td>{{ field.value|yesno }}</td>
                     {% else %}
                     <td>{{ field.value }}</td>


### PR DESCRIPTION
Closes #1400 

### Summary
Prevents the _Registrations_ tab in admin for a specific event from hiding the true value of a checkbox.

**Note:** even though it is checked if a field of the type _checkbox_ is being shown in the _registrations_table.html_ file, the actual type of the checkbox is actually a _boolean_. Check if this should actually be the case or whether it has to be refactored.

### How to test

1. Register yourself (or another member) for an event that includes an optional checkbox.
2. Register directly (without checking the checkbox) **or** click out of the tab entirely without completing the registration.
3. Head over to the admin panel and click on 'Events' -> the event you registered for.
4. Check if the value of the checkbox you filled in is _None_ (when you closed the tab) or _False_ (if you completed your registration but did not check the checkbox).