### PR TITLE
Move email send function to utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The latest Thalia Website built on Django.
 Getting started
 ---------------
 
-0. Get at least Python 3.7 and install poetry and the Pillow requirements as per below.
+0. Get at least Python 3.8 and install poetry and the Pillow requirements as per below.
 1. Clone this repository
 2. `make superuser` to create the first user (note that this user won't be a member!)
 3. `make fixtures` to generate a bunch of test data

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -9,7 +9,7 @@ from django.utils import timezone, translation
 from django.utils.translation import gettext_lazy as _
 
 from members.models import Member
-from registrations.emails import _send_email
+from utils.snippets import _send_email
 from .exceptions import PaymentError
 from .models import Payment, BankAccount, Payable, PaymentUser
 

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -9,7 +9,7 @@ from django.utils import timezone, translation
 from django.utils.translation import gettext_lazy as _
 
 from members.models import Member
-from utils.snippets import _send_email
+from utils.snippets import send_email
 from .exceptions import PaymentError
 from .models import Payment, BankAccount, Payable, PaymentUser
 
@@ -133,7 +133,7 @@ def send_tpay_batch_processing_emails(batch):
         total_amount = member_row["total"]
 
         with translation.override(member.profile.language):
-            _send_email(
+            send_email(
                 member.email,
                 _("Thalia Pay withdrawal notice"),
                 "payments/email/tpay_withdrawal_notice_mail.txt",

--- a/website/registrations/emails.py
+++ b/website/registrations/emails.py
@@ -2,14 +2,13 @@
 from typing import Union
 
 from django.conf import settings
-from django.core import mail
-from django.template import loader
 from django.template.defaultfilters import floatformat
 from django.urls import reverse
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 
 from registrations.models import Registration, Renewal
+from utils.snippets import _send_email
 
 
 def send_registration_email_confirmation(registration: Registration) -> None:
@@ -180,19 +179,3 @@ def send_references_information_message(entry: Union[Registration, Renewal]) -> 
                 ),
             },
         )
-
-
-def _send_email(to: str, subject: str, body_template: str, context: dict) -> None:
-    """Easily send an email with the right subject and a body template.
-
-    :param to: where should the email go?
-    :param subject: what is the email about?
-    :param body_template: what is the content of the email?
-    :param context: add some context to the body
-    """
-    mail.EmailMessage(
-        "[THALIA] {}".format(subject),
-        loader.render_to_string(body_template, context),
-        settings.DEFAULT_FROM_EMAIL,
-        [to],
-    ).send()

--- a/website/registrations/emails.py
+++ b/website/registrations/emails.py
@@ -8,7 +8,7 @@ from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 
 from registrations.models import Registration, Renewal
-from utils.snippets import _send_email
+from utils.snippets import send_email
 
 
 def send_registration_email_confirmation(registration: Registration) -> None:
@@ -17,7 +17,7 @@ def send_registration_email_confirmation(registration: Registration) -> None:
     :param registration: the registration entry
     """
     with translation.override(registration.language):
-        _send_email(
+        send_email(
             registration.email,
             _("Confirm email address"),
             "registrations/email/registration_confirm_mail.txt",
@@ -37,7 +37,7 @@ def send_registration_accepted_message(registration: Registration) -> None:
     :param registration: the registration entry
     """
     with translation.override(registration.language):
