### PR TITLE
Allow changing event registration information after publishing

### DIFF
--- a/website/events/admin.py
+++ b/website/events/admin.py
@@ -144,6 +144,11 @@ class EventAdmin(DoNextTranslatedModelAdmin):
         (_("Extra"), {"fields": ("slide", "documents"), "classes": ("collapse",)}),
     )
 
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form = super().get_form(request, obj, change, **kwargs)
+        form.clean = lambda form: form.instance.clean_changes(form.changed_data)
+        return form
+
     def overview_link(self, obj):
         return format_html(
             '<a href="{link}">{title}</a>',

--- a/website/events/admin.py
+++ b/website/events/admin.py
@@ -144,11 +144,6 @@ class EventAdmin(DoNextTranslatedModelAdmin):
         (_("Extra"), {"fields": ("slide", "documents"), "classes": ("collapse",)}),
     )
 
-    def get_form(self, request, obj=None, change=False, **kwargs):
-        form = super().get_form(request, obj, change, **kwargs)
-        form.clean = lambda form: form.instance.clean_changes(form.changed_data)
-        return form
-
     def overview_link(self, obj):
         return format_html(
             '<a href="{link}">{title}</a>',

--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -349,8 +349,8 @@ class Event(models.Model, metaclass=ModelTranslateMeta):
                         {"registration_start": message, "registration_end": message}
                     )
 
-        if self.published:
-            old_event = Event.objects.get(pk=self.pk)
+        old_event = Event.objects.get(pk=self.pk)
+        if old_event.published:
             if (
                 self.price != old_event.price
                 and old_event.registration_start


### PR DESCRIPTION
Closes #1607 

### Summary
It is now possible to change the price and the registration start and price as long as the registration has not started yet

### How to test
1. Create an event with registrations in the future
2. Publish the event
3. Try to change the registration start date or price
4. Profit
