### PR TITLE
Refactor Payables to use a registry

### DIFF
--- a/website/events/apps.py
+++ b/website/events/apps.py
@@ -8,3 +8,9 @@ class EventsConfig(AppConfig):
 
     name = "events"
     verbose_name = _("Events")
+
+    def ready(self):
+        # pylint: disable=import-outside-toplevel
+        from .payables import register
+
+        register()

--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -1,12 +1,10 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
-from django.template.defaulttags import date
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from payments.models import Payable
-from . import Event
+from .event import Event
 
 
 def registration_member_choices_limit():
@@ -16,7 +14,7 @@ def registration_member_choices_limit():
     )
 
 
-class EventRegistration(models.Model, Payable):
+class EventRegistration(models.Model):
     """Describes a registration for an Event."""
 
     event = models.ForeignKey(Event, models.CASCADE)
@@ -136,28 +134,6 @@ class EventRegistration(models.Model, Payable):
         if self.member:
             return "{}: {}".format(self.member.get_full_name(), self.event)
         return "{}: {}".format(self.name, self.event)
-
-    @property
-    def payment_amount(self):
-        return self.event.price
-
-    @property
-    def payment_topic(self):
-        return f'{self.event.title_en} [{date(self.event.start, "Y-m-d")}]'
-
-    @property
-    def payment_notes(self):
-        notes = f"Event registration {self.event.title_en}. "
-        notes += f"{date(self.event.start)}. Registration date: {date(self.date)}."
-        return notes
-
-    @property
-    def payment_payer(self):
-        return self.member
-
-    @property
-    def tpay_allowed(self):
-        return self.event.tpay_allowed
 
     class Meta:
         verbose_name = _("Registration")

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -293,7 +293,7 @@ def update_registration_by_organiser(registration, member, data):
                 delete_payment(registration)
         else:
             registration.payment = create_payment(
-                payable=registration,
+                model_payable=registration,
                 processed_by=member,
                 pay_type=data["payment"]["type"],
             )

--- a/website/payments/__init__.py
+++ b/website/payments/__init__.py
@@ -1,0 +1,1 @@
+from .payables import *

--- a/website/payments/api/v1/viewsets/payments.py
+++ b/website/payments/api/v1/viewsets/payments.py
@@ -56,7 +56,7 @@ class PaymentViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
             services.create_payment(
                 payable, PaymentUser.objects.get(pk=request.user.pk), Payment.TPAY,
             )
-            payable.save()
+            payable.model.save()
         except PaymentError as e:
             raise ValidationError(detail=str(e))
 

--- a/website/payments/models.py
+++ b/website/payments/models.py
@@ -396,31 +396,3 @@ class BankAccount(models.Model):
 
     class Meta:
         ordering = ("created_at",)
-
-
-class Payable:
-    pk = None
-    payment = None
-
-    @property
-    def payment_amount(self):
-        raise NotImplementedError
-
-    @property
-    def payment_topic(self):
-        raise NotImplementedError
-
-    @property
-    def payment_notes(self):
-        raise NotImplementedError
-
-    @property
-    def payment_payer(self):
-        raise NotImplementedError
-
-    def save(self):
-        raise NotImplementedError
-
-    @property
-    def tpay_allowed(self):
-        return True

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -1,0 +1,69 @@
+from functools import lru_cache
+
+from django.db.models import Model
+
+_registry = {}
+
+
+class NotRegistered(Exception):
+    pass
+
+
+class Payable:
+    def __init__(self, model: Model):
+        self.model = model
+
+    @property
+    def pk(self):
+        return self.model.pk
+
+    @property
+    def payment(self):
+        return self.model.payment
+
+    @payment.setter
+    def payment(self, payment):
+        self.model.payment = payment
+
+    @property
+    def payment_amount(self):
+        raise NotImplementedError
+
+    @property
+    def payment_topic(self):
+        raise NotImplementedError
+
+    @property
+    def payment_notes(self):
+        raise NotImplementedError
+
+    @property
+    def payment_payer(self):
+        raise NotImplementedError
+
+    @property
+    def tpay_allowed(self):
+        return True
+
+    def can_create_payment(self, member):
+        raise NotImplementedError
+
+
+class Payables:
+    _registry = {}
+
+    @lru_cache(maxsize=None)
+    def _get_key(self, model):
+        return f"{model._meta.app_label}_{model._meta.model_name}"
+
+    @lru_cache(maxsize=None)
+    def get_payable(self, model: Model) -> Payable:
+        if self._get_key(model) not in self._registry:
+            raise NotRegistered(f"No Payable registered for {self._get_key(model)}")
+        return self._registry[self._get_key(model)](model)
+
+    def register(self, model: Model, payable_class: Payable):
+        self._registry[self._get_key(model)] = payable_class
+
+
+payables = Payables()

