### PR TITLE
Move event changes validation to the admin form

### DIFF
--- a/website/events/admin.py
+++ b/website/events/admin.py
@@ -143,6 +143,11 @@ class EventAdmin(DoNextTranslatedModelAdmin):
         (_("Extra"), {"fields": ("slide", "documents"), "classes": ("collapse",)}),
     )
 
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form = super().get_form(request, obj, change, **kwargs)
+        form.clean = lambda form: form.instance.clean_changes(form.changed_data)
+        return form
+
     def overview_link(self, obj):
         return format_html(
             '<a href="{link}">{title}</a>',

--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -178,11 +178,6 @@ class Event(models.Model, metaclass=ModelTranslateMeta):
         null=True,
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._price = self.price
-        self._registration_start = self.registration_start
-
     @property
     def after_cancel_deadline(self):
         return self.cancel_deadline and self.cancel_deadline <= timezone.now()
@@ -259,6 +254,34 @@ class Event(models.Model, metaclass=ModelTranslateMeta):
             return True
         except ObjectDoesNotExist:
             return False
+
+    def clean_changes(self, changed_data):
+        """Check if changes from `changed_data` are allowed.
+
+        This method should be run from a form clean() method, where changed_data
+        can be retrieved from self.changed_data
+        """
+        errors = {}
+        if self.published:
+            if "price" in changed_data:
+                errors.update(
+                    {
+                        "price": _(
+                            "You cannot change this field after the registration has started."
+                        )
+                    }
+                )
+            if "registration_start" in changed_data:
+                errors.update(
+                    {
+                        "registration_start": _(
+                            "You cannot change this field after the registration has started."
+                        )
+                    }
+                )
+
+        if errors:
+            raise ValidationError(errors)
 
     def clean(self):
         # pylint: disable=too-many-branches
@@ -353,34 +376,6 @@ class Event(models.Model, metaclass=ModelTranslateMeta):
                 )
         except ObjectDoesNotExist:
             pass
-
-        if self.published:
-            if (
-                self.price != self._price
-                and self._registration_start
-                and self._registration_start <= timezone.now()
-            ):
-                errors.update(
-                    {
-                        "price": _(
-                            "You cannot change this field after "
-                            "the registration has started."
-                        )
-                    }
-                )
-            if (
-                self._registration_start
-                and self.registration_start != self._registration_start
-                and self._registration_start <= timezone.now()
-            ):
-                errors.update(
-                    {
-                        "registration_start": _(
-                            "You cannot change this field after "
-                            "the registration has started."
-                        )
-                    }
-                )
 
         if errors:
             raise ValidationError(errors)

--- a/website/pushnotifications/tests.py
+++ b/website/pushnotifications/tests.py
@@ -1,0 +1,41 @@
+import datetime
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from activemembers.models import Committee
+from events.models import Event, Member
+from mailinglists.models import MailingList
+
+
+@override_settings(SUSPEND_SIGNALS=True)
+class PushNotificationsTest(TestCase):
+    """Tests push notifications"""
+
+    fixtures = ["members.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.mailinglist = MailingList.objects.create(name="testmail")
+
+        cls.committee = Committee.objects.create(
+            name="committee", contact_mailinglist=cls.mailinglist,
+        )
+
+        cls.event = Event.objects.create(
+            title_en="testevent",
+            organiser=cls.committee,
+            description_en="desc",
+            start=(timezone.now() + datetime.timedelta(hours=2)),
+            end=(timezone.now() + datetime.timedelta(hours=3)),
+            location_en="test location",
+            map_location="test map location",
+            price=0.00,
+            fine=5.00,
+            published=True,
+        )
+        cls.member = Member.objects.first()
+
+    def test_deleting_notification_for_event_doesnt_crash(self) -> None:
+        self.assertIsNotNone(self.event.start_reminder)
+        self.event.start_reminder.delete()


### PR DESCRIPTION


Closes #1307

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Includes a test to make sure deleting push notifications associated with
this event will not crash python. This commit fixes #1307 by not saving
anything in the __init__ of the event model, as this seems to break
deleting things from foreign keys.

### How to test
Steps to test the changes you made:
1. Create event with a registration and start date more than 1 hour in the future
2. Check that a push notification is created for this event
3. Delete push notification
4. Python doesn't crash
