### PR TITLE
Fix FileField support in the media helpers

### DIFF
--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -17,6 +17,8 @@ def get_media_url(path, attachment=False):
     """
     if isinstance(path, ImageFieldFile):
         path = path.name
+    if isinstance(path, FieldFile):
+        path = path.name
 
     parts = path.split("/")
     query = ""


### PR DESCRIPTION
### Summary
The change to support SVG files in the slides made the content field a FileField. This values is fed into the thumbnailer code in some cases but that code did not support that type of field.

### How to test
Steps to test the changes you made:
1. Check that /api/v2/announcements/slides/ does work
