### PR TITLE
Include 100% covered files in the html coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ coverage: .coverage ## Generate a coverage report after running the tests
 	poetry run coverage report
 
 covhtml: .coverage ## Generate an HTML coverage report
-	poetry run coverage html --directory=covhtml --title="Coverage Report"
+	poetry run coverage html --directory=covhtml --no-skip-covered --title="Coverage Report"
 
 .make/docsdeps: .make .make/deps
 	poetry install $(POETRY_FLAGS) --extras "docs"


### PR DESCRIPTION
### Summary
The html report will now contain files that are 100% covered, so it doesn't look like something is missing from the report