### PR TITLE
Use right site_url in event details admin

### DIFF
--- a/website/events/admin_views.py
+++ b/website/events/admin_views.py
@@ -37,7 +37,7 @@ class EventAdminDetails(DetailView, PermissionRequiredMixin):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context.update({"payment": Payment, "has_permission": True, "site_url": True})
+        context.update({"payment": Payment, "has_permission": True, "site_url": "/"})
 
         return context
 


### PR DESCRIPTION
Closes #969 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
You now get redirected to the homepage of the site when you click on `VIEW SITE` when you're in the event details admin

### How to test
Steps to test the changes you made:
1. Go to the event details in the admin
2. Click on `VIEW SITE` (top right)
3. Get redirected to the homepage
