### PR TITLE
Change youtube domain to nocookie variant

### DIFF
--- a/website/thaliawebsite/templates/error.html
+++ b/website/thaliawebsite/templates/error.html
@@ -10,7 +10,7 @@
             <h1 class="text-center section-title">{% blocktrans %}Error{% endblocktrans %}</h1>
             <p class="text-center">{% block error_message %}{% trans "An error occurred." %}{% endblock %}</p>
             <p class="text-center">
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/t3otBjVZzT0?autoplay=0"
+                <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/t3otBjVZzT0?autoplay=0"
                         frameborder="0" allowfullscreen></iframe>
             </p>
         </div>


### PR DESCRIPTION
Closes #1558 

### Summary
Update youtube embedded domain.

### How to test
Go to https://thalia.nu/not-a-real-page and check in source code if the nocookie domain is used for the youtube player.
