### PR TITLE
Added the 'too late to cancel without paying fine'-message to the API…

### DIFF
--- a/website/events/api/v1/serializers/events/retrieve.py
+++ b/website/events/api/v1/serializers/events/retrieve.py
@@ -41,6 +41,7 @@ class EventRetrieveSerializer(serializers.ModelSerializer):
             "google_maps_url",
             "is_admin",
             "slide",
+            "cancel_too_late_message",
         )
 
     description = serializers.SerializerMethodField("_description")

--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -183,7 +183,7 @@ class Event(models.Model, metaclass=ModelTranslateMeta):
 
     @property
     def cancel_too_late_message(self):
-        return (
+        return _(
             "Cancellation isn't possible anymore without having to pay "
             "the full costs of €" + str(self.fine) + ". Also note that "
             "you will be unable to re-register. Note: If you have any "

--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -183,12 +183,14 @@ class Event(models.Model, metaclass=ModelTranslateMeta):
 
     @property
     def cancel_too_late_message(self):
-        return "Cancellation isn\'t possible anymore without having to pay " \
-                "the full costs of €" + str(self.fine) + ". Also note that " \
-                "you will be unable to re-register. Note: If you have any " \
-                "COVID-19 symptoms you will not have to pay these fees. " \
-                "Let us know via info@thalia.nu that this is this reason " \
-                "for your cancellation."
+        return (
+            "Cancellation isn't possible anymore without having to pay "
+            "the full costs of €" + str(self.fine) + ". Also note that "
+            "you will be unable to re-register. Note: If you have any "
+            "COVID-19 symptoms you will not have to pay these fees. "
+            "Let us know via info@thalia.nu that this is this reason "
+            "for your cancellation."
+        )
 
     @property
     def after_cancel_deadline(self):

--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -182,6 +182,15 @@ class Event(models.Model, metaclass=ModelTranslateMeta):
     tpay_allowed = models.BooleanField(_("Allow Thalia Pay"), default=True)
 
     @property
+    def cancel_too_late_message(self):
+        return "Cancellation isn\'t possible anymore without having to pay " \
+                "the full costs of €" + str(self.fine) + ". Also note that " \
+                "you will be unable to re-register. Note: If you have any " \
+                "COVID-19 symptoms you will not have to pay these fees. " \
+                "Let us know via info@thalia.nu that this is this reason " \
+                "for your cancellation."
+
+    @property
     def after_cancel_deadline(self):
         return self.cancel_deadline and self.cancel_deadline <= timezone.now()
 

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -217,9 +217,7 @@
                                             {% endblocktrans %}
                                         {% endif %}
                                         {% if event.after_cancel_deadline and not registration.queue_position %}
-                                            {% blocktrans trimmed with no_cancellation=event.cancel_too_late_message%}
-                                                {{ no_cancellation }}
-                                            {% endblocktrans %}
+                                            {{ event.cancel_too_late_message }}
                                         {% endif %}
                                         {% if event.after_cancel_deadline and registration.queue_position %}
                                             {% blocktrans trimmed with costs=event.fine %}

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -217,11 +217,8 @@
                                             {% endblocktrans %}
                                         {% endif %}
                                         {% if event.after_cancel_deadline and not registration.queue_position %}
-                                            {% blocktrans trimmed with costs=event.fine %}
-                                                Cancellation isn't possible anymore without having to pay the full costs of €{{ costs }}.
-                                                Also note that you will be unable to re-register.{% endblocktrans %}
-                                            {% blocktrans trimmed %}
-                                                Note: If you have any COVID-19 symptoms you will not have to pay these fees. Let us know via info@thalia.nu that this is this reason for your cancellation.
+                                            {% blocktrans trimmed with no_cancellation=event.cancel_too_late_message%}
+                                                {{ no_cancellation }}
                                             {% endblocktrans %}
                                         {% endif %}
                                         {% if event.after_cancel_deadline and registration.queue_position %}

--- a/website/events/tests/test_views.py
+++ b/website/events/tests/test_views.py
@@ -433,7 +433,6 @@ class RegistrationTest(TestCase):
         self.event.save()
         EventRegistration.objects.create(event=self.event, member=self.member)
         response = self.client.get("/events/1/")
-        print(response.rendered_content)
         self.assertContains(
             response,
             "Cancellation isn&#x27;t possible anymore without having to pay the full costs of",

--- a/website/events/tests/test_views.py
+++ b/website/events/tests/test_views.py
@@ -433,9 +433,10 @@ class RegistrationTest(TestCase):
         self.event.save()
         EventRegistration.objects.create(event=self.event, member=self.member)
         response = self.client.get("/events/1/")
+        print(response.rendered_content)
         self.assertContains(
             response,
-            "Cancellation isn't possible anymore without having to pay the full costs of",
+            "Cancellation isn&#x27;t possible anymore without having to pay the full costs of",
         )
 
     def test_registration_cancel_after_deadline_waitinglist_no_warning(self):


### PR DESCRIPTION
…, so it doesn't have to be hardcoded in the app anymore.

Closes #1383 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The message that's shown when cancellation isn't possible without paying a fine can now be requested from the API.

### How to test
Steps to test the changes you made:
1. Make sure you're registered for an event for which the registration deadline has already passed 
2. Go to thalia.nu/api/v1/events/1/
2. The message is shown at the bottom: "cancellation isn't possible anymore without..."
3. Go to thalia.nu/events/1/
4. The same message is also shown here
