### PR TITLE
Rename --preset to --primary and fix the grid overlay RGBA background

### DIFF
--- a/website/announcements/static/announcements/css/style.scss
+++ b/website/announcements/static/announcements/css/style.scss
@@ -1,30 +1,30 @@
 #announcements-alerts {
     .announcement {
-        background: var(--preset);
-        color: var(--preset-contrast);
+        background: var(--primary);
+        color: var(--primary-contrast);
         text-align: center;
         padding: 0.5rem 1rem;
         position: relative;
 
         .close {
-            color: var(--preset-contrast);
+            color: var(--primary-contrast);
         }
 
         p {
             display: inline;
             margin-left: 0.5rem;
-            color: var(--preset-contrast);
+            color: var(--primary-contrast);
             font-size: 0.9rem;
             font-weight: $bold;
         }
 
         a {
-            color: var(--preset-contrast);
+            color: var(--primary-contrast);
             text-decoration: underline;
         }
 
         a:hover {
-            color: var(--preset-contrast-hover);
+            color: var(--primary-contrast-hover);
         }
 
         button {

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -13,7 +13,7 @@
         }
 
         .card-date {
-            color: var(--preset);
+            color: var(--primary);
             margin-bottom: .7rem;
         }
 
@@ -34,7 +34,7 @@
             }
 
             .has-registration {
-                background-color: var(--preset);
+                background-color: var(--primary);
             }
         }
     }
@@ -46,7 +46,7 @@
     }
 
     .fc-now-indicator {
-        border-color: var(--preset);
+        border-color: var(--primary);
 
         &.fc-now-indicator-arrow {
             border-top-color: transparent;
@@ -72,7 +72,7 @@
                 &.regular-event {
                     background-color: $grey;
                     &.has-registration {
-                        background-color: var(--preset);
+                        background-color: var(--primary);
                     }
                 }
 
@@ -87,7 +87,7 @@
                 &.birthday-event {
                     background-color: var(--secondary);
                     &.honorary {
-                        background-color: var(--preset);
+                        background-color: var(--primary);
                     }
                 }
             }
@@ -104,7 +104,7 @@
 
         &.regular-event {
             &.has-registration {
-                background-color: var(--preset);
+                background-color: var(--primary);
                 color: $white;
             }
         }
@@ -115,11 +115,11 @@
         }
 
         &.partner-event {
-            color: var(--preset);
+            color: var(--primary);
             background-color: var(--secondary);
 
             &:active, &:hover {
-                color: var(--preset);
+                color: var(--primary);
             }
         }
 
@@ -127,7 +127,7 @@
             background-color: var(--secondary);
             color: var(--secondary-contrast);
             &.honorary {
-                background-color: var(--preset);
+                background-color: var(--primary);
                 color: var(--secondary);
             }
         }

--- a/website/thaliawebsite/static/css/_buttons.scss
+++ b/website/thaliawebsite/static/css/_buttons.scss
@@ -23,27 +23,27 @@
 }
 
 .btn-link {
-    color: var(--preset);
+    color: var(--primary);
 
     &:hover {
-        color: var(--preset-hover);
+        color: var(--primary-hover);
         text-decoration: none;
     }
 
     &:focus {
-        color: var(--preset-hover);
+        color: var(--primary-hover);
         text-decoration: none;
     }
 }
 
 .btn-primary, .btn-primary:active, .btn-primary:focus {
-    background: var(--preset) !important;
-    border-color: var(--preset) !important;
-    color: var(--preset-contrast) !important;
+    background: var(--primary) !important;
+    border-color: var(--primary) !important;
+    color: var(--primary-contrast) !important;
 
     &:hover, &.active {
-        background: var(--preset-hover) !important;
-        border-color: var(--preset-hover) !important;
+        background: var(--primary-hover) !important;
+        border-color: var(--primary-hover) !important;
     }
 }
 

