### PR TITLE
Allow HTTP OAuth redirects on staging

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -510,6 +510,7 @@ CORS_URLS_REGEX = r"^/(?:api/v1|api/v2|user/oauth)/.*"
 OAUTH2_PROVIDER = {
     "ALLOWED_REDIRECT_URI_SCHEMES": setting(
         production=["https", APP_OAUTH_SCHEME],
+        staging=["http", "https", APP_OAUTH_SCHEME],
         development=["http", "https", APP_OAUTH_SCHEME],
     ),
     "SCOPES": {


### PR DESCRIPTION
### Summary
Allow HTTP OAUTH redirects on staging. This is nice to test out OAuth applications, like Thadmin, during development (and as it is staging I don't care too much about the security)

### How to test
