### PR TITLE
Set secure cookie in production

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -224,9 +224,9 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = os.environ.get("DATA_UPLOAD_MAX_NUMBER_FIELDS", 
 DEBUG = setting(development=True, production=False, testing=False)
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-secure
-SESSION_COOKIE_SECURE = setting(development=True, production=False)
+SESSION_COOKIE_SECURE = setting(development=False, production=True)
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-secure
-CSRF_COOKIE_SECURE = setting(development=True, production=False)
+CSRF_COOKIE_SECURE = setting(development=False, production=True)
 
 ###############################################################################
 # Email settings


### PR DESCRIPTION
### Summary
I think some other middleware already made sure cookies are always secure, but it's important that cookies also work on a http localhost

### How to test
Steps to test the changes you made:
1. Run site in development mode
2. Check that cookies are not "secure" in the storage tab in firefox for example