--- a/website/thaliawebsite/static/css/_forms.scss
+++ b/website/thaliawebsite/static/css/_forms.scss
@@ -17,7 +17,7 @@
     outline: none;
 
     &:focus {
-        border-color: var(--preset);
+        border-color: var(--primary);
         box-shadow: none;
         color: var(--form-text);
         background: var(--form-background);

--- a/website/thaliawebsite/static/css/_navs.scss
+++ b/website/thaliawebsite/static/css/_navs.scss
@@ -5,7 +5,7 @@
 
         &.show {
             .nav-link {
-                color: var(--preset);
+                color: var(--primary);
             }
         }
 
@@ -21,11 +21,11 @@
             border-top-left-radius: 0;
 
             &:hover {
-                color: var(--preset-hover);
+                color: var(--primary-hover);
             }
 
             &.active, &.mixitup-control-active {
-                color: var(--preset);
+                color: var(--primary);
                 border-color: #dee2e6 #dee2e6 var(--background-color);
             }
         }
@@ -42,7 +42,7 @@
             border: 1px solid transparent;
 
             &.active {
-                color: var(--preset);
+                color: var(--primary);
             }
         }
     }
@@ -58,7 +58,7 @@
     .page-item {
 
         .page-link {
-            color: var(--preset);
+            color: var(--primary);
             background-color: var(--background-color);
             border-color: var(--background-shade);
             border-radius: 0;
@@ -73,8 +73,8 @@
         &.active {
             .page-link {
                 color: var(--white);
-                background-color: var(--preset);
-                border-color: var(--preset);
+                background-color: var(--primary);
+                border-color: var(--primary);
             }
         }
     }

--- a/website/thaliawebsite/static/css/_progress.scss
+++ b/website/thaliawebsite/static/css/_progress.scss
@@ -8,7 +8,7 @@
         -webkit-border-radius: 0;
         -moz-border-radius: 0;
         border-radius: 0;
-        background-color: var(--preset);
+        background-color: var(--primary);
 
         @for $i from 1 through 100 {
             &.progress#{$i} {

--- a/website/thaliawebsite/static/css/_typography.scss
+++ b/website/thaliawebsite/static/css/_typography.scss
@@ -37,10 +37,10 @@ h6 {
 }
 
 a {
-    color: var(--preset);
+    color: var(--primary);
     @include transition(.2s);
     &:hover, &:active, &:focus {
-        color: var(--preset-hover);
+        color: var(--primary-hover);
         text-decoration: none;
     }
     letter-spacing: $letter-spacing;
@@ -59,13 +59,13 @@ p {
 
 .bg-default {
     color: var(--text-color);
-    background: var(--preset);
+    background: var(--primary);
     padding: 3px 4px;
 }
 
 .bg-primary {
-    color: var(--preset-contrast);
-    background: var(--preset);
+    color: var(--primary-contrast);
+    background: var(--primary);
     padding: 3px 4px;
 }
 

--- a/website/thaliawebsite/static/css/_variables.scss
+++ b/website/thaliawebsite/static/css/_variables.scss
@@ -29,86 +29,41 @@ $red: #e62a17;
 $red-shade: #ce2816;
 
 :root {
-  --background-color: #{$white};
-  --background-shade: #{$light-grey};
-  --background-shade-light: #{$lightlight-grey};
-  --navbar-background-color: #{$white};
+    --background-color: #{$white};
+    --background-shade: #{$light-grey};
+    --background-shade-light: #{$lightlight-grey};
+    --navbar-background-color: #{$white};
 
-  --card-background: #{$lightlight-grey};
-  --card-background-contrast: #{$black};
-  --card-background-hover: #{$light-grey};
-  --card-background-hover-contrast: #{$magenta};
+    --card-background: #{$lightlight-grey};
+    --card-background-contrast: #{$black};
+    --card-background-hover: #{$light-grey};
+    --card-background-hover-contrast: #{$magenta};
 
-  --banner-background: #{$light-grey};
+    --banner-background: #{$light-grey};
 
-  --form-background: #{$white};
-  --form-background-disabled: #{$light-grey};
-  --form-border: #{$black};
-  --form-text: #{$dark-grey};
+    --form-background: #{$white};
+    --form-background-disabled: #{$light-grey};
+    --form-border: #{$black};
+    --form-text: #{$dark-grey};
 
-  --title-color: #{$black};
-  --sub-title-color: #{$dark-grey};
-  --text-color: #{$dark-grey};
-  --nav-link-color: #{$black};
-
-  --footer-text-color: #{$white};
-  --footer-text-color-hover: #{$lightlight-grey};
-
-  --preset: #{$magenta};
-  --preset-hover: #{$magenta-shade};
-  --preset-contrast: #{$white};
-  --preset-contrast-hover: #{$light-grey};
-  --secondary: #{$black};
-  --secondary-hover: #{$darkdark-grey};
-  --secondary-contrast: #{$white};
-  --success: #{$green};
-  --success-hover: #{$green-shade};
-  --success-contrast: #{$white};
-  --info: #{$blue};
-  --info-hover: #{$blue-shade};
-  --info-contrast: #{$white};
-  --warning: #{$yellow};
-  --warning-hover: #{$yellow-shade};
-  --warning-contrast: #{$white};
-  --danger: #{$red};
-  --danger-hover: #{$red-shade};
-  --danger-contrast: #{$white};
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background-color: #{$black};
-    --background-shade: #{$dark-grey};
-    --background-shade-light: #{$darkdark-grey};
-    --navbar-background-color: #{$black};
-
-    --card-background: #{$darkdark-grey};
-    --card-background-contrast: #{$white};
-    --card-background-hover: #{$dark-grey};
-    --card-background-hover-contrast: #{$white};
-
-    --banner-background: #{$dark-grey};
-
-    --form-background: #{$black};
-    --form-background-disabled: #{$darkdark-grey};
-    --form-border: #{$white};
-    --form-text: #{$light-grey};
-
-    --title-color: #{$white};
-    --sub-title-color: #{$lightlight-grey};
-    --text-color: #{$light-grey};
-    --nav-link-color: #{$white};
+    --title-color: #{$black};
+    --sub-title-color: #{$dark-grey};
+    --text-color: #{$dark-grey};
+    --nav-link-color: #{$black};
 
     --footer-text-color: #{$white};
     --footer-text-color-hover: #{$lightlight-grey};
 
-    --preset: #{$magenta};
-    --preset-hover: #{$magenta-shade};
-    --preset-contrast: #{$white};
-    --preset-contrast-hover: #{$light-grey};
-    --secondary: #{$light-grey};
-    --secondary-hover: #{$lightlight-grey};
-    --secondary-contrast: #{$black};
+    --primary: #{$magenta};
+    --primary-rgb: #{red($magenta), green($magenta), blue($magenta)};
+    --primary-hover: #{$magenta-shade};
+    --primary-contrast: #{$white};
+    --primary-contrast-hover: #{$light-grey};
+
+    --secondary: #{$black};
+    --secondary-hover: #{$darkdark-grey};
+    --secondary-contrast: #{$white};
+
     --success: #{$green};
     --success-hover: #{$green-shade};
     --success-contrast: #{$white};
@@ -121,5 +76,37 @@ $red-shade: #ce2816;
     --danger: #{$red};
     --danger-hover: #{$red-shade};
     --danger-contrast: #{$white};
-  }
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --background-color: #{$black};
+        --background-shade: #{$dark-grey};
+        --background-shade-light: #{$darkdark-grey};
+        --navbar-background-color: #{$black};
+
+        --card-background: #{$darkdark-grey};
+        --card-background-contrast: #{$white};
+        --card-background-hover: #{$dark-grey};
+        --card-background-hover-contrast: #{$white};
+
+        --banner-background: #{$dark-grey};
+
+        --form-background: #{$black};
+        --form-background-disabled: #{$darkdark-grey};
+        --form-border: #{$white};
+        --form-text: #{$light-grey};
+
+        --title-color: #{$white};
+        --sub-title-color: #{$lightlight-grey};
+        --text-color: #{$light-grey};
+        --nav-link-color: #{$white};
+
+        --footer-text-color: #{$white};
+        --footer-text-color-hover: #{$lightlight-grey};
+
+        --secondary: #{$light-grey};
+        --secondary-hover: #{$lightlight-grey};
+        --secondary-contrast: #{$black};
+    }
 }

--- a/website/thaliawebsite/static/css/base.scss
+++ b/website/thaliawebsite/static/css/base.scss
@@ -16,7 +16,7 @@ body {
 #accentbar {
     position: -webkit-sticky;
     position: sticky;
-    background: var(--preset);
+    background: var(--primary);
     height: 5px;
     top: 0;
     z-index: 1020;
@@ -59,7 +59,7 @@ body {
 
             &.active, &:hover {
                 .nav-link {
-                    color: var(--preset);
+                    color: var(--primary);
                 }
             }
         }
@@ -101,7 +101,7 @@ body {
     tbody tr {
         &:hover {
             cursor: pointer;
-            color: var(--preset);
+            color: var(--primary);
             background-color: var(--background-shade);
         }
     }
@@ -208,7 +208,7 @@ body {
             padding: 20px 0 0;
 
             &::before {
-                background: var(--preset);
+                background: var(--primary);
                 content: '';
                 position: absolute;
                 left: 50%;
@@ -236,7 +236,7 @@ body {
 
 footer {
     position: absolute;
-    background: var(--preset);
+    background: var(--primary);
     overflow: hidden;
     font-size: 14px;
     color: var(--footer-text-color);
@@ -275,13 +275,13 @@ footer {
         color: var(--nav-link-color);
 
         &:focus {
-            background-color: var(--preset-hover);
-            color: var(--preset-contrast-hover);
+            background-color: var(--primary-hover);
+            color: var(--primary-contrast-hover);
         }
 
         &:hover, &:active, &.active {
-            background-color: var(--preset);
-            color: var(--preset-contrast);
+            background-color: var(--primary);
+            color: var(--primary-contrast);
         }
     }
 }
@@ -305,7 +305,7 @@ img {
         right: -3px;
 
         .ribbon {
-            color: var(--preset-contrast);
+            color: var(--primary-contrast);
             text-align: center;
             -webkit-transform: rotate(45deg);
             -moz-transform: rotate(45deg);
@@ -316,7 +316,7 @@ img {
             left: -5px;
             top: 28px;
             width: 170px;
-            background-color: var(--preset);
+            background-color: var(--primary);
         }
     }
 
@@ -345,7 +345,7 @@ img {
     .overlay {
         position: absolute;
         opacity: 0;
-        background-color: rgba(var(--preset), .7);
+        background-color: rgba(var(--primary-rgb), .7);
         transition: all 300ms ease-in-out 0s;
         -moz-transition: all 300ms ease-in-out 0s;
         -webkit-transition: all 300ms ease-in-out 0s;
@@ -354,7 +354,7 @@ img {
         height: 100%;
 
         h5, p {
-            color: var(--preset-contrast);
+            color: var(--primary-contrast);
             -webkit-transform: translateY(-50px);
         }
 
@@ -390,7 +390,7 @@ img {
         -webkit-transition: all 300ms ease-in-out 0s;
         -o-transition: all 300ms ease-in-out 0s;
 
-        color: var(--preset-contrast);
+        color: var(--primary-contrast);
         font-size: 15px;
 
         background: rgba(0, 0, 0, 0);


### PR DESCRIPTION
### Summary

This PR does four things: 
1. It renames the primary CSS colour variable from `--preset` to `--primary` to bring it in line with the fact that we have a secondary colour.
2. It removes all duplicate variables from the dark mode variables
3. The variables document is now properly formatted with 4 spaces
3. It fixes an issue with the usage of the primary colour in a rgba function

### How to test
Steps to test the changes you made:
1. Setup a review environment
2. Check that the colours are still correct
3. Check that the overlay has a background again by going to a page with the grid structure (for example photos, members or documents) and hover over an item.
