### PR TITLE
Payable tpay allowed

### DIFF
--- a/website/payments/api/v2/admin/serializers/payable_detail.py
+++ b/website/payments/api/v2/admin/serializers/payable_detail.py
@@ -1,9 +1,9 @@
-from rest_framework.fields import CharField, ListField, DecimalField, empty
+from rest_framework.fields import CharField, ListField, DecimalField
 from rest_framework.serializers import Serializer
 
 from members.api.v2.serializers.member import MemberSerializer
 from payments.api.v2.admin.serializers.payment import PaymentAdminSerializer
-from payments.models import Payment, PaymentUser
+from payments.models import Payment
 
 
 class PayableAdminSerializer(Serializer):

--- a/website/payments/api/v2/serializers/payable_detail.py
+++ b/website/payments/api/v2/serializers/payable_detail.py
@@ -11,3 +11,4 @@ class PayableSerializer(Serializer):
     topic = CharField(source="payment_topic")
     notes = CharField(source="payment_notes")
     payment = PaymentSerializer(read_only=True)
+    tpay_allowed = BooleanField()

--- a/website/payments/api/v2/serializers/payable_detail.py
+++ b/website/payments/api/v2/serializers/payable_detail.py
@@ -1,4 +1,4 @@
-from rest_framework.fields import CharField, empty, DecimalField
+from rest_framework.fields import CharField, DecimalField, BooleanField
 from rest_framework.serializers import Serializer
 
 from payments.api.v2.serializers import PaymentSerializer

--- a/website/registrations/tests/test_services.py
+++ b/website/registrations/tests/test_services.py
@@ -533,7 +533,9 @@ class ServicesTest(TestCase):
         self.e0.status = Entry.STATUS_REVIEW
         self.e0.save()
 
+    @freeze_time("2019-01-01")
     def test_accept_tpay_registration(self):
+        self.e2.created_at = timezone.now()
         self.e2.direct_debit = True
         self.e2.iban = "NL91ABNA0417164300"
         self.e2.initials = "J"


### PR DESCRIPTION
References #1728

### Summary
Provide the `tpay_allowed` attribute of payables

### How to test
1. Checkout a payable like `http://localhost:8000/api/v2/payments/payables/<APPNAME>/<MODELNAME>/<PK>/`
2. It should display a `tpay_allowed` value