### PR TITLE
Allow deleting/unregistering event registrations from API

### DIFF
--- a/website/events/api/v2/admin/views.py
+++ b/website/events/api/v2/admin/views.py
@@ -84,7 +84,9 @@ class EventRegistrationAdminListView(AdminListAPIView, AdminCreateAPIView):
         return EventRegistration.objects.none()
 
 
-class EventRegistrationAdminDetailView(AdminRetrieveAPIView, AdminUpdateAPIView):
+class EventRegistrationAdminDetailView(
+    AdminRetrieveAPIView, AdminUpdateAPIView, AdminDestroyAPIView
+):
     """Returns details of an event registration."""
 
     serializer_class = EventRegistrationAdminSerializer

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -3,7 +3,12 @@ from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScop
 from rest_framework import filters as framework_filters
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.generics import ListAPIView, RetrieveAPIView, get_object_or_404
+from rest_framework.generics import (
+    ListAPIView,
+    RetrieveAPIView,
+    get_object_or_404,
+    DestroyAPIView,
+)
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from rest_framework.response import Response
 from rest_framework.utils import json
@@ -46,7 +51,7 @@ class EventDetailView(RetrieveAPIView):
     required_scopes = ["events:read"]
 
 
-class EventRegistrationsView(ListAPIView):
+class EventRegistrationsView(ListAPIView, DestroyAPIView):
     """Returns a list of registrations."""
 
     serializer_class = EventRegistrationSerializer
@@ -108,8 +113,15 @@ class EventRegistrationsView(ListAPIView):
         except RegistrationError as e:
             raise PermissionDenied(detail=e) from e
 
+    def delete(self, request, *args, **kwargs):
+        try:
+            services.cancel_registration(request.member, self.event)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except RegistrationError as e:
+            raise PermissionDenied(detail=e) from e
 
-class EventRegistrationDetailView(RetrieveAPIView):
+
+class EventRegistrationDetailView(RetrieveAPIView, DestroyAPIView):
     """Returns details of an event registration."""
 
     serializer_class = EventRegistrationSerializer


### PR DESCRIPTION
Closes #1753

### Summary
Allow deleting event registrations from the events API

### How to test
1. Try to delete an event registration from the event admin API
2. This should just work
3. Note that this is very different from unregistering.
4. Try to unregister for an event by deleting from the regular events API
5. This should just work