### PR TITLE
Fix event registrations API internal server error

### DIFF
--- a/website/events/api/v1/serializers/event_registrations/list.py
+++ b/website/events/api/v1/serializers/event_registrations/list.py
@@ -73,7 +73,7 @@ class EventRegistrationAdminListSerializer(EventRegistrationListSerializer):
 
     def _queue_position(self, instance):
         pos = instance.queue_position
-        return pos if pos > 0 else None
+        return pos if pos and pos > 0 else None
 
     def _is_cancelled(self, instance):
         return instance.date_cancelled is not None


### PR DESCRIPTION
Closes #1549 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This fixes the internal server error for the event registrations API.

### How to test
1. Register for an event
2. Go to /api/v1/events/{pk}/registrations/
3. No crash

