### PR TITLE
Fix contribution being float in renewal

### DIFF
--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -139,7 +139,7 @@ class RenewalForm(forms.ModelForm):
         required=False, label=_("I am an employee of iCIS")
     )
 
-    contribution = forms.IntegerField(required=False,)
+    contribution = forms.DecimalField(required=False, max_digits=5, decimal_places=2,)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Closes #1742

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Fix contribution being float in renewal.

### How to reproduce
Steps to reproduce the behaviour:
1. Go to http://localhost:8000/user/membership/
2. Add a benefactor membership renewal 
3. The form will not error when trying to send