-        _send_email(
+        send_email(
             registration.email,
             _("Registration accepted"),
             "registrations/email/registration_accepted.txt",
@@ -54,7 +54,7 @@ def send_registration_rejected_message(registration: Registration) -> None:
     :param registration: the registration entry
     """
     with translation.override(registration.language):
-        _send_email(
+        send_email(
             registration.email,
             _("Registration rejected"),
             "registrations/email/registration_rejected.txt",
@@ -67,7 +67,7 @@ def send_new_registration_board_message(registration: Registration) -> None:
 
     :param registration: the registration entry
     """
-    _send_email(
+    send_email(
         settings.BOARD_NOTIFICATION_ADDRESS,
         "New registration",
         "registrations/email/registration_board.txt",
@@ -89,7 +89,7 @@ def send_renewal_accepted_message(renewal: Renewal) -> None:
     :param renewal: the renewal entry
     """
     with translation.override(renewal.member.profile.language):
-        _send_email(
+        send_email(
             renewal.member.email,
             _("Renewal accepted"),
             "registrations/email/renewal_accepted.txt",
@@ -108,7 +108,7 @@ def send_renewal_rejected_message(renewal: Renewal) -> None:
     :param renewal: the renewal entry
     """
     with translation.override(renewal.member.profile.language):
-        _send_email(
+        send_email(
             renewal.member.email,
             _("Renewal rejected"),
             "registrations/email/renewal_rejected.txt",
@@ -122,7 +122,7 @@ def send_renewal_complete_message(renewal: Renewal) -> None:
     :param renewal: the renewal entry
     """
     with translation.override(renewal.member.profile.language):
-        _send_email(
+        send_email(
             renewal.member.email,
             _("Renewal successful"),
             "registrations/email/renewal_complete.txt",
@@ -135,7 +135,7 @@ def send_new_renewal_board_message(renewal: Renewal) -> None:
 
     :param renewal: the renewal entry
     """
-    _send_email(
+    send_email(
         settings.BOARD_NOTIFICATION_ADDRESS,
         "New renewal",
         "registrations/email/renewal_board.txt",
@@ -167,7 +167,7 @@ def send_references_information_message(entry: Union[Registration, Renewal]) -> 
         language = entry.member.profile.language
 
     with translation.override(language):
-        _send_email(
+        send_email(
             email,
             _("Information about references"),
             "registrations/email/references_information.txt",

--- a/website/registrations/tests/test_emails.py
+++ b/website/registrations/tests/test_emails.py
@@ -20,7 +20,7 @@ class EmailsTest(TestCase):
     def setUp(self):
         translation.activate("en")
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_registration_email_confirmation(self, send_email):
         reg = Registration(
             email="test@example.org",
@@ -45,7 +45,7 @@ class EmailsTest(TestCase):
                 },
             )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_registration_accepted_message(self, send_email):
         reg = Registration(
             email="test@example.org",
@@ -65,7 +65,7 @@ class EmailsTest(TestCase):
                 {"name": reg.get_full_name(), "fees": floatformat(reg.contribution, 2)},
             )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_registration_rejected_message(self, send_email):
         reg = Registration(
             email="test@example.org", first_name="John", last_name="Doe", pk=0,
@@ -81,7 +81,7 @@ class EmailsTest(TestCase):
                 {"name": reg.get_full_name()},
             )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_new_registration_board_message(self, send_email):
         registration = Registration(
             email="test@example.org", first_name="John", last_name="Doe", pk=0,
@@ -105,7 +105,7 @@ class EmailsTest(TestCase):
             },
         )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_renewal_accepted_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -131,7 +131,7 @@ class EmailsTest(TestCase):
                 },
             )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_renewal_rejected_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -152,7 +152,7 @@ class EmailsTest(TestCase):
                 {"name": renewal.member.get_full_name()},
             )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_renewal_complete_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -173,7 +173,7 @@ class EmailsTest(TestCase):
                 {"name": renewal.member.get_full_name()},
             )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_new_renewal_board_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -199,7 +199,7 @@ class EmailsTest(TestCase):
             },
         )
 
-    @mock.patch("utils.snippets.send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_references_information_message(self, send_email):
         with self.subTest("Registrations"):
             registration = Registration(

--- a/website/registrations/tests/test_emails.py
+++ b/website/registrations/tests/test_emails.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 
 from members.models import Member, Profile
 from registrations import emails
-from registrations.emails import send_email
+from utils.snippets import send_email
 from registrations.models import Registration, Renewal
 
 

--- a/website/registrations/tests/test_emails.py
+++ b/website/registrations/tests/test_emails.py
@@ -20,7 +20,7 @@ class EmailsTest(TestCase):
     def setUp(self):
         translation.activate("en")
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_registration_email_confirmation(self, send_email):
         reg = Registration(
             email="test@example.org",
@@ -45,7 +45,7 @@ class EmailsTest(TestCase):
                 },
             )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_registration_accepted_message(self, send_email):
         reg = Registration(
             email="test@example.org",
@@ -65,7 +65,7 @@ class EmailsTest(TestCase):
                 {"name": reg.get_full_name(), "fees": floatformat(reg.contribution, 2)},
             )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_registration_rejected_message(self, send_email):
         reg = Registration(
             email="test@example.org", first_name="John", last_name="Doe", pk=0,
@@ -81,7 +81,7 @@ class EmailsTest(TestCase):
                 {"name": reg.get_full_name()},
             )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_new_registration_board_message(self, send_email):
         registration = Registration(
             email="test@example.org", first_name="John", last_name="Doe", pk=0,
@@ -105,7 +105,7 @@ class EmailsTest(TestCase):
             },
         )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_renewal_accepted_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -131,7 +131,7 @@ class EmailsTest(TestCase):
                 },
             )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_renewal_rejected_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -152,7 +152,7 @@ class EmailsTest(TestCase):
                 {"name": renewal.member.get_full_name()},
             )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_renewal_complete_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -173,7 +173,7 @@ class EmailsTest(TestCase):
                 {"name": renewal.member.get_full_name()},
             )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_new_renewal_board_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -199,7 +199,7 @@ class EmailsTest(TestCase):
             },
         )
 
-    @mock.patch("registrations.emails.send_email")
+    @mock.patch("utils.snippets.send_email")
     def test_send_references_information_message(self, send_email):
         with self.subTest("Registrations"):
             registration = Registration(

--- a/website/registrations/tests/test_emails.py
+++ b/website/registrations/tests/test_emails.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 
 from members.models import Member, Profile
 from registrations import emails
-from registrations.emails import _send_email
+from registrations.emails import send_email
 from registrations.models import Registration, Renewal
 
 
@@ -20,7 +20,7 @@ class EmailsTest(TestCase):
     def setUp(self):
         translation.activate("en")
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_registration_email_confirmation(self, send_email):
         reg = Registration(
             email="test@example.org",
@@ -45,7 +45,7 @@ class EmailsTest(TestCase):
                 },
             )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_registration_accepted_message(self, send_email):
         reg = Registration(
             email="test@example.org",
@@ -65,7 +65,7 @@ class EmailsTest(TestCase):
                 {"name": reg.get_full_name(), "fees": floatformat(reg.contribution, 2)},
             )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_registration_rejected_message(self, send_email):
         reg = Registration(
             email="test@example.org", first_name="John", last_name="Doe", pk=0,
@@ -81,7 +81,7 @@ class EmailsTest(TestCase):
                 {"name": reg.get_full_name()},
             )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_new_registration_board_message(self, send_email):
         registration = Registration(
             email="test@example.org", first_name="John", last_name="Doe", pk=0,
@@ -105,7 +105,7 @@ class EmailsTest(TestCase):
             },
         )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_renewal_accepted_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -131,7 +131,7 @@ class EmailsTest(TestCase):
                 },
             )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_renewal_rejected_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -152,7 +152,7 @@ class EmailsTest(TestCase):
                 {"name": renewal.member.get_full_name()},
             )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_renewal_complete_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -173,7 +173,7 @@ class EmailsTest(TestCase):
                 {"name": renewal.member.get_full_name()},
             )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_new_renewal_board_message(self, send_email):
         member = Member(
             email="test@example.org",
@@ -199,7 +199,7 @@ class EmailsTest(TestCase):
             },
         )
 
-    @mock.patch("registrations.emails._send_email")
+    @mock.patch("registrations.emails.send_email")
     def test_send_references_information_message(self, send_email):
         with self.subTest("Registrations"):
             registration = Registration(
@@ -252,7 +252,7 @@ class EmailsTest(TestCase):
             )
 
     def test_send_email(self):
-        _send_email(
+        send_email(
             subject="Subject",
             to="test@example.org",
             body_template="registrations/email/renewal_board.txt",

--- a/website/utils/snippets.py
+++ b/website/utils/snippets.py
@@ -187,9 +187,7 @@ def overlaps(check, others, can_equal=True):
 
 
 def send_email(to: str, subject: str, body_template: str, context: dict) -> None:
-    """
-    Easily send an email with the right subject and a body template
-
+    """Easily send an email with the right subject and a body template.
     :param to: where should the email go?
     :param subject: what is the email about?
     :param body_template: what is the content of the email?

--- a/website/utils/snippets.py
+++ b/website/utils/snippets.py
@@ -6,6 +6,8 @@ from collections import namedtuple
 from _sha1 import sha1
 
 from django.conf import settings
+from django.core import mail
+from django.template import loader
 from django.template.defaultfilters import urlencode
 from django.templatetags.static import static
 from django.utils import timezone, dateparse
@@ -182,3 +184,20 @@ def overlaps(check, others, can_equal=True):
             return True
 
     return False
+
+
+def _send_email(to: str, subject: str, body_template: str, context: dict) -> None:
+    """
+    Easily send an email with the right subject and a body template
+
+    :param to: where should the email go?
+    :param subject: what is the email about?
+    :param body_template: what is the content of the email?
+    :param context: add some context to the body
+    """
+    mail.EmailMessage(
+        "[THALIA] {}".format(subject),
+        loader.render_to_string(body_template, context),
+        settings.DEFAULT_FROM_EMAIL,
+        [to],
+    ).send()

--- a/website/utils/snippets.py
+++ b/website/utils/snippets.py
@@ -186,7 +186,7 @@ def overlaps(check, others, can_equal=True):
     return False
 
 
-def _send_email(to: str, subject: str, body_template: str, context: dict) -> None:
+def send_email(to: str, subject: str, body_template: str, context: dict) -> None:
     """
     Easily send an email with the right subject and a body template
 

--- a/website/utils/snippets.py
+++ b/website/utils/snippets.py
@@ -188,6 +188,7 @@ def overlaps(check, others, can_equal=True):
 
 def send_email(to: str, subject: str, body_template: str, context: dict) -> None:
     """Easily send an email with the right subject and a body template.
+
     :param to: where should the email go?
     :param subject: what is the email about?
     :param body_template: what is the content of the email?


### PR DESCRIPTION
Closes #1305 Use utils.snippets.send_email everywhere

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add?
I have moved the send_emails function to utils since it is a better position.

### How to test
Steps to test the changes you made:
Try to send a mail when register a new account or send a mail for a payment
