### PR TITLE
Fix username uniqueness

### DIFF
--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -16,6 +16,7 @@ from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.views import View
+from sentry_sdk import capture_exception
 
 from payments import services
 from .models import Payment, Batch, PaymentUser
@@ -48,6 +49,7 @@ class PaymentAdminView(View):
             payable_obj.save()
         # pylint: disable=broad-except
         except Exception as e:
+            capture_exception(e)
             messages.error(
                 request,
                 _("Something went wrong paying %s: %s")

--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -45,6 +45,7 @@ class PaymentAdminView(View):
                 payable_obj, self.request.member, request.POST["type"],
             )
             payable_obj.save()
+        # pylint: disable=broad-except
         except Exception as e:
             messages.error(
                 request,

--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -44,6 +44,7 @@ class PaymentAdminView(View):
             result = services.create_payment(
                 payable_obj, self.request.member, request.POST["type"],
             )
+            payable_obj.payment = result
             payable_obj.save()
         # pylint: disable=broad-except
         except Exception as e:

--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -40,10 +40,18 @@ class PaymentAdminView(View):
         payable_model = apps.get_model(app_label=app_label, model_name=model_name)
         payable_obj = payable_model.objects.get(pk=payable)
 
-        result = services.create_payment(
-            payable_obj, self.request.member, request.POST["type"],
-        )
-        payable_obj.save()
+        try:
+            result = services.create_payment(
+                payable_obj, self.request.member, request.POST["type"],
+            )
+            payable_obj.save()
+        except Exception as e:
+            messages.error(
+                request,
+                _("Something went wrong paying %s: %s")
+                % (model_ngettext(payable_obj, 1), str(e)),
+            )
+            return redirect(f"admin:{app_label}_{model_name}_change", payable_obj.pk)
 
         if result:
             messages.success(

--- a/website/payments/tests/test_admin_views.py
+++ b/website/payments/tests/test_admin_views.py
@@ -150,6 +150,15 @@ class PaymentAdminViewTest(TestCase):
                 response.wsgi_request, "Could not pay MockPayable.",
             )
 
+        with self.subTest("Send post with exception during processing"):
+            create_payment.side_effect = Exception("A test exception was thrown.")
+            response = self.client.post(url, {"type": payment_type,})
+
+            messages_error.assert_called_with(
+                response.wsgi_request,
+                "Something went wrong paying MockPayable: A test exception was thrown.",
+            )
+
 
 @override_settings(SUSPEND_SIGNALS=True, THALIA_PAY_ENABLED_PAYMENT_METHOD=True)
 @patch("payments.models.PaymentUser.tpay_allowed", PropertyMock, True)

--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -340,7 +340,9 @@ class Registration(Entry):
 
         if self.username is not None and (
             get_user_model().objects.filter(username=self.username).exists()
-            or Registration.objects.filter(username=self.username).exists()
+            or Registration.objects.filter(username=self.username)
+            .exclude(pk=self.pk)
+            .exists()
         ):
             errors.update({"username": _("A user with that username already exists.")})
 

--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -338,9 +338,9 @@ class Registration(Entry):
         ):
             errors.update({"student_number": _("This field is required.")})
 
-        if (
-            self.username is not None
-            and get_user_model().objects.filter(username=self.username).exists()
+        if self.username is not None and (
+            get_user_model().objects.filter(username=self.username).exists()
+            or Registration.objects.filter(username=self.username).exists()
         ):
             errors.update({"username": _("A user with that username already exists.")})
 

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -190,7 +190,7 @@ def accept_entries(user_id: int, queryset: QuerySet) -> int:
     return len(updated_entries)
 
 
-def revert_entry(user_id: int, entry: Entry) -> None:
+def revert_entry(user_id: int or None, entry: Entry) -> None:
     """Revert status of entry to review so that it can be corrected.
 
     :param user_id: Id of the user executing this action
@@ -217,7 +217,7 @@ def revert_entry(user_id: int, entry: Entry) -> None:
         except Renewal.DoesNotExist:
             pass
 
-    if log_obj:
+    if log_obj and user_id is not None:
         LogEntry.objects.log_action(
             user_id=user_id,
             content_type_id=get_content_type_for_model(log_obj).pk,

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -60,6 +60,8 @@ def check_unique_user(entry: Entry) -> bool:
             get_user_model()
             .objects.filter(Q(email=registration.email) | Q(username=username))
             .exists()
+        ) and not (
+            Registration.objects.filter(username=username).exclude(pk=entry.pk).exists()
         )
     except Registration.DoesNotExist:
         pass

--- a/website/registrations/signals.py
+++ b/website/registrations/signals.py
@@ -2,7 +2,7 @@
 from django.db.models.signals import post_save
 
 from registrations import services
-from registrations.models import Registration, Renewal
+from registrations.models import Registration, Renewal, Entry
 from utils.models.signals import suspendingreceiver
 
 
@@ -15,5 +15,7 @@ def post_entry_save(sender, instance, **kwargs):
     except Exception as e:
         # if something goes wrong creating the member,
         # make sure the payment is deleted
+        # and mark the entry again as 'ready for review'
         instance.payment.delete()
+        instance.status = Entry.STATUS_REVIEW
         raise e

--- a/website/registrations/signals.py
+++ b/website/registrations/signals.py
@@ -10,4 +10,10 @@ from utils.models.signals import suspendingreceiver
 @suspendingreceiver(post_save, sender=Renewal)
 def post_entry_save(sender, instance, **kwargs):
     """Process an entry when it is saved."""
-    services.process_entry_save(instance)
+    try:
+        services.process_entry_save(instance)
+    except Exception as e:
+        # if something goes wrong creating the member,
+        # make sure the payment is deleted
+        instance.payment.delete()
+        raise e

--- a/website/registrations/signals.py
+++ b/website/registrations/signals.py
@@ -14,8 +14,7 @@ def post_entry_save(sender, instance, **kwargs):
         services.process_entry_save(instance)
     except Exception as e:
         # if something goes wrong creating the member,
-        # make sure the payment is deleted
+        # revert the entry: remove the payment
         # and mark the entry again as 'ready for review'
-        instance.payment.delete()
-        instance.status = Entry.STATUS_REVIEW
+        services.revert_entry(None, instance)
         raise e

--- a/website/registrations/signals.py
+++ b/website/registrations/signals.py
@@ -2,7 +2,7 @@
 from django.db.models.signals import post_save
 
 from registrations import services
-from registrations.models import Registration, Renewal, Entry
+from registrations.models import Registration, Renewal
 from utils.models.signals import suspendingreceiver
 
 


### PR DESCRIPTION
Closes #945 

### Summary
This PR does 2 things related to the problem in #945:

1. It prevents the bug from occurring in some cases, by making sure that it is not possible to save registrations that share the username with other registrations (even when they are not completed yet)
2. When the bug still occurs, the payment is deleted so that we will never end up in the situation that a registration is paid but not accepted.
3. In all these cases, the payment button admin view will show an error to the user

### How to test
Steps to test the changes you made:
1. Create a registration
2. Approve it, etc.
3. Set the username to a different user's username 
4. That should fail
5. Set the username to the username of a different accepted registration
6. That should fail as well
7. Secretly force override the username value by manually inserting it in the database. Choose a username of a user that already exists
8. Paying will fail and result in an error shown to the user. The payment will be deleted / not be created and the entry will be 'ready for review' again.