### PR TITLE
Prevent API from crashing when throttling on the anonymous user

### DIFF
--- a/website/thaliawebsite/api/throttling.py
+++ b/website/thaliawebsite/api/throttling.py
@@ -1,0 +1,38 @@
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class AnonRateThrottle(SimpleRateThrottle):
+    """Limits the rate of API calls that may be made by a anonymous users.
+
+    The IP address of the request will be used as the unique cache key.
+    """
+
+    scope = "anon"
+
+    def get_cache_key(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return None  # Only throttle unauthenticated requests.
+
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": self.get_ident(request),
+        }
+
+
+class UserRateThrottle(SimpleRateThrottle):
+    """Limits the rate of API calls that may be made by a given user.
+
+    The user id will be used as a unique cache key if the user is
+    authenticated.  For anonymous requests, the IP address of the request will
+    be used.
+    """
+
+    scope = "user"
+
+    def get_cache_key(self, request, view):
+        if request.user and request.user.is_authenticated:
+            ident = request.user.pk
+        else:
+            ident = self.get_ident(request)
+
+        return self.cache_format % {"scope": self.scope, "ident": ident}

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -560,8 +560,8 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "DEFAULT_SCHEMA_CLASS": "thaliawebsite.api.openapi.OAuthAutoSchema",
     "DEFAULT_THROTTLE_CLASSES": [
-        "rest_framework.throttling.AnonRateThrottle",
-        "rest_framework.throttling.UserRateThrottle",
+        "thaliawebsite.api.throttling.AnonRateThrottle",
+        "thaliawebsite.api.throttling.UserRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {"anon": "100/day", "user": "1000/day"},
 }


### PR DESCRIPTION
Closes #1583

### Summary
If you were using a the API using client credentials it would not work if no user has been attached to the application.

### How to test
Steps to test the changes you made:
1. Create an application with client_credentials
2. Use the credentials
3. Use the API
4. It crashes instantly