--- a/website/payments/tests/__mocks__.py
+++ b/website/payments/tests/__mocks__.py
@@ -1,15 +1,22 @@
 from unittest.mock import MagicMock
 
-from payments.models import Payable
+from django.db.models import Model
+
+from payments import Payable
 
 
-class MockPayable(Payable):
-    save = MagicMock()
+class MockModel:
+    class Meta:
+        app_label = "mock_app"
+        model_name = "mock_model"
+
+    payment = None
+    pk = 1
+    _meta = Meta()
 
     def __init__(
         self, payer, amount=5, topic="mock topic", notes="mock notes", payment=None
     ) -> None:
-        super().__init__()
         self.payer = payer
         self.amount = amount
         self.topic = topic
@@ -19,20 +26,29 @@ class MockPayable(Payable):
         # Because we have to do as if this is a model sometimes
         self.verbose_name = "MockPayable"
         self.verbose_name_plural = self.verbose_name + "s"
-        self.pk = 0
+
+    def save(self):
+        pass
+
+
+class MockPayable(Payable):
+    save = MagicMock()
 
     @property
     def payment_amount(self):
-        return self.amount
+        return self.model.amount
 
     @property
     def payment_topic(self):
-        return self.topic
+        return self.model.topic
 
     @property
     def payment_notes(self):
-        return self.notes
+        return self.model.notes
 
     @property
     def payment_payer(self):
-        return self.payer
+        return self.model.payer
+
+    def can_create_payment(self, member):
+        return False

--- a/website/payments/tests/test_models.py
+++ b/website/payments/tests/test_models.py
@@ -7,41 +7,41 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from payments import services
-from payments.models import Payment, BankAccount, Batch, Payable, PaymentUser
-from payments.tests.__mocks__ import MockPayable
+from payments import services, Payable
+from payments.models import Payment, BankAccount, Batch, PaymentUser
+from payments.tests.__mocks__ import MockPayable, MockModel
 
 
 class PayableTest(TestCase):
     """Tests for the Payable class."""
 
     def test_payment_amount_not_implemented(self):
-        p = Payable()
+        p = Payable(None)
         with self.assertRaises(NotImplementedError):
             _ = p.payment_amount
 
     def test_payment_topic_not_implemented(self):
-        p = Payable()
+        p = Payable(None)
         with self.assertRaises(NotImplementedError):
             _ = p.payment_topic
 
     def test_payment_notes_not_implemented(self):
-        p = Payable()
+        p = Payable(None)
         with self.assertRaises(NotImplementedError):
             _ = p.payment_notes
 
     def test_payment_payer_not_implemented(self):
-        p = Payable()
+        p = Payable(None)
         with self.assertRaises(NotImplementedError):
             _ = p.payment_payer
 
-    def test_save_not_implemented(self):
-        p = Payable()
+    def test_can_create_payment_not_implemented(self):
+        p = Payable(None)
         with self.assertRaises(NotImplementedError):
-            p.save()
+            p.can_create_payment(None)
 
     def test_tpay_allowed_by_default(self):
-        p = Payable()
+        p = Payable(None)
         self.assertTrue(p.tpay_allowed)
 
 
