### PR TITLE
Fix batch creation CSRF check

### DIFF
--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -220,7 +220,7 @@ class BatchTopicDescriptionAdminView(View):
 class BatchNewFilledAdminView(View):
     """View that adds a new batch filled with all payments that where not already in a batch."""
 
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         batch = Batch()
         batch.save()
 

--- a/website/payments/templates/admin/payments/change_list.html
+++ b/website/payments/templates/admin/payments/change_list.html
@@ -4,7 +4,8 @@
 {% block object-tools-items %}
     {% if opts.model_name == "payment" or opts.model_name == "batch" %}
     <li>
-        <a href="{% url 'admin:payments_batch_new_batch_filled' %}">{% trans "New batch from unbatched Thalia Pay payments" %}</a>
+        <form action="{% url 'admin:payments_batch_new_batch_filled' %}" id="new-batch" method="post">{% csrf_token %}</form>
+        <a onclick="document.getElementById('new-batch').submit();" href="#new-filled-batch">{% trans "New batch from unbatched Thalia Pay payments" %}</a>
     </li>
     {% endif %}
     {{ block.super }}

--- a/website/payments/tests/test_admin_views.py
+++ b/website/payments/tests/test_admin_views.py
@@ -594,18 +594,18 @@ class BatchNewFilledAdminViewTest(TestCase):
 
     def test_permission(self):
         url = "/admin/payments/batch/new_filled/"
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertRedirects(response, f"/admin/login/?next={url}")
 
         self._give_user_permissions()
 
-        response = self.client.get(url)
+        response = self.client.post(url)
 
         b = Batch.objects.exclude(id=self.batch.id).first()
         self.assertRedirects(response, f"/admin/payments/batch/{b.id}/change/")
 
     @freeze_time("2020-03-01")
-    def test_get(self):
+    def test_post(self):
         self._give_user_permissions()
 
         Payment.objects.bulk_create(
@@ -649,7 +649,7 @@ class BatchNewFilledAdminViewTest(TestCase):
             ]
         )
 
-        self.client.get("/admin/payments/batch/new_filled/")
+        self.client.post("/admin/payments/batch/new_filled/")
 
         b = Batch.objects.exclude(id=self.batch.id).first()
 


### PR DESCRIPTION
Closes #1600

### Summary

This PR fixes the new batch code and makes sure a POST request is done instead of a GET. This forces the usage of CSRF.

### How to test
Steps to test the changes you made:
1. Go to the payments batch admin
2. Click on the "New batch from unbatched Thalia Pay payments"
3. Check the browser network tab to see what request was executed
