### PR TITLE
Added DEFAULT_AUTO_FIELD setting

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -228,6 +228,9 @@ SESSION_COOKIE_SECURE = setting(development=False, production=True)
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-secure
 CSRF_COOKIE_SECURE = setting(development=False, production=True)
 
+# https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 ###############################################################################
 # Email settings
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend


### PR DESCRIPTION
Closes #1619 

### Summary
Added the `DEFAULT_AUTO_FIELD` to suppress all the warnings about the field not explicitly being set.
It is now explicitly set to `django.db.models.AutoField` which is a 32-bit integer field, before it was implicitly set to `django.db.models.AutoField`

### How to test
1. Run the server
2. Notice that there are now warnings about `DEFAULT_AUTO_FIELD`
