### PR TITLE
Fix crash on `api/v2/members/me/`

### DIFF
--- a/website/members/api/v2/serializers/member.py
+++ b/website/members/api/v2/serializers/member.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from members.api.v2.serializers.profile import ProfileSerializer
 from members.models import Member
@@ -52,6 +53,9 @@ class MemberSerializer(serializers.ModelSerializer):
         return None
 
     def update(self, instance, validated_data):
+        if "profile" not in validated_data:
+            raise ValidationError("profile field is missing")
+
         profile_data = validated_data.pop("profile")
         instance.profile = self.fields["profile"].update(
             instance=instance.profile, validated_data=profile_data


### PR DESCRIPTION
Closes #1627 

### Summary
`api/v2/members/me/` would crash if there was no `profile` field. It'll now return a 500

### How to test
Steps to test the changes you made:
1. Go to `api/v2/members/me/`
2. Select the `Raw data` ab at the bottom of the page
3. Remove the `profile` object
4. Click `PATCH`
5. No 500
