### PR TITLE
Better names for Make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ website/db.sqlite3: .make/deps $(MIGRATIONS)
 migrate: ## Run all database migrations
 	poetry run website/manage.py migrate
 
-makemigrations: ## Automatically create migration scripts
+migrations: ## Automatically create migration scripts
 	poetry run website/manage.py makemigrations
 
-createsuperuser: .make/deps website/db.sqlite3 ## Create a superuser for your local concrexit
+superuser: .make/deps website/db.sqlite3 ## Create a superuser for your local concrexit
 	poetry run website/manage.py createsuperuser
 
-createfixtures: .make/deps website/db.sqlite3 ## Create dummy database entries
+fixtures: .make/deps website/db.sqlite3 ## Create dummy database entries
 	poetry run website/manage.py createfixtures -a
 
 .make/fmt: .make .make/deps $(PYTHONFILES)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ If you use Docker, please look at [this part](#docker) of the README.
 
 0. Get at least Python 3.7 and install poetry and the Pillow requirements as per below.
 1. Clone this repository
-2. Make sure `poetry` uses your Python 3.x installation: `poetry env use python3`
-3. `make createsuperuser` to create the first user (note that this user won't be a member!)
-4. `make createfixtures` to generate a bunch of test data
-5. `make run` to run a testing server
-6. Go to the user you created and complete the profile and add a membership for full access
+2. `make superuser` to create the first user (note that this user won't be a member!)
+3. `make fixtures` to generate a bunch of test data
+4. `make run` to run a testing server
+5. Go to the user you created and complete the profile and add a membership for full access
 
 Testing and linting
 -------------------


### PR DESCRIPTION
### Summary
Better names for Make commands that are not 'make create' or 'make make' which makes (pun intended) no sense.

I also removed a line from the README that is no longer true because Poetry searches for the right python install!

### How to test
Steps to test the changes you made:
1. Everything should still work as before, but you could try `make superuser`
