### PR TITLE
Fix album media

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -91,6 +91,7 @@ in
       apply = x: {
         SITE_DOMAIN = if cfg.ssl then cfg.domain else "*";
         MEDIA_ROOT = "${cfg.dir}/media";
+        SENDFILE_ROOT = "${cfg.dir}/media";
         POSTGRES_USER = "concrexit";
         POSTGRES_DB = "concrexit";
         DJANGO_ENV = "staging";
@@ -188,6 +189,7 @@ in
           User = cfg.user;
           KillSignal = "SIGQUIT";
           Type = "notify";
+          TimeoutStartSec = "infinity";
           NotifyAccess = "all";
         };
 


### PR DESCRIPTION
Closes #1522 

### Summary
Album media did not work because the sendfile root was not set properly.

### How to test
Steps to test the changes you made:
1. Go to albums
2. View images
3. You can view images