### PR TITLE
Change api to show non-current FoodEvents

### DIFF
--- a/website/pizzas/api/v2/views.py
+++ b/website/pizzas/api/v2/views.py
@@ -28,7 +28,7 @@ class FoodEventListView(ListAPIView):
     """Returns an overview of all food events."""
 
     serializer_class = FoodEventSerializer
-    queryset = FoodEvent.current_objects.all()
+    queryset = FoodEvent.objects.all()
     filter_backends = (
         framework_filters.OrderingFilter,
         filters.FoodEventDateFilterBackend,
@@ -45,7 +45,7 @@ class FoodEventDetailView(RetrieveAPIView):
     """Returns one single food event."""
 
     serializer_class = FoodEventSerializer
-    queryset = FoodEvent.current_objects.all()
+    queryset = FoodEvent.objects.all()
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
         DjangoModelPermissionsOrAnonReadOnly,


### PR DESCRIPTION
Closes #1679 

### Summary
This changes the api to also return food events that you can not currently order from.

### How to test
Steps to test the changes you made:
1. make a future or past food event
2. check it out in api v2.
