### PR TITLE
Filter and search for groups in api v2

### DIFF
--- a/website/activemembers/api/v2/filters.py
+++ b/website/activemembers/api/v2/filters.py
@@ -39,7 +39,7 @@ class MemberGroupDateFilter(filters.BaseFilterBackend):
         start, end = extract_date_range(request, allow_empty=True)
 
         if start is not None:
-            queryset = queryset.filter(Q(until__isnull=True) | Q(until_gte=start))
+            queryset = queryset.filter(Q(until__isnull=True) | Q(until__gte=start))
         if end is not None:
             queryset = queryset.filter(Q(since__isnull=True) | Q(since__lte=end))
 

--- a/website/activemembers/api/v2/filters.py
+++ b/website/activemembers/api/v2/filters.py
@@ -1,0 +1,65 @@
+from django.db.models import Q
+from rest_framework import filters
+
+from activemembers.models import Board, Committee, Society
+from utils.snippets import extract_date_range
+
+
+class MemberGroupTypeFilter(filters.BaseFilterBackend):
+    """Allows you to filter by organiser id."""
+
+    def filter_queryset(self, request, queryset, view):
+        type = request.query_params.get("type", None)
+
+        if type:
+            if type == "board":
+                queryset = Board.objects.all()
+            elif type == "committee":
+                queryset = Committee.objects.all()
+            elif type == "society":
+                queryset = Society.objects.all()
+
+        return queryset
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                "name": "type",
+                "required": False,
+                "in": "query",
+                "description": "Filter by member group type",
+                "schema": {"type": "string", "enum": ["board", "committee", "society"]},
+            }
+        ]
+
+
+class MemberGroupDateFilter(filters.BaseFilterBackend):
+    """Allows you to filter by event start/end dates."""
+
+    def filter_queryset(self, request, queryset, view):
+        start, end = extract_date_range(request, allow_empty=True)
+
+        if start is not None:
+            queryset = queryset.filter(Q(until__isnull=True) | Q(until_gte=start))
+        if end is not None:
+            queryset = queryset.filter(Q(since__isnull=True) | Q(since__lte=end))
+
+        return queryset
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                "name": "start",
+                "required": False,
+                "in": "query",
+                "description": "Filter member groups by ISO date, starting with this parameter (e.g. 2021-03-30T04:20:00) where `group.until >= value`",
+                "schema": {"type": "string", "format": "date-time"},
+            },
+            {
+                "name": "end",
+                "required": False,
+                "in": "query",
+                "description": "Filter member groups by ISO date, ending with this parameter (e.g. 2021-05-16T13:37:00) where `group.since <= value`",
+                "schema": {"type": "string", "format": "date-time"},
+            },
+        ]

--- a/website/activemembers/api/v2/filters.py
+++ b/website/activemembers/api/v2/filters.py
@@ -12,11 +12,11 @@ class MemberGroupTypeFilter(filters.BaseFilterBackend):
         type = request.query_params.get("type", None)
 
         if type == "board":
-            queryset = Board.active_objects.all()
+            queryset = queryset.filter(pk__in=Board.active_objects.values("pk"))
         elif type == "committee":
-            queryset = Committee.active_objects.all()
+            queryset = queryset.filter(pk__in=Committee.active_objects.values("pk"))
         elif type == "society":
-            queryset = Society.active_objects.all()
+            queryset = queryset.filter(pk__in=Society.active_objects.values("pk"))
 
         return queryset
 

--- a/website/activemembers/api/v2/filters.py
+++ b/website/activemembers/api/v2/filters.py
@@ -11,13 +11,12 @@ class MemberGroupTypeFilter(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         type = request.query_params.get("type", None)
 
-        if type:
-            if type == "board":
-                queryset = Board.objects.all()
-            elif type == "committee":
-                queryset = Committee.objects.all()
-            elif type == "society":
-                queryset = Society.objects.all()
+        if type == "board":
+            queryset = Board.active_objects.all()
+        elif type == "committee":
+            queryset = Committee.active_objects.all()
+        elif type == "society":
+            queryset = Society.active_objects.all()
 
         return queryset
 

--- a/website/activemembers/api/v2/urls.py
+++ b/website/activemembers/api/v2/urls.py
@@ -2,12 +2,6 @@
 from django.urls import path, include
 
 from activemembers.api.v2.views import (
-    CommitteeDetailView,
-    CommitteeListView,
-    SocietyDetailView,
-    SocietyListView,
-    BoardDetailView,
-    BoardListView,
     MemberGroupListView,
     MemberGroupDetailView,
 )
@@ -17,22 +11,6 @@ urlpatterns = [
         "activemembers/",
         include(
             [
-                path("committees/", CommitteeListView.as_view(), name="committee-list"),
-                path(
-                    "committees/<int:pk>/",
-                    CommitteeDetailView.as_view(),
-                    name="committee-detail",
-                ),
-                path("societies/", SocietyListView.as_view(), name="society-list"),
-                path(
-                    "societies/<int:pk>/",
-                    SocietyDetailView.as_view(),
-                    name="society-detail",
-                ),
-                path("boards/", BoardListView.as_view(), name="board-list"),
-                path(
-                    "boards/<int:pk>/", BoardDetailView.as_view(), name="board-detail"
-                ),
                 path("groups/", MemberGroupListView.as_view(), name="group-list"),
                 path(
                     "groups/<int:pk>/",


### PR DESCRIPTION
Closes #1640 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
- Added a search option on group name
- Added a filter on group type (i.e. board, committee, society)
- Added `start` and `end` parameters to filter on when groups existed
- Removed the `/api/v2/activemembers/committees/`, `/api/v2/activemembers/societies/`, `/api/v2/activemembers/boards/` endpoints since they're replaced by the `type` filter

### How to test
Steps to test the changes you made:
1. Go to `/api/v2/activemembers/groups/`
2. Check out the search and filter options
