### PR TITLE
Hide benefactor renewal option if not allowed

### DIFF
--- a/website/registrations/views.py
+++ b/website/registrations/views.py
@@ -11,7 +11,6 @@ from django.http import Http404
 from django.shortcuts import redirect, get_object_or_404
 from django.template.defaultfilters import floatformat
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views import View
@@ -230,28 +229,6 @@ class RenewalFormView(FormView):
         ).exists()
         context["benefactor_type"] = Membership.BENEFACTOR
         return context
-
-    def get_form(self, form_class=None):
-        form = super().get_form(form_class)
-        member = self.request.member
-        if member is not None and member.latest_membership is not None:
-            latest_membership = member.latest_membership
-            # If latest membership has not ended or does not ends
-            # within 1 month: do not show 'year' length
-            hide_year_choice = not (
-                latest_membership is not None
-                and latest_membership.until is not None
-                and (latest_membership.until - timezone.now().date()).days <= 31
-            )
-
-            if hide_year_choice:
-                form.fields["length"].choices = [
-                    c
-                    for c in form.fields["length"].choices
-                    if c[0] != Entry.MEMBERSHIP_YEAR
-                ]
-
-        return form
 
     def post(self, request, *args, **kwargs):
         request.POST = request.POST.dict()


### PR DESCRIPTION
Closes #1740 

### Summary
Throughout the year, when you are a member, you cannot renew your membership already. That is only possible in august. This PR hides the possibility to renew to benefactor membership as well

### How to test
Steps to test the changes you made:
1. Be active thalia member
2. The end date of your membership should be more than 30 days away (otherwise you are allowed to upgrade already).
3. Try to renew membership
4. You are only shown the possibility to upgrade to study membership, no benefactor renewal option is shown 