### PR TITLE
Add make ci subcommand that does all the CI checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        
+
       - name: Run pydocstyle
         run: make pydocstyle
 
@@ -87,8 +87,7 @@ jobs:
 
       - name: Run API docs script
         run: |
-          make apidocs
-          git diff --exit-code
+          make apidocscheck
 
       - name: Save documentation HTML
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
### Summary
I always forget which make checks I should do before committing so I added this `make ci` subcommand that does all the checks the CI does

### How to test
Run `make ci`