### PR TITLE
Add extra filters for the members v2 API

### DIFF
--- a/website/members/api/v2/filters.py
+++ b/website/members/api/v2/filters.py
@@ -1,0 +1,50 @@
+from rest_framework import filters
+
+from members.models import Membership
+
+
+class StartingYearFilter(filters.BaseFilterBackend):
+    """Allows you to filter by starting year."""
+
+    def filter_queryset(self, request, queryset, view):
+        starting_year = request.query_params.get("starting_year", None)
+
+        if starting_year:
+            queryset = queryset.filter(profile__starting_year=starting_year)
+
+        return queryset
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                "name": "starting_year",
+                "required": False,
+                "in": "query",
+                "description": "Filter by starting year",
+                "schema": {"type": "number",},
+            }
+        ]
+
+
+class MembershipTypeFilter(filters.BaseFilterBackend):
+    """Allows you to filter by membership type."""
+
+    def filter_queryset(self, request, queryset, view):
+        membership_type = request.query_params.get("membership_type", None)
+
+        if membership_type:
+            memberships = Membership.objects.filter(type=membership_type)
+            queryset = queryset.filter(pk__in=memberships.values("user__pk"))
+
+        return queryset
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                "name": "membership_type",
+                "required": False,
+                "in": "query",
+                "description": "Filter by membership type",
+                "schema": {"type": "string",},
+            }
+        ]

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -2,7 +2,7 @@
 
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from django.shortcuts import get_object_or_404
-from rest_framework import filters
+from rest_framework import filters as framework_filters
 from rest_framework.generics import (
     ListAPIView,
     RetrieveAPIView,
@@ -10,6 +10,7 @@ from rest_framework.generics import (
 )
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
+from members.api.v2 import filters
 from thaliawebsite.api.openapi import OAuthAutoSchema
 from members.api.v2.serializers.member import (
     MemberSerializer,
@@ -31,8 +32,10 @@ class MemberListView(ListAPIView):
     ]
     required_scopes = ["members:read"]
     filter_backends = (
-        filters.OrderingFilter,
-        filters.SearchFilter,
+        framework_filters.OrderingFilter,
+        framework_filters.SearchFilter,
+        filters.MembershipTypeFilter,
+        filters.StartingYearFilter,
     )
     ordering_fields = ("first_name", "last_name", "username")
     search_fields = (


### PR DESCRIPTION
Part of #1428 

### Summary
Add extra filters for the members v2 API.

### How to test
Steps to test the changes you made:
1. Go to the API docs
2. Check that there are filters for the starting year and membership type.
3. Yay!
