### PR TITLE
Small bugfixes to the sales admin

### DIFF
--- a/website/sales/admin/order_admin.py
+++ b/website/sales/admin/order_admin.py
@@ -187,21 +187,23 @@ class OrderAdmin(admin.ModelAdmin):
     fields = (
         "shift",
         "created_at",
-        "total_amount",
-        "num_items",
-        "discount",
-        "payment",
         "order_description",
+        "num_items",
         "age_restricted",
-        "payment_url",
+        "subtotal",
+        "discount",
+        "total_amount",
         "payer",
+        "payment",
+        "payment_url",
     )
 
     readonly_fields = (
         "created_at",
-        "total_amount",
-        "num_items",
         "order_description",
+        "num_items",
+        "subtotal",
+        "total_amount",
         "age_restricted",
         "payment_url",
     )
@@ -326,8 +328,23 @@ class OrderAdmin(admin.ModelAdmin):
             )
         return super().changelist_view(request, extra_context)
 
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        object_id
+        return super().change_view(request, object_id, form_url, extra_context)
+        # TODO WARN WHEN ORDER IS AGE RESTRICTED AND PAYER IS UNDERAGE
+
+    def order_description(self, obj):
+        if obj.order_description:
+            return obj.order_description
+        return "-"
+
     def num_items(self, obj):
         return obj.num_items
+
+    def subtotal(self, obj):
+        if obj.subtotal:
+            return f"€{obj.subtotal:.2f}"
+        return "-"
 
     def discount(self, obj):
         if obj.discount:

--- a/website/sales/admin/shift_admin.py
+++ b/website/sales/admin/shift_admin.py
@@ -108,20 +108,25 @@ class ShiftAdmin(admin.ModelAdmin):
         "end",
         "active",
         "product_list",
+        "managers",
         "product_sales",
         "num_orders",
         "total_revenue",
         "locked",
-        "managers",
     )
 
     readonly_fields = (
-        "title",
         "active",
         "total_revenue",
         "num_orders",
         "product_sales",
     )
+
+    def get_readonly_fields(self, request, obj=None):
+        fields = super().get_readonly_fields(request, obj)
+        if not obj:
+            fields += ("locked",)
+        return fields
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)


### PR DESCRIPTION
### Summary
After merging #1445 I found some minor bugs in the sales admin. This PR fixes them

### How to test
1. The shift title field in the admin is actually readable
2. It is possible to create a shift without setting any managers
3. It is not possible anymore to lock a shift directly when creating it
4. The order of the fields in the shift admin makes more sense