### PR TITLE
Remove mention of suffix mailing list

### DIFF
--- a/website/mailinglists/templates/admin/mailinglists/change_list.html
+++ b/website/mailinglists/templates/admin/mailinglists/change_list.html
@@ -76,9 +76,6 @@
             </tbody>
             </table>
         </div>
-        <p class="paginator">
-            {% trans "Support for the language code suffix means that adding <code>-en</code> of <code>-nl</code> to the name will only send this email to users with that specific preferred language on their profiles." %}
-        </p>
         <div class="clear"></div>
     </div>
     <br />


### PR DESCRIPTION

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Removed the line in the mailinglist admin about -en and -nl suffixes as those lists don't exist anymore.

### How to test
Steps to test the changes you made:
1. Go to mailinglist admin
2. See that the line is removed
