### PR TITLE
Fix bug when deleting users crashed

### DIFF
--- a/website/payments/tests/test_models.py
+++ b/website/payments/tests/test_models.py
@@ -83,6 +83,12 @@ class PaymentTest(TestCase):
         with self.assertRaises(ValidationError):
             self.payment.save()
 
+    def test_deleting_member_who_made_a_payment_doesnt_crach(self) -> None:
+        """
+        Check that https://github.com/svthalia/concrexit/issues/1328 is fixed
+        """
+        self.member.delete()
+
     def test_clean(self):
         """
         Tests the model clean functionality


### PR DESCRIPTION


Closes #1328

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
When looking up foreign keys in the __init__ method things go wrong with
some kind of infinite recursion. This removes the database lookup within
__init__ and moves it to the clean() method where it's actually used.

### How to test
Steps to test the changes you made:
1. Go to user which has done Payments
2. Delete user
3. Website doesn't crash
