### PR TITLE
Add calendar coloring based on registration

### DIFF
--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -13,19 +13,20 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
         return reverse("events:event", kwargs={"pk": instance.id})
 
     def _class_names(self, instance):
-        class_names = ["regular-event"]
         if self.context["member"] and services.is_user_registered(
             self.context["member"], instance
         ):
             if not services.user_registration_pending(self.context["member"], instance):
-                class_names.append("pending-registration")
+                return ["regular-event-pending-registration"]
             else:
-                class_names.append("has-registration")
+                return ["regular-event-has-registration"]
         elif not instance.registration_required:
-            class_names.append("no-registration")
+            return ["regular-event-no-registration"]
         elif not instance.registration_allowed:
-            class_names.append("registration-closed")
-        return class_names
+            return ["regular-event-registration-closed"]
+        else:
+            # I think this handles the case that registration is needed, but the user is not registered?
+            return ["regular-event-not-registered"]
 
 
 class UnpublishedEventsCalenderJSSerializer(CalenderJSSerializer):

--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -16,17 +16,15 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
         if self.context["member"] and services.is_user_registered(
             self.context["member"], instance
         ):
-            if not services.user_registration_pending(self.context["member"], instance):
+            if services.user_registration_pending(self.context["member"], instance):
                 return ["regular-event-pending-registration"]
             else:
                 return ["regular-event-has-registration"]
-        elif not instance.registration_required:
-            return ["regular-event-no-registration"]
-        elif not instance.registration_allowed:
-            return ["regular-event-registration-closed"]
+        elif (not instance.registration_required) or instance.registration_allowed:
+            return ["regular-event-registration-open"]
         else:
-            # I think this handles the case that registration is needed, but the user is not registered?
-            return ["regular-event-not-registered"]
+            # I think this handles the case that registration is needed, but not yet possible
+            return ["regular-event-registration-closed"]
 
 
 class UnpublishedEventsCalenderJSSerializer(CalenderJSSerializer):

--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -21,6 +21,8 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
                 class_names.append("pending-registration")
             else:
                 class_names.append("has-registration")
+        elif not instance.registration_required:
+            class_names.append("no-registration")
         elif not instance.registration_allowed:
             class_names.append("registration-closed")
         return class_names

--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -17,10 +17,10 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
         if self.context["member"] and services.is_user_registered(
             self.context["member"], instance
         ):
-            class_names.append("has-registration")
-            # EventRegistration.status should be used
-            if services.user_registration_pending(self.context["member"], instance):
+            if not services.user_registration_pending(self.context["member"], instance):
                 class_names.append("pending-registration")
+            else:
+                class_names.append("has-registration")
         elif not instance.registration_allowed:
             class_names.append("registration-closed")
         return class_names

--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -18,6 +18,11 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
             self.context["member"], instance
         ):
             class_names.append("has-registration")
+            # EventRegistration.status should be used
+            if services.user_registration_pending(self.context["member"], instance):
+                class_names.append("pending-registration")
+        elif not instance.registration_allowed:
+            class_names.append("registration-closed")
         return class_names
 
 

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -19,7 +19,7 @@ def is_user_registered(member, event):
     :param event: the event
     :return: None if registration is not required or no member else True/False
     """
-    if not event.registration_required or not member.is_authenticated:
+    if not member.is_authenticated:
         return None
 
     return event.registrations.filter(member=member, date_cancelled=None).count() > 0

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -32,11 +32,13 @@ def user_registration_pending(member, event):
     :param event: the event
     :return: None if registration is not required or no member else True/False
     """
-    if not event.registration_required or not member.is_authenticated:
+    if not event.registration_required:
+        return False
+    if not member.is_authenticated:
         return None
 
     reg = event.registrations.filter(member=member, date_cancelled=None)
-    return len(list(filter(lambda r: r.queue_position, reg))) == 0
+    return len(list(filter(lambda r: r.queue_position, reg))) > 0
 
 
 def is_user_present(member, event):

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -34,8 +34,9 @@ def user_registration_pending(member, event):
     if not event.registration_required or not member.is_authenticated:
         return None
 
-    return event.queue.filter(member=member, date_cancelled=None).count() > 0
-
+    reg = event.registrations.filter(member=member, date_cancelled=None)
+    return len(list(filter(lambda r: r.queue_position, reg))) > 0
+    
 def is_user_present(member, event):
     if not event.registration_required or not member.is_authenticated:
         return None

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -35,7 +35,7 @@ def user_registration_pending(member, event):
         return None
 
     reg = event.registrations.filter(member=member, date_cancelled=None)
