### PR TITLE
Fix missing slides and frontpage articles in API v2

### DIFF
--- a/website/announcements/models.py
+++ b/website/announcements/models.py
@@ -5,6 +5,7 @@ from django.core.validators import (
 )
 from django.db import models
 from django.db.models import CharField, Manager, Q
+from django.db.models.functions import Now
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from tinymce.models import HTMLField
@@ -19,8 +20,8 @@ class VisibleObjectManager(Manager):
             super()
             .get_queryset()
             .filter(
-                (Q(until__isnull=True) | Q(until__gt=timezone.now()))
-                & (Q(since__isnull=True) | Q(since__lte=timezone.now()))
+                (Q(until__isnull=True) | Q(until__gt=Now()))
+                & (Q(since__isnull=True) | Q(since__lte=Now()))
                 & ~(Q(since__isnull=True) & Q(until__isnull=True))
             )
         )


### PR DESCRIPTION
Closes #1702 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The timestamp was hardcoded in the query. The timestamp is now computed at the time the query is executed such that new articles or slides do appear in the API

### How to test
Steps to test the changes you made:
1. Go to `api/v2/announcements/frontpage-articles/`
2. Add a new frontpage articles in the admin
3. Go again to `api/v2/announcements/frontpage-articles/` and notice that the new one appeared
