### PR TITLE
Use distinct queryset in PaymentUserAdmin

### DIFF
--- a/website/payments/models.py
+++ b/website/payments/models.py
@@ -7,8 +7,8 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import DEFERRED, Q, Sum, BooleanField, DecimalField, Count
-from django.db.models.expressions import Case, When, Value
+from django.db.models import DEFERRED, Q, Sum, BooleanField, DecimalField
+from django.db.models.expressions import Case, When, Value, Exists, OuterRef
 from django.db.models.functions import Coalesce
 from django.urls import reverse
 from django.utils import timezone
@@ -32,17 +32,17 @@ class PaymentUser(Member):
     @classmethod
     def tpay_enabled(cls):
         today = timezone.now().date()
-        return Count(
-            "bank_accounts__pk",
-            filter=Q(
-                bank_accounts__valid_from__isnull=False,
-                bank_accounts__valid_from__lte=today,
-            )
-            & (
-                Q(bank_accounts__valid_until__isnull=True)
-                | Q(bank_accounts__valid_until__gt=today)
-            )
-            & Value(settings.THALIA_PAY_ENABLED_PAYMENT_METHOD),
+        return Case(
+            When(
+                Exists(
+                    BankAccount.objects.filter(owner=OuterRef("pk")).filter(
+                        Q(valid_from__isnull=False, valid_from__lte=today,)
+                        & (Q(valid_until__isnull=True) | Q(valid_until__gt=today))
+                    )
+                ),
+                then=settings.THALIA_PAY_ENABLED_PAYMENT_METHOD,
+            ),
+            default=False,
             output_field=BooleanField(),
         )
 

--- a/website/payments/tests/test_admin.py
+++ b/website/payments/tests/test_admin.py
@@ -1078,3 +1078,35 @@ class PaymentUserAdminTest(TestCase):
             request._messages = Mock()
             self.admin.allow_thalia_pay(request, PaymentUser.objects.all())
             mock.assert_called()
+
+    def test_paymentuser_two_bankaccounts(self):
+        p = PaymentUser.objects.get(pk=self.user.pk)
+        self.user.is_superuser = True
+        self.user.save()
+        self.client = Client()
+        self.client.force_login(self.user)
+        response = self.client.get(f"/admin/payments/paymentuser/{p.pk}/change/")
+        self.assertEqual(response.status_code, 200)
+        b1 = BankAccount.objects.create(
+            owner=p,
+            initials="J",
+            last_name="Test2",
+            iban="NL91ABNA0417164300",
+            mandate_no="test1",
+            valid_from=timezone.now().date() - timezone.timedelta(days=5),
+            valid_until=timezone.now().date() - timezone.timedelta(days=3),
+            last_used=timezone.now().date() - timezone.timedelta(days=4),
+            signature="base64,png",
+        )
+        b2 = BankAccount.objects.create(
+            owner=p,
+            initials="J",
+            last_name="Test2",
+            iban="NL91ABNA0417164300",
+            mandate_no="test2",
+            valid_from=timezone.now().date() - timezone.timedelta(days=3),
+            last_used=timezone.now().date() - timezone.timedelta(days=2),
+            signature="base64,png",
+        )
+        response = self.client.get(f"/admin/payments/paymentuser/{p.pk}/change/")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Summary
On certain sql systems, querying for whether a bank account exists (in the `tpay_enabled` `queryable-property`) could duplicate the entries, because in the backend a Cartesian product of the two tables was computed. This PR introduces a different way of counting bank accounts that are valid that does not have this problem

### How to test
1. Have a user
2. Make it have 2 bank accounts used for Thalia Pay (one active, one inactive)
3. Check out the PaymentUserAdmin
4. It should contain that user just once (and ignore the old inactive bank account)