### PR TITLE
Fix redirection page title in shortlinks app

### DIFF
--- a/website/shortlinks/templates/shortlinks/confirm.html
+++ b/website/shortlinks/templates/shortlinks/confirm.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load static i18n %}
 
-{% block title %}Shortlink for {{ link.key }} — {{ block.super }}{% endblock %}
-{% block opengraph_title %}Shortlink for {{ link.key }} — {{ block.super }}{% endblock %}
+{% block title %}{{ link.slug|title }} redirect — {{ block.super }}{% endblock %}
+{% block opengraph_title %}{{ link.slug|title }} redirect — {{ block.super }}{% endblock %}
 
 {% block body %}
 


### PR DESCRIPTION
### Summary
This PR fixes the title of the shortlink redirection confirmation page.

### How to test
Steps to test the changes you made:
1. Create a shortlink
2. Open the shortlink
3. Check the title
