### PR TITLE
Set unknown data instead of None on minimisation

### DIFF
--- a/website/members/services.py
+++ b/website/members/services.py
@@ -1,5 +1,5 @@
 """Services defined in the members package"""
-from datetime import date
+from datetime import date, datetime
 from typing import Callable, List, Dict, Any
 
 from django.conf import settings
@@ -225,12 +225,12 @@ def execute_data_minimisation(dry_run=False, members=None) -> List[Member]:
             profile = member.profile
             profile.student_number = None
             profile.phone_number = None
-            profile.address_street = None
+            profile.address_street = "<removed> 1"
             profile.address_street2 = None
-            profile.address_postal_code = None
-            profile.address_city = None
-            profile.address_country = None
-            profile.birthday = None
+            profile.address_postal_code = "<removed>"
+            profile.address_city = "<removed>"
+            profile.address_country = "NL"
+            profile.birthday = datetime(1900, 1, 1)
             profile.emergency_contact_phone_number = None
             profile.emergency_contact = None
             member.bank_accounts.all().delete()


### PR DESCRIPTION

Closes #1188

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Fixes #1188 by setting removed data to <removed> instead of None so that
the admin page remains usable

### How to test
Steps to test the changes you made:
1. Run dataminimisation
2. Go to a minimised user in the admin
3. Change something
4. No need to set values to some value manually, as required values are set to "<removed>"
