### PR TITLE
Fix bug when manually adding users crashed

### DIFF
--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -38,25 +38,7 @@ class ProfileForm(forms.ModelForm):
         ]
         model = Profile
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not kwargs["instance"].user.is_staff:
-            self.fields["email_gsuite_only"].widget = self.fields[
-                "email_gsuite_only"
-            ].hidden_widget()
-
-
 class UserCreationForm(BaseUserCreationForm):
-    """Custom Form that removes the password fields from user creation and sends a welcome message when a user is created."""
-
-    # Don't forget to edit the formset in admin.py!
-    # This is a stupid quirk of the user admin.
-    password1 = forms.CharField(label='Password', widget=forms.PasswordInput)
-    password2 = forms.CharField(label='Repeat Password', widget=forms.PasswordInput)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def clean(self):
         if "username" in self.cleaned_data:
             self.cleaned_data["username"] = self.cleaned_data["username"].lower()

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -35,6 +35,9 @@ class ProfileForm(forms.ModelForm):
         ]
         model = Profile
 
+def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
 
 class UserCreationForm(BaseUserCreationForm):
     def clean(self):

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -35,6 +35,7 @@ class ProfileForm(forms.ModelForm):
         ]
         model = Profile
 
+
 def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
 

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -35,6 +35,13 @@ class ProfileForm(forms.ModelForm):
         ]
         model = Profile
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not kwargs["instance"].user.is_staff:
+            self.fields["email_gsuite_only"].widget = self.fields[
+                "email_gsuite_only"
+            ].hidden_widget()
+
 
 class UserCreationForm(BaseUserCreationForm):
     """Custom Form that lowercases the username on creation."""

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -41,6 +41,10 @@ def __init__(self, *args, **kwargs):
 
 
 class UserCreationForm(BaseUserCreationForm):
+    """
+    Custom Form that lowercases the username on creation.
+    """
+
     def clean(self):
         if "username" in self.cleaned_data:
             self.cleaned_data["username"] = self.cleaned_data["username"].lower()

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -51,44 +51,19 @@ class UserCreationForm(BaseUserCreationForm):
 
     # Don't forget to edit the formset in admin.py!
     # This is a stupid quirk of the user admin.
-
-    # shadow the password fields to prevent validation errors,
-    #   since we generate the passwords dynamically.
-    password1 = None
-    password2 = None
+    password1 = forms.CharField(label='Password', widget=forms.PasswordInput)
+    password2 = forms.CharField(label='Repeat Password', widget=forms.PasswordInput)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        for field in ("email", "first_name", "last_name"):
-            self.fields[field].required = True
-
-    send_welcome_email = forms.BooleanField(
-        label=_("Send welcome email"),
-        help_text=_("This email will include the generated password"),
-        required=False,
-        initial=True,
-    )
 
     def clean(self):
         if "username" in self.cleaned_data:
             self.cleaned_data["username"] = self.cleaned_data["username"].lower()
         super().clean()
 
-    def save(self, commit=True):
-        password = get_user_model().objects.make_random_password(length=15)
-        # pass the password on as if it was filled in, so that save() works
-        self.cleaned_data["password1"] = password
-        user = super().save(commit=False)
-        user.set_password(password)
-        if commit:
-            user.save()
-        if self.cleaned_data["send_welcome_email"]:
-            language = settings.LANGUAGE_CODE
-            emails.send_welcome_message(user, password, language)
-        return user
-
     class Meta:
-        fields = ("username", "first_name", "last_name", "send_welcome_email")
+        fields = ("username", "first_name", "last_name")
 
 
 class UserChangeForm(BaseUserChangeForm):

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -38,6 +38,7 @@ class ProfileForm(forms.ModelForm):
         ]
         model = Profile
 
+
 class UserCreationForm(BaseUserCreationForm):
     def clean(self):
         if "username" in self.cleaned_data:

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -1,13 +1,10 @@
 """Forms defined by the members package."""
 from django import forms
-from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserChangeForm as BaseUserChangeForm
 from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm
 from django.core.validators import RegexValidator
 from django.utils.translation import gettext_lazy as _
 
-from members import emails
 from .models import Profile
 
 

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -36,10 +36,6 @@ class ProfileForm(forms.ModelForm):
         model = Profile
 
 
-def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
-
-
 class UserCreationForm(BaseUserCreationForm):
     """Custom Form that lowercases the username on creation."""
 

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -41,9 +41,7 @@ def __init__(self, *args, **kwargs):
 
 
 class UserCreationForm(BaseUserCreationForm):
-    """
-    Custom Form that lowercases the username on creation.
-    """
+    """Custom Form that lowercases the username on creation."""
 
     def clean(self):
         if "username" in self.cleaned_data:


### PR DESCRIPTION
Closes #1242

### Summary
When wanting to manually add a user in the /admin dashboard, the site would throw an error where it didn't recognise the password1 and password2 fields. This PR solves above issue.

### How to test
Steps to test the changes you made:
1. Log in as an administrative user
2. Go to the admin dashboard
2. Under 'Authentication and Authorization' click on 'Add' next to the 'Users' tab
3. Site shows the form to create a new user and does not crash
