### PR TITLE
Fixed encoding bug in withdrawal notice issue

### DIFF
--- a/website/payments/templates/payments/email/tpay_withdrawal_notice_mail.txt
+++ b/website/payments/templates/payments/email/tpay_withdrawal_notice_mail.txt
@@ -1,3 +1,5 @@
+{% autoescape off %}
+
 Dear {{ name }},
 
 We would like to inform you that on {{ batch.withdrawal_date|date }}, we will withdraw an amount of € {{ total_amount|floatformat:2 }} from your bank account {{ bank_account.iban }}{% if bank_account.bic %}, {{ bank_account.bic }},{% endif %} to settle the following Thalia Pay payments:
@@ -17,3 +19,5 @@ In case you have any questions, you can contact treasurer@thalia.nu
 ————
 
 This email was automatically generated.
+
+{% endautoescape %}


### PR DESCRIPTION
Closes #1496

### Summary
When sending a withdrawal notice to a user after their Thalia Pay payment is processed in a batch, the withdrawal notice will display all characters correctly.

### How to test
1. Make sure your user has Thalia Pay enabled and is allowed to use Thalia pay
2. Add a 'Thalia Pay payment' to your user -> make sure the *topic* includes a special character (e.g. asterisk or apostrophe)
3. Add a payment batch
4. Return to the payment and add the payment to the batch
5. Process the batch
6. Check the console output, all characters in the withdrawal notice should be encoded and displayed correctly