@@ -455,12 +455,12 @@ class PaymentUserTest(TestCase):
             signature="base64,png",
         )
         p1 = services.create_payment(
-            MockPayable(self.member), self.member, Payment.TPAY
+            MockPayable(MockModel(self.member)), self.member, Payment.TPAY
         )
         self.assertEqual(self.member.tpay_balance, Decimal(-5))
 
         p2 = services.create_payment(
-            MockPayable(self.member), self.member, Payment.TPAY
+            MockPayable(MockModel(self.member)), self.member, Payment.TPAY
         )
         self.assertEqual(self.member.tpay_balance, Decimal(-10))
 

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from payments import payables, NotRegistered
+from payments.tests.__mocks__ import MockModel, MockPayable
+
+
+class PayablesTest(TestCase):
+    def setUp(self):
+        payables.register(MockModel, MockPayable)
+
+    def test_registered_payable(self):
+        self.assertIsInstance(payables.get_payable(MockModel), MockPayable)
+
+    def test_not_registered_payable(self):
+        payables._registry = {}
+        with self.assertRaises(NotRegistered):
+            payables.get_payable(MockModel)

--- a/website/payments/views.py
+++ b/website/payments/views.py
@@ -22,7 +22,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView
 from django.views.generic.edit import CreateView, UpdateView, FormView
 
-from payments import services
+from payments import services, payables
 from payments.exceptions import PaymentError
 from payments.forms import BankAccountForm, PaymentCreateForm, BankAccountUserRevokeForm
 from payments.models import BankAccount, Payment, PaymentUser
@@ -210,7 +210,7 @@ class PaymentProcessView(SuccessMessageMixin, FormView):
         payable_pk = request.POST["payable"]
 
         payable_model = apps.get_model(app_label=app_label, model_name=model_name)
-        self.payable = payable_model.objects.get(pk=payable_pk)
+        self.payable = payables.get_payable(payable_model.objects.get(pk=payable_pk))
 
         if (
             self.payable.payment_payer.pk
@@ -249,7 +249,7 @@ class PaymentProcessView(SuccessMessageMixin, FormView):
                 PaymentUser.objects.get(pk=self.request.member.pk),
                 Payment.TPAY,
             )
-            self.payable.save()
+            self.payable.model.save()
         except PaymentError as e:
             messages.error(self.request, str(e))
         return super().form_valid(form)

--- a/website/pizzas/apps.py
+++ b/website/pizzas/apps.py
@@ -13,3 +13,7 @@ class PizzasConfig(AppConfig):
         """Import the signals when the app is ready."""
         # pylint: disable=unused-import,import-outside-toplevel
         from . import signals
+
+        from .payables import register
+
+        register()

--- a/website/pizzas/models.py
+++ b/website/pizzas/models.py
@@ -4,12 +4,11 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from django.template.defaulttags import date
 
 from events.models import Event
 import members
 from members.models import Member
-from payments.models import Payment, Payable
+from payments.models import Payment
 from payments.services import delete_payment
 from pushnotifications.models import ScheduledMessage, Category
 from utils.translation import ModelTranslateMeta, MultilingualField
@@ -164,7 +163,7 @@ class Product(models.Model, metaclass=ModelTranslateMeta):
         permissions = (("order_restricted_products", _("Order restricted products")),)
 
 
