### PR TITLE
Allow registration for events that do not require it

### DIFF
--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -107,6 +107,8 @@ class EventRegistration(models.Model, Payable):
 
     def would_cancel_after_deadline(self):
         now = timezone.now()
+        if not self.event.registration_required:
+            return False
         return not self.queue_position and now >= self.event.cancel_deadline
 
     def clean(self):

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -66,20 +66,20 @@ def event_permissions(member, event, name=None):
 
     perms["create_registration"] = (
         (registration is None or registration.date_cancelled is not None)
-        and event.registration_allowed
+        and (event.registration_allowed or not event.registration_required)
         and (name or member.can_attend_events)
     )
     perms["cancel_registration"] = (
         registration is not None
         and registration.date_cancelled is None
-        and (event.cancellation_allowed or name)
+        and (event.cancellation_allowed or name or not event.registration_required)
         and registration.payment is None
     )
     perms["update_registration"] = (
         registration is not None
         and registration.date_cancelled is None
         and event.has_fields
-        and event.registration_allowed
+        and (event.registration_allowed or not event.registration_required)
         and (name or member.can_attend_events)
     )
     return perms

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -155,15 +155,25 @@
                                     </form>
                                 {% endif %}
                                 {% if permissions.create_registration %}
-                                    <p>
-                                        {% url 'singlepages:event-registration-terms' as terms_url %}
-                                        {% blocktrans trimmed %}
-                                            By registering,
-                                            you confirm that you have read the
-                                            <a target="_blank" href="{{ terms_url }}">terms and conditions</a>,
-                                            that you understand them and that you agree to be bound by them.
-                                        {% endblocktrans %}
-                                    </p>
+                                    {% if event.registration_required %}
+                                        <p>
+                                            {% url 'singlepages:event-registration-terms' as terms_url %}
+                                            {% blocktrans trimmed %}
+                                                By registering,
+                                                you confirm that you have read the
+                                                <a target="_blank" href="{{ terms_url }}">terms and conditions</a>,
+                                                that you understand them and that you agree to be bound by them.
+                                            {% endblocktrans %}
+                                        </p>
+                                    {% else %}
+                                        <p>
+                                            {% blocktrans trimmed %}
+                                                Even though registration is not required for this event,
+                                                you can still register to give an indication of who will be there
+                                                as well as mark the event as 'registered' in your calendar.
+                                            {% endblocktrans %}
+                                        </p>
+                                    {% endif %}
                                     <form action="{% url 'events:register' event.id %}" method="post">{% csrf_token %}
                                         {% if event.reached_participants_limit %}
                                             <input type="submit" class="btn btn-primary"

--- a/website/events/tests/test_api.py
+++ b/website/events/tests/test_api.py
@@ -45,8 +45,8 @@ class RegistrationApiTest(TestCase):
 
     def test_registration_register_not_required(self):
         response = self.client.post("/api/v1/events/1/registrations/", follow=True)
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(self.event.participants.count(), 0)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(self.event.participants.count(), 1)
 
     def test_registration_register(self):
         self.event.registration_start = timezone.now() - datetime.timedelta(hours=1)

--- a/website/events/tests/test_views.py
+++ b/website/events/tests/test_views.py
@@ -158,7 +158,7 @@ class RegistrationTest(TestCase):
     def test_registration_register_not_required(self):
         response = self.client.post("/events/1/registration/register/", follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.event.participants.count(), 0)
+        self.assertEqual(self.event.participants.count(), 1)
 
     def test_registration_register(self):
         self.event.registration_start = timezone.now() - datetime.timedelta(hours=1)


### PR DESCRIPTION
Closes #1443

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I added the possibility to register for events that do not require it. That should make it possible to get an indication of how many people will be there, but also who, and also makes it possible to make it show up in your own calendar.

### How to test
Steps to test the changes you made:
1. Go to an event that does not require registration.
2. Click on "register".
3. Check that the user is now registered.

I did not test this very extensively, and it might be rough around the edges, so I'd be glad to hear about any deficiencies.