### PR TITLE
Fix placeholder photo for committees

### DIFF
--- a/website/activemembers/templates/activemembers/membergroup_detail.html
+++ b/website/activemembers/templates/activemembers/membergroup_detail.html
@@ -15,7 +15,7 @@
                          src="{% thumbnail membergroup.photo THUMBNAIL_SIZE_LARGE fit=False %}">
                 {% else %}
                     <img alt="{{ membergroup.name }}" class="col-12"
-                         src="/static/activemembers/images/{{ LANGUAGE_CODE }}/placeholder.png">
+                         src="/static/activemembers/images/placeholder.png">
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
Closes #1520 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The placeholder photo for committees was not showing because of old language code 

### How to test
1. Create a committee without a committee picture
2. Go to the committee page
3. See the placeholder image