-class Order(models.Model, Payable):
+class Order(models.Model):
     """Describes an order of an item during an event."""
 
     member = models.ForeignKey(
@@ -195,26 +194,6 @@ class Order(models.Model, Payable):
     pizza_event = models.ForeignKey(
         verbose_name=_("event"), to=PizzaEvent, on_delete=models.CASCADE
     )
-
-    @property
-    def payment_amount(self):
-        return self.product.price
-
-    @property
-    def payment_topic(self):
-        start_date = date(self.pizza_event.start, "Y-m-d")
-        return f"Pizzas {self.pizza_event.event.title_en} [{start_date}]"
-
-    @property
-    def payment_notes(self):
-        return (
-            f"Pizza order by {self.member_name} "
-            f"for {self.pizza_event.event.title_en}"
-        )
-
-    @property
-    def payment_payer(self):
-        return self.member
 
     def clean(self):
         if (self.member is None and not self.name) or (self.member and self.name):

--- a/website/pizzas/payables.py
+++ b/website/pizzas/payables.py
@@ -1,0 +1,34 @@
+from django.template.defaultfilters import date
+
+from payments import Payable, payables
+from pizzas.models import Order
+from pizzas.services import can_change_order
+
+
+class FoodOrderPayable(Payable):
+    @property
+    def payment_amount(self):
+        return self.model.product.price
+
+    @property
+    def payment_topic(self):
+        start_date = date(self.model.pizza_event.start, "Y-m-d")
+        return f"Pizzas {self.model.pizza_event.event.title_en} [{start_date}]"
+
+    @property
+    def payment_notes(self):
+        return (
+            f"Pizza order by {self.model.member_name} "
+            f"for {self.model.pizza_event.event.title_en}"
+        )
+
+    @property
+    def payment_payer(self):
+        return self.model.member
+
+    def can_create_payment(self, member):
+        return can_change_order(member, self.model.pizza_event)
+
+
+def register():
+    payables.register(Order, FoodOrderPayable)

--- a/website/registrations/apps.py
+++ b/website/registrations/apps.py
@@ -13,3 +13,6 @@ class RegistrationsConfig(AppConfig):
         """Import the signals when the app is ready."""
         # pylint: disable=unused-import,import-outside-toplevel
         from . import signals
+        from .payables import register
+
+        register()

--- a/website/registrations/payables.py
+++ b/website/registrations/payables.py
@@ -1,0 +1,49 @@
+from django.template.defaultfilters import date
+
+from payments.payables import Payable, payables
+from registrations.models import Renewal, Registration, Entry
+
+
+class EntryPayable(Payable):
+    @property
+    def payment_amount(self):
+        return self.model.contribution
+
+    @property
+    def payment_payer(self):
+        if self.model.membership:
+            return self.model.membership.user
+        return None
+
+    @property
+    def payment_topic(self):
+        return "Registration entry"
+
+    @property
+    def payment_notes(self):
+        return f"{self.payment_topic}. Creation date: {date(self.model.created_at)}. Completion date: {date(self.model.updated_at)}"
+
+    def can_create_payment(self, member):
+        return False
+
+
+class RegistrationPayable(EntryPayable):
+    @property
+    def payment_topic(self):
+        return f"Membership registration {self.model.membership_type} ({self.model.length})"
+
+
+class RenewalPayable(EntryPayable):
+    @property
+    def payment_payer(self):
+        return self.model.member
+
+    @property
+    def payment_topic(self):
+        return f"Membership renewal {self.model.membership_type} ({self.model.length})"
+
+
+def register():
+    payables.register(Entry, EntryPayable)
+    payables.register(Renewal, RenewalPayable)
+    payables.register(Registration, RegistrationPayable)

--- a/website/registrations/tests/test_models.py
+++ b/website/registrations/tests/test_models.py
@@ -126,27 +126,6 @@ class EntryTest(TestCase):
             entry.contribution = 7.5
             entry.clean()
 
-    @freeze_time("2019-01-01")
-    def test_payable_attributes(self):
-        entry = Entry(
-            contribution=8,
-            length=Entry.MEMBERSHIP_YEAR,
-            registration=self.registration,
-        )
-
-        self.assertEqual(entry.payment_amount, 8)
-        self.assertEqual(
-            entry.payment_notes,
-            "Registration entry. Creation date: Jan. 1, 2019. Completion date: Jan. 1, 2019",
-        )
-
-        with self.subTest("Without membership"):
-            self.assertEqual(entry.payment_payer, None)
-
-        with self.subTest("With membership"):
-            entry.membership = Membership(user=self.member)
-            self.assertEqual(entry.payment_payer, self.member)
-
 
 @override_settings(SUSPEND_SIGNALS=True)
 @freeze_time("2019-01-01")
@@ -286,13 +265,6 @@ class RegistrationTest(TestCase):
         self.registration.membership_type = Membership.BENEFACTOR
         self.registration.contribution = 7.5
         self.registration.clean()
-
-    def test_payable_attributes(self):
-        self.assertEqual(self.registration.payment_amount, 7.5)
-        self.assertEqual(
-            self.registration.payment_notes,
-            "Membership registration member (year). Creation date: Jan. 1, 2019. Completion date: Jan. 1, 2019",
-        )
 
     def test_require_bank_details(self):
         self.registration.direct_debit = True
@@ -436,14 +408,6 @@ class RenewalTest(TestCase):
                     "membership_type": "You currently have an active membership.",
                 },
             )
-
-    def test_payable_attributes(self):
-        self.assertEqual(self.renewal.payment_amount, 8)
-        self.assertEqual(
-            self.renewal.payment_notes,
-            "Membership renewal member (study). Creation date: Jan. 1, 2019. Completion date: Jan. 1, 2019",
-        )
-        self.assertEqual(self.renewal.payment_payer, self.renewal.member)
 
 
 @override_settings(SUSPEND_SIGNALS=True)

--- a/website/registrations/tests/test_payables.py
+++ b/website/registrations/tests/test_payables.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from members.models import Membership
+from registrations.payables import EntryPayable, RegistrationPayable, RenewalPayable
+
+
+class EntryPayableTest(TestCase):
+    def setUp(self):
+        self.model = MagicMock()
+        self.model.contribution = 2
+        self.model.membership = MagicMock()
+        self.model.membership.user = "user"
+        self.model.created_at = datetime(2018, 3, 4, 12, 0, 0)
+        self.model.updated_at = datetime(2018, 3, 5, 12, 0, 0)
+
+        self.payable = EntryPayable(self.model)
+
+    def test_attributes(self):
+        self.assertEqual(self.payable.payment_amount, 2)
+        self.assertEqual(self.payable.payment_payer, "user")
+        self.payable.model.membership = None
+        self.assertEqual(self.payable.payment_payer, None)
+        self.assertEqual(self.payable.payment_topic, "Registration entry")
+        self.assertEqual(
+            self.payable.payment_notes,
+            "Registration entry. Creation date: March 4, 2018. Completion date: March 5, 2018",
+        )
+        self.assertFalse(self.payable.can_create_payment(None))
+
+
+class RegistrationPayableTest(TestCase):
+    def setUp(self):
+        self.model = MagicMock()
+        self.model.contribution = 2
+        self.model.membership = MagicMock()
+        self.model.membership.user = "user"
+        self.model.length = "1 year"
+        self.model.membership_type = Membership.BENEFACTOR
+        self.model.created_at = datetime(2018, 3, 4, 12, 0, 0)
+        self.model.updated_at = datetime(2018, 3, 5, 12, 0, 0)
+
+        self.payable = RegistrationPayable(self.model)
+
+    def test_attributes(self):
+        self.assertEqual(
+            self.payable.payment_topic, "Membership registration benefactor (1 year)"
+        )
+
+
+class RenewalPayableTest(TestCase):
+    def setUp(self):
+        self.model = MagicMock()
+        self.model.contribution = 2
+        self.model.membership = MagicMock()
+        self.model.member = "member"
+        self.model.length = "1 year"
+        self.model.membership_type = Membership.BENEFACTOR
+        self.model.created_at = datetime(2018, 3, 4, 12, 0, 0)
+        self.model.updated_at = datetime(2018, 3, 5, 12, 0, 0)
+
+        self.payable = RenewalPayable(self.model)
+
+    def test_attributes(self):
+        self.assertEqual(self.payable.payment_payer, "member")
+        self.assertEqual(
+            self.payable.payment_topic, "Membership renewal benefactor (1 year)"
+        )

--- a/website/registrations/tests/test_services.py
+++ b/website/registrations/tests/test_services.py
@@ -10,7 +10,7 @@ from freezegun import freeze_time
 
 from members.models import Member, Membership
 from payments.models import Payment, BankAccount
-from registrations import services
+from registrations import services, payables
 from registrations.models import Entry, Registration, Renewal
 from utils.snippets import datetime_to_lectureyear
 
@@ -21,6 +21,8 @@ class ServicesTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        payables.register()
+
         cls.e0 = Entry.objects.create(
             length=Entry.MEMBERSHIP_YEAR,
             membership_type=Membership.MEMBER,

--- a/website/sales/migrations/0001_initial.py
+++ b/website/sales/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                 'ordering': ['created_at'],
                 'permissions': [('custom_prices', 'Can use custom prices and discounts in orders')],
             },
-            bases=(models.Model, payments.models.Payable),
+            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='Product',

--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -22,7 +22,7 @@ from queryable_properties.managers import QueryablePropertiesManager
 from queryable_properties.properties import AnnotationProperty
 
 from members.models import uuid, Member
-from payments.models import Payable, Payment
+from payments.models import Payment
 from sales.models.product import ProductListItem
 from sales.models.shift import Shift
 
@@ -31,7 +31,7 @@ def default_order_shift():
     return Shift.objects.filter(active=True).first()
 
 
-class Order(models.Model, Payable):
+class Order(models.Model):
 
     objects = QueryablePropertiesManager()
 
@@ -149,26 +149,8 @@ class Order(models.Model, Payable):
             raise ValidationError(errors)
 
     @property
-    def payment_amount(self):
-        return self.total_amount
-
-    @property
-    def payment_topic(self):
-        return f"Sales at {self.shift}"
-
-    @property
     def order_description(self):
         return ", ".join(str(x) for x in self.order_items.all())
-
-    @property
-    def payment_notes(self):
-        return (
-            f"{self.order_description}. Ordered at {self.created_at.time()} ({self.id})"
-        )
-
-    @property
-    def payment_payer(self):
-        return self.payer
 
     @property
     def accept_payment_from_any_user(self):
@@ -179,7 +161,7 @@ class Order(models.Model, Payable):
         return (
             settings.BASE_URL + reverse("sales:order-pay", kwargs={"pk": self.pk})
             if not self.payment
-            and (self.payment_amount is not None and self.payment_amount != 0)
+            and (self.total_amount is not None and self.total_amount != 0)
             else None
         )
 

--- a/website/sales/payables.py
+++ b/website/sales/payables.py
@@ -1,0 +1,27 @@
+from payments import Payable, payables
+from sales.models.order import Order
+
+
+class OrderPayable(Payable):
+    @property
+    def payment_amount(self):
+        return self.model.total_amount
+
+    @property
+    def payment_topic(self):
+        return f"Sales at {self.model.shift}"
+
+    @property
+    def payment_notes(self):
+        return f"{self.model.order_description}. Ordered at {self.model.created_at.time()} ({self.model.id})"
+
+    @property
+    def payment_payer(self):
+        return self.model.payer
+
+    def can_create_payment(self, member):
+        return True
+
+
+def register():
+    payables.register(Order, OrderPayable)

--- a/website/sales/tests/test_admin.py
+++ b/website/sales/tests/test_admin.py
@@ -13,7 +13,7 @@ from activemembers.models import Committee, MemberGroupMembership
 from members.models import Member
 from payments.models import Payment
 from payments.services import create_payment
-from sales import admin
+from sales import payables
 from sales.admin.order_admin import OrderAdmin
 from sales.admin.shift_admin import ShiftAdmin
 from sales.models.order import Order, OrderItem
@@ -26,6 +26,8 @@ class OrderAdminTest(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
+        payables.register()
+
         cls.user = Member.objects.filter(last_name="Wiggers").first()
 
         cls.beer = Product.objects.create(name="beer", age_restricted=True)


### PR DESCRIPTION
This rewrites the Payable working to use a registry instead of the models directly so that some logic can be outside the entity and we do not get circular dependencies.

It should not actually change any workings, and the only changes made to get the tests to work again were really to register the right models.

The implementation is inspired a lot by the way Django admin sites work, unfortunately decorators do not seem to work on models directly.