### PR TITLE
Remove the ability to download albums

### DIFF
--- a/website/photos/templates/photos/album.html
+++ b/website/photos/templates/photos/album.html
@@ -11,17 +11,6 @@
         <div class="container">
             <h1 class="text-center section-title">
                 {{ album.title }}
-                <a 
-                   {% if album.shareable %}
-                   href="{% url 'photos:shared-album-download' album.slug album.access_token %}"
-                   {% else %}
-                   href="{% url 'photos:album-download' album.slug %}"
-                   {% endif %}
-                   target="_blank"
-                   class="btn btn-primary btn-first"
-                >
-                    <i class="fas fa-download"></i>
-                </a>
             </h1>
 
             <h2 class="text-center mt-2">{{ album.date|date:"d-m-Y" }}</h2>

--- a/website/photos/tests/test_views.py
+++ b/website/photos/tests/test_views.py
@@ -344,28 +344,3 @@ class SharedDownloadTest(_DownloadBaseTestCase):
             )
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response["Content-Type"], "image/jpeg")
-
-
-@override_settings(SUSPEND_SIGNALS=True)
-class AlbumDownloadTest(_DownloadBaseTestCase):
-
-    fixtures = ["members.json"]
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.member = Member.objects.filter(last_name="Wiggers").first()
-
-    def test_download(self):
-        self.client.force_login(self.member)
-
-        response = self.client.get(
-            reverse("photos:album-download", args=(self.album.slug,))
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "application/zip")
-
-    def test_logged_out(self):
-        response = self.client.get(
-            reverse("photos:album-download", args=(self.album.slug,))
-        )
-        self.assertEqual(response.status_code, 302)

--- a/website/photos/urls.py
+++ b/website/photos/urls.py
@@ -20,11 +20,6 @@ urlpatterns = [
                                 include(
                                     [
                                         path(
-                                            "",
-                                            views.album_download,
-                                            name="album-download",
-                                        ),
-                                        path(
                                             "<filename>",
                                             views.download,
                                             name="download",
@@ -33,11 +28,6 @@ urlpatterns = [
                                             "<token>/",
                                             include(
                                                 [
-                                                    path(
-                                                        "",
-                                                        views.shared_album_download,
-                                                        name="shared-album-download",
-                                                    ),
                                                     path(
                                                         "<filename>",
                                                         views.shared_download,


### PR DESCRIPTION
Closes #1171

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Remove the ability to download albums

### How to test
Steps to test the changes you made:
1. Go to album page
2. There is no download button
