### PR TITLE
Fix http/https redirect for oauth in production/development

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -504,8 +504,8 @@ CORS_URLS_REGEX = r"^/(?:api/v1|api/v2|user/oauth)/.*"
 # OAuth configuration
 OAUTH2_PROVIDER = {
     "ALLOWED_REDIRECT_URI_SCHEMES": setting(
-        development=["https", APP_OAUTH_SCHEME],
-        production=["http", "https", APP_OAUTH_SCHEME],
+        production=["https", APP_OAUTH_SCHEME],
+        development=["http", "https", APP_OAUTH_SCHEME],
     ),
     "SCOPES": {
         "read": "Authenticated read access to the website",


### PR DESCRIPTION
### Summary
There was a mistake in the settings file where production and development settings were mixed up. This disallowed HTTP redirects in development but did allow it on production. This was obviously wrong.

### How to test
Steps to test the changes you made:
1. Make sure the OAuth authorization still works...