### PR TITLE
Fix activemembers v2 API schema

### DIFF
--- a/website/activemembers/api/v2/serializers/member_group.py
+++ b/website/activemembers/api/v2/serializers/member_group.py
@@ -13,7 +13,7 @@ class MemberGroupSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if "get_memberships" not in self.context:
+        if "get_memberships" not in self.context and "members" in self.fields:
             self.fields.pop("members")
 
     class Meta:


### PR DESCRIPTION
### Summary
The schema for APIv2 is broken on staging currently. This PR fixes the culprit and makes sure the v2 schema works again.

### How to test
Steps to test the changes you made:
1. Go to /api/docs and selection the v2 in the top right
2. It should work