### PR TITLE
Prevent crash in leap year

### DIFF
--- a/website/members/services.py
+++ b/website/members/services.py
@@ -79,6 +79,9 @@ def member_achievements(member) -> List:
         # Ensure mentorships appear last but are sorted
         earliest = date.today()
         earliest = earliest.replace(year=earliest.year + mentor_year.year)
+        # Making sure it does not crash in leap years
+        if earliest.month == 2 and earliest.day == 29:
+            earliest = earliest.replace(day=28)
         if not achievements.get(name):
             achievements[name] = {
                 "name": name,


### PR DESCRIPTION
Closes #1014

### Summary
On leap years the function to get the mentor year would crash because the 29th of Feb does not exist in most years.

### How to test
Steps to test the changes you made:
1. Set your day to 29 February
2. Check the member profile pages
