### PR TITLE
Fix sorting by payments in events admin

### DIFF
--- a/website/events/static/events/js/admin.js
+++ b/website/events/static/events/js/admin.js
@@ -24,6 +24,7 @@ django.jQuery(function () {
         if (payment_previous === $(this).val()) {
             return;
         }
+        $('table').trigger('update', false).trigger('sortReset');
 
         if ($(this).val() === none) {
             $(this).removeClass('paid');
@@ -38,9 +39,10 @@ django.jQuery(function () {
                 select.addClass('paid');
             }
             select.val(data.payment);
-            $('table').trigger('update');
+            $('table').trigger('update', false);
         }, function(xhr) {
             select.val(payment_previous);
+            $('table').trigger('update', false);
 
             if (payment_previous === none) {
                 select.removeClass('paid');
@@ -72,17 +74,17 @@ django.jQuery(function () {
             return false;
         },
         format: function(s, t, node) {
-            var val = $(node).find('select').val();
+            const val = node.firstElementChild.value;
             if (val === 'no_payment') {
-                return '';
+                return 'z';
             }
-            return $(node).find('select').val();
+            return val;
         },
-        type: 'text'
+        type: "text",
     });
 
     $.tablesorter.addParser({
-        id: "date",
+        id: "sortval",
         is: function(s) {
             return false;
         },

--- a/website/events/templates/events/admin/registrations_table.html
+++ b/website/events/templates/events/admin/registrations_table.html
@@ -9,9 +9,9 @@
                 <th scope="col" class="sorter-payment">{% trans 'payment'|capfirst %} <span class="toggle"></span></th>
                 {% endif %}
                 <th scope="col" class="sorter-checkbox">{% trans "present"|capfirst %} <span class="toggle"></span></th>
-                <th scope="col" class="sorter-date">{% trans "registration date"|capfirst %} <span class="toggle"></span></th>
+                <th scope="col" class="sorter-sortval">{% trans "registration date"|capfirst %} <span class="toggle"></span></th>
                 {% if cancellations %}
-                <th scope="col" class="sorter-date">{% trans "cancellation date"|capfirst %} <span class="toggle"></span></th>
+                <th scope="col" class="sorter-sortval">{% trans "cancellation date"|capfirst %} <span class="toggle"></span></th>
                 {% endif %}
                 {% for field in fields %}
                 <th scope="col">{{ field.name }} <span class="toggle"></span></th>


### PR DESCRIPTION
Closes #1419

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Rewrote the payment sorting parser and changed the sort behaviour when
changing payments. Now the table will not reorder when changing a
payment, as this happens after a network call and can cause an
unexpected moving of the edited row. Now instead the table will not be
resorted, and instead is reverted to an unordered state.

### How to test
Steps to test the changes you made:
1. Go to event with payments
2. Sort based on payments
3. Check if sorting changes the order