### PR TITLE
Reintroduce settings LANGUAGE_CODE in base.html

### DIFF
--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -1,4 +1,5 @@
 {% load i18n static menu compress pick_header_image %}
+{% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
Closes #1461 with the simplest possible approach: reverting the change of removing LANGUAGE_CODE from base.html.

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I readded `{% get_current_language as LANGUAGE_CODE %}` to base.html

### How to test
Steps to test the changes you made:
1. Go to 'Events'.
2. Observe that the page loads correctly now.

