### PR TITLE
Remove push trigger from test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@
 
 name: Linting and Testing
 on:
-  - push
   - pull_request
 
 jobs:


### PR DESCRIPTION
### Summary
This removes push as trigger for PR workflows. I believe we're doing double pipelines for every PR and that is not necesary.

### How to test
Steps to test the changes you made:
1. Cannot really test this right.
