### PR TITLE
Add NixOS test

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -12,7 +12,7 @@ jobs:
       with:
         name: svthalia-concrexit
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix-build -j 4 release.nix
+    - run: nix-build -j 4 -A github-actions release.nix
     - run: nix-shell --run "echo OK"
     - name: Deploy if this is master or staging
       if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/staging'

--- a/docs/thaliawebsite.rst
+++ b/docs/thaliawebsite.rst
@@ -26,6 +26,14 @@ thaliawebsite.admin module
    :undoc-members:
    :show-inheritance:
 
+thaliawebsite.apps module
+-------------------------
+
+.. automodule:: thaliawebsite.apps
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 thaliawebsite.context\_processors module
 ----------------------------------------
 

--- a/nix/concrexit.nix
+++ b/nix/concrexit.nix
@@ -65,7 +65,7 @@ let
 
   # Wrapper script that sets the right options for uWSGI
   concrexit-uwsgi = writeScript "concrexit-uwsgi" ''
-    ${concrexit-env}/bin/python ${manage-py} migrate
+    MANAGE_PY=1 ${concrexit-env}/bin/python ${manage-py} migrate
 
     ${uwsgi-python}/bin/uwsgi $@ \
       --plugins python3 \

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,0 +1,48 @@
+{ ... }:
+{
+  name = "concrexit";
+
+  machine = { ... }: {
+    imports = [ ./configuration.nix ];
+
+    concrexit.ssl = false;
+  };
+
+  testScript = { nodes }: ''
+    def remove_prefix(text, prefix):
+        if text.startswith(prefix):
+            return text[len(prefix) :]
+        return text
+
+
+    machine.wait_for_unit("concrexit.service")
+    machine.wait_for_open_port(80)
+    machine.wait_for_open_port(${toString nodes.machine.config.concrexit.app-port})
+
+    machine.succeed("GSUITE_MEMBERS_AUTOSYNC=0 concrexit-manage createfixtures -a 2>&1")
+
+    import xml.etree.ElementTree as ET
+    import os.path
+
+    machine.succeed("curl --fail 'http://localhost/'")
+
+    sitemap_xml = machine.succeed("curl --fail 'http://localhost/sitemap.xml'")
+    root = ET.fromstring(sitemap_xml)
+    urls = []
+    for child in root:
+        url = child.find("{http://www.sitemaps.org/schemas/sitemap/0.9}loc")
+        urls.append(url.text)
+
+    # Only get one url per boring suffix (e.g. only one event etc.)
+    urls = sorted(sorted((url, len(url.split("/"))) for url in urls), key=lambda x: x[1])
+    last_url = urls[0]
+    for url in urls[1:]:
+        if last_url[1] == url[1] and re.fullmatch(
+            r"[\d\-]+",
+            remove_prefix(url[0], os.path.commonprefix([url[0], last_url[0]])).strip("/"),
+        ):
+            continue
+        machine.succeed(f"curl --fail '{url[0]}'")
+        last_url = url
+  '';
+}

--- a/release.nix
+++ b/release.nix
@@ -16,6 +16,7 @@ let
 
         nixpkgs.pkgs = pkgs;
 
+        networking.hostName = "staging";
         networking.hosts = pkgs.lib.mkForce { };
 
         services.mingetty.helpLine = ''
@@ -53,6 +54,7 @@ let
 
         nixpkgs.pkgs = pkgs;
 
+        networking.hostName = "staging";
         networking.domain = "thalia.nu";
         # This is needed because otherwise socket.getfqdn() breaks in Python
         # TODO: find a better solution for this?
@@ -66,6 +68,8 @@ let
       system = "x86_64-linux";
     }
   ).system;
+
+  test = pkgs.nixosTest ./nix/test.nix;
 in
 {
   # Instead of a regular attrset we use this aggregate function which might help
@@ -78,10 +82,11 @@ in
       pkgs.concrexit
       vm
       machine
+      test
     ];
   };
 
   # This is to make sure we can do -A machine to only build the machine in nix-build
   inherit (pkgs) concrexit;
-  inherit vm machine;
+  inherit vm machine test;
 }

--- a/release.nix
+++ b/release.nix
@@ -86,6 +86,17 @@ in
     ];
   };
 
+  github-actions = pkgs.releaseTools.aggregate {
+    name = "ci";
+
+    constituents = [
+      pre-commit-check
+      pkgs.concrexit
+      vm
+      machine
+    ];
+  };
+
   # This is to make sure we can do -A machine to only build the machine in nix-build
   inherit (pkgs) concrexit;
   inherit vm machine test;

--- a/website/thaliawebsite/apps.py
+++ b/website/thaliawebsite/apps.py
@@ -1,0 +1,29 @@
+import logging
+import os
+from subprocess import Popen
+
+from django.apps import AppConfig
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class ThaliaWebsiteConfig(AppConfig):
+    name = "thaliawebsite"
+
+    def ready(self):
+        if (
+            settings.DJANGO_ENV in ["production", "staging"]
+            and os.environ.get("MANAGE_PY", "0") == "0"
+        ):
+            logger.info("Telling systemd we're ready")
+            try:
+                Popen(
+                    [
+                        "/run/current-system/sw/bin/systemd-notify",
+                        "--ready",
+                        "--status=App registry populated",
+                    ]
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logger.exception(e)

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -381,7 +381,7 @@ INSTALLED_APPS = [
     # Our apps
     # Directly link to the app config when applicable as recommended
     # by the docs: https://docs.djangoproject.com/en/2.0/ref/applications/
-    "thaliawebsite",  # include for admin settings
+    "thaliawebsite.apps.ThaliaWebsiteConfig",  # include for admin settings
     # Load django.contrib.admin after thaliawebsite so the admin page gets modified
     "django.contrib.admin",
     "pushnotifications.apps.PushNotificationsConfig",


### PR DESCRIPTION
Closes #1464 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
NixOS has a testing module where you can write python scripts to test an actual system (running as a VM). I added a test that requests pages from the sitemap and checks if they return a succesful page.

### How to test
We cannot test this yet as GitHub Actions does not have the ability to start up a VM