### PR TITLE
Make event registration member serializer read only

### DIFF
--- a/website/events/api/v2/serializers/event_registration.py
+++ b/website/events/api/v2/serializers/event_registration.py
@@ -31,4 +31,4 @@ class EventRegistrationSerializer(serializers.ModelSerializer):
             "name",
         )
 
-    member = MemberSerializer(detailed=False)
+    member = MemberSerializer(detailed=False, read_only=True)


### PR DESCRIPTION
Closes #1747 

### Summary
Makes event registration member serializer read only 

### How to test
1. Go to `/api/v2/events/<id>/registrations/` 
2. see that you can't post the profile