### PR TITLE
Fix API v1 global pagination

### DIFF
--- a/website/thaliawebsite/api/pagination.py
+++ b/website/thaliawebsite/api/pagination.py
@@ -6,7 +6,7 @@ class APIv2LimitOffsetPagination(LimitOffsetPagination):
     """Pagination class that uses LimitOffsetPagination and sets the default value for the pagination size to None for API v1."""
 
     def get_limit(self, request):
-        if self.limit_query_param:
+        if self.limit_query_param in request.query_params:
             return super().get_limit(request)
 
         if request.version == "v1":


### PR DESCRIPTION
### Summary
This change disables default pagination for API v1. This was accidentally enabled in the API v2 pull requests.

### How to test
Steps to test the changes you made:
1. Go to `/api/docs`
2. Compare the results of the v1 events, members and activemembers groups API endpoints with those on production
3. They should not by default implement pagination