-    return len(list(filter(lambda r: r.queue_position, reg))) > 0
+    return len(list(filter(lambda r: r.queue_position, reg))) == 0
     
 def is_user_present(member, event):
     if not event.registration_required or not member.is_authenticated:

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -26,7 +26,7 @@ def is_user_registered(member, event):
 
 
 def user_registration_pending(member, event):
-    """Return if the user is in the queue, but not yet registered for, the specific event
+    """Return if the user is in the queue, but not yet registered for, the specific event.
 
     :param member: the user
     :param event: the event

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -24,6 +24,7 @@ def is_user_registered(member, event):
 
     return event.registrations.filter(member=member, date_cancelled=None).count() > 0
 
+
 def user_registration_pending(member, event):
     """Return if the user is in the queue, but not yet registered for, the specific event
 
@@ -36,7 +37,8 @@ def user_registration_pending(member, event):
 
     reg = event.registrations.filter(member=member, date_cancelled=None)
     return len(list(filter(lambda r: r.queue_position, reg))) == 0
-    
+
+
 def is_user_present(member, event):
     if not event.registration_required or not member.is_authenticated:
         return None

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -24,6 +24,17 @@ def is_user_registered(member, event):
 
     return event.registrations.filter(member=member, date_cancelled=None).count() > 0
 
+def user_registration_pending(member, event):
+    """Return if the user is in the queue, but not yet registered for, the specific event
+
+    :param member: the user
+    :param event: the event
+    :return: None if registration is not required or no member else True/False
+    """
+    if not event.registration_required or not member.is_authenticated:
+        return None
+
+    return event.queue.filter(member=member, date_cancelled=None).count() > 0
 
 def is_user_present(member, event):
     if not event.registration_required or not member.is_authenticated:

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -73,9 +73,9 @@
                     background-color: $grey;
                     &.has-registration {
                         background-color: $green;
-                        &.pending-registration {
-                            background-color: $yellow;
-                        }
+                    }
+                    &.pending-registration {
+                        background-color: $yellow;
                     }
                     &.no-registration { // for events that do not require registration
                         background-color: $magenta;

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -36,6 +36,10 @@
             .has-registration {
                 background-color: var(--primary);
             }
+
+            .pending-registration {
+                background-color: $yellow;
+            }
         }
     }
 }
@@ -113,8 +117,14 @@
 
         &.regular-event {
             &.has-registration {
-                background-color: var(--primary);
+                background-color: $green;
                 color: $white;
+            }
+            &.pending-registration {
+                background-color: $yellow;
+            }
+            &.no-registration {
+                background-color: var(--primary);
             }
         }
 

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -72,7 +72,16 @@
                 &.regular-event {
                     background-color: $grey;
                     &.has-registration {
-                        background-color: var(--primary);
+                        background-color: $green;
+                        &.pending-registration {
+                            background-color: $yellow;
+                        }
+                    }
+                    &.no-registration { // for events that do not require registration
+                        background-color: $magenta;
+                    }
+                    &.registration-closed {
+                        background-color: rgba(0, 0, 0, 128);
                     }
                 }
 

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -23,21 +23,21 @@
             right: 1.25rem;
             top: 1.25rem;
 
-            .no-registration, .has-registration {
+            .regular-event-no-registration, .regular-event-has-registration .regular-event-pending-registration {
                 border-radius: 20px;
                 width: 12px;
                 height: 12px;
             }
 
-            .no-registration {
+            .regular-event-no-registration {
                 background-color: $grey;
             }
 
-            .has-registration {
+            .regular-event-has-registration {
                 background-color: var(--primary);
             }
 
-            .pending-registration {
+            .regular-event-pending-registration {
                 background-color: $yellow;
             }
         }
@@ -73,22 +73,22 @@
                 margin-right: 1rem;
                 flex-shrink: 0;
 
-                &.regular-event {
+                &.regular-event-not-registered {
                     background-color: $grey;
-                    &.has-registration {
-                        background-color: $green;
-                    }
-                    &.pending-registration {
-                        background-color: $yellow;
-                    }
-                    &.no-registration { // for events that do not require registration
-                        background-color: $magenta;
-                    }
-                    &.registration-closed {
-                        background-color: rgba(0, 0, 0, 128);
-                    }
                 }
-
+                &.regular-event-has-registration {
+                    background-color: $green;
+                }
+                &.regular-event-pending-registration {
+                    background-color: $yellow;
+                }
+                &.regular-event-no-registration { // for events that do not require registration
+                    background-color: $magenta;
+                }
+                &.regular-event-registration-closed {
+                    // background-color: rgba(0, 0, 0, 128);
+                    background-color: $red;
+                }
                 &.unpublished-event, &.unpublished-event:active, &.unpublished-event:hover {
                     background-color: rgba(255, 0, 0, 0.3);
                 }
@@ -115,17 +115,22 @@
         overflow: hidden;
         transition-property: opacity;
 
-        &.regular-event {
-            &.has-registration {
-                background-color: $green;
-                color: $white;
-            }
-            &.pending-registration {
-                background-color: $yellow;
-            }
-            &.no-registration {
-                background-color: var(--primary);
-            }
+        &.regular-event-not-registered {
+            background-color: $grey;
+        }
+        &.regular-event-has-registration {
+            background-color: $green;
+            color: $white;
+        }
+        &.regular-event-pending-registration {
+            background-color: $yellow;
+            color: $black;
+        }
+        &.regular-event-no-registration {
+            background-color: var(--primary);
+        }
+        &.regular-event-registration-closed {
+            background-color: $red;
         }
 
         &.unpublished-event, &.unpublished-event:active, &.unpublished-event:hover {

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -23,13 +23,13 @@
             right: 1.25rem;
             top: 1.25rem;
 
-            .regular-event-no-registration, .regular-event-has-registration .regular-event-pending-registration {
+            .regular-event-registration-open, .regular-event-has-registration .regular-event-pending-registration {
                 border-radius: 20px;
                 width: 12px;
                 height: 12px;
             }
 
-            .regular-event-no-registration {
+            .regular-event-registration-open {
                 background-color: $grey;
             }
 
@@ -73,21 +73,17 @@
                 margin-right: 1rem;
                 flex-shrink: 0;
 
-                &.regular-event-not-registered {
+                &.regular-event-registration-open {
                     background-color: $grey;
                 }
                 &.regular-event-has-registration {
-                    background-color: $green;
+                    background-color: $magenta;
                 }
                 &.regular-event-pending-registration {
                     background-color: $yellow;
                 }
-                &.regular-event-no-registration { // for events that do not require registration
-                    background-color: $magenta;
-                }
                 &.regular-event-registration-closed {
-                    // background-color: rgba(0, 0, 0, 128);
-                    background-color: $red;
+                    background-color: transparent;
                 }
                 &.unpublished-event, &.unpublished-event:active, &.unpublished-event:hover {
                     background-color: rgba(255, 0, 0, 0.3);
@@ -115,22 +111,19 @@
         overflow: hidden;
         transition-property: opacity;
 
-        &.regular-event-not-registered {
+        &.regular-event-registration-open {
             background-color: $grey;
         }
         &.regular-event-has-registration {
-            background-color: $green;
-            color: $white;
+            background-color: var(--primary);
         }
         &.regular-event-pending-registration {
             background-color: $yellow;
             color: $black;
         }
-        &.regular-event-no-registration {
-            background-color: var(--primary);
-        }
         &.regular-event-registration-closed {
-            background-color: $red;
+            background-color: #8a8a8a30;
+            color: $grey;
         }
 
         &.unpublished-event, &.unpublished-event:active, &.unpublished-event:hover {


### PR DESCRIPTION
Closes #1116

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
I implemented changes in the calendar view, so that the colours of the event indicators/backgrounds are a lot richer:

- As in #1116, when pending, the event clearly indicates this (by being yellow).
- Events without registration are also marked clearly, by being magenta. It might be good to think if this is better than it being the same color as either a registered or registerable event. #1443 would also solve this.
- Events for which you are registered become green.
- Events with closed registration are red. This is rather hard to distinguish from an unpublished event, which is also red. It might be wise to give another color to one of these.

Here are some screenshots:
![screen_2021-02-22-20:56:03](https://user-images.githubusercontent.com/7569492/108763880-314f9800-7552-11eb-95d3-7877cf4edf56.png)
![screen_2021-02-22-20:56:09](https://user-images.githubusercontent.com/7569492/108763887-3280c500-7552-11eb-9478-73f5d72349c5.png)
![screen_2021-02-22-20:56:30](https://user-images.githubusercontent.com/7569492/108763898-357bb580-7552-11eb-835b-afab636cf0b0.png)
![screen_2021-02-22-20:57:10](https://user-images.githubusercontent.com/7569492/108763905-37457900-7552-11eb-880f-065befcc5015.png)


### How to test
<!-- Steps to test the changes you made:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....' -->

- The main functionality is easy to test, simply open the event list/calendar view.
- The change modifies the CalendarJS serializer, I am not sure if this is used elsewhere (like in the app). The flattening I did for the class names (to fix the event indicators in the list view, which are even an issue on current production), might break anything else that depends on it.