### PR TITLE
event registration now saves changes

### DIFF
--- a/website/events/services.py
+++ b/website/events/services.py
@@ -186,8 +186,8 @@ def update_registration(
         name = registration.name
 
     if (
-        not event_permissions(member, event, name)["update_registration"]
-        or not field_values
+        (not event_permissions(member, event, name)["update_registration"]
+        or not field_values) and is_organiser(member,event)
     ):
         return
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -186,8 +186,8 @@ def update_registration(
         name = registration.name
 
     if (
-        (not event_permissions(member, event, name)["update_registration"]
-        or not field_values) and is_organiser(member,event)
+        (not event_permissions(member, event, name)["update_registration"] and is_organiser(member,event))
+        or not field_values 
     ):
         return
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -186,9 +186,9 @@ def update_registration(
         name = registration.name
 
     if (
-        (not event_permissions(member, event, name)["update_registration"] and is_organiser(member,event))
-        or not field_values 
-    ):
+        not event_permissions(member, event, name)["update_registration"]
+        and is_organiser(member, event)
+    ) or not field_values:
         return
 
     for field_id, field_value in field_values:


### PR DESCRIPTION
Closes  #1345

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Organizers of events should be able to edit the members' fields at their events even for non-members. Now they can.

### How to test
Steps to test the changes you made:
1. Add a manual event registration.
1. Edit the information fields of the participants.
1. It works.