### PR TITLE
Use correct total amount calculation when saving orders

### DIFF
--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -118,12 +118,7 @@ class Order(models.Model, Payable):
             return
         if self.shift.start > timezone.now():
             return
-        if (
-            self.payment
-            and float(sum(self.order_items.values_list("total", flat=True)))
-            - (self.discount or 0)
-            != self.payment.amount
-        ):
+        if self.payment and self.total_amount != self.payment.amount:
             return
         if self.payment and not self.payer:
             self.payer = self.payment.paid_by

--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -115,11 +115,13 @@ class Order(models.Model, Payable):
         self, force_insert=False, force_update=False, using=None, update_fields=None
     ):
         if self.shift.locked:
-            return
+            raise ValueError("The shift this order belongs to is locked.")
         if self.shift.start > timezone.now():
-            return
+            raise ValueError("The shift hasn't started yet.")
         if self.payment and self.total_amount != self.payment.amount:
-            return
+            raise ValueError(
+                "The payment amount does not match the order total amount."
+            )
         if self.payment and not self.payer:
             self.payer = self.payment.paid_by
 
@@ -223,9 +225,9 @@ class OrderItem(models.Model):
         self, force_insert=False, force_update=False, using=None, update_fields=None
     ):
         if self.order.shift.locked:
-            return
+            raise ValueError("The shift this order belongs to is locked.")
         if self.order.payment:
-            return
+            raise ValueError("This order has already been paid for.")
 
         if not self.total:
             self.total = self.product.price * self.amount

--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -118,7 +118,11 @@ class Order(models.Model, Payable):
             raise ValueError("The shift this order belongs to is locked.")
         if self.shift.start > timezone.now():
             raise ValueError("The shift hasn't started yet.")
-        if self.payment and self.total_amount != self.payment.amount:
+        if (
+            self.payment
+            and self.subtotal - Decimal(self.discount or 0) != self.payment.amount
+        ):
+            # We cannot use self.total_amount as it is a requires a database query and hence will not use any updated values
             raise ValueError(
                 "The payment amount does not match the order total amount."
             )


### PR DESCRIPTION
Closes #1675

### Summary
Previously, we didn't use the general queryable property when checking to save a payment. This PR fixes that, to prevent #1675 from occurring


### How to test
For example, create an order of 3x a €1,20 product ⇒ €3,60 total. Paying this via Thalia pay doesn't work on master, but it does work after this PR