### PR TITLE
Fix missing fields in definition for renewal form

### DIFF
--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -151,7 +151,14 @@ class RenewalForm(forms.ModelForm):
 
     class Meta:
         model = Renewal
-        fields = ("member", "length", "contribution", "membership_type")
+        fields = (
+            "member",
+            "length",
+            "contribution",
+            "membership_type",
+            "no_references",
+            "remarks",
+        )
 
 
 class ReferenceForm(forms.ModelForm):


### PR DESCRIPTION
Closes #1738


### Summary
Fix missing fields in definition for renewal form.

### How to test
Steps to test the changes you made:
1. Create a registration for a completely new user
2. Create an upgrade for the membership
3. Get the email
