### PR TITLE
Make registrations readonly after they are completed

### DIFF
--- a/website/registrations/admin.py
+++ b/website/registrations/admin.py
@@ -221,6 +221,14 @@ class RegistrationAdmin(admin.ModelAdmin):
         """Check if the user has the review permission."""
         return request.user.has_perm("registrations.review_entries")
 
+    def has_change_permission(self, request, obj=None):
+        """Completed registrations are read-only."""
+        return (
+            False
+            if obj and obj.status == Entry.STATUS_COMPLETED
+            else super().has_change_permission(request, obj)
+        )
+
     def save_model(self, request, obj, form, change):
         if not (
             obj.status == Entry.STATUS_REJECTED


### PR DESCRIPTION
Closes #884

### Summary
Completed registrations can now not be saved anymore from the admin, preventing errors

### How to test
Steps to test the changes you made:
1. Go to a registration admin
2. Complete a registration
3. The save button disappears