### PR TITLE
Fix events api registration fields

### DIFF
--- a/website/events/api/v1/viewsets/event_registrations.py
+++ b/website/events/api/v1/viewsets/event_registrations.py
@@ -50,7 +50,9 @@ class EventRegistrationViewSet(RetrieveModelMixin, UpdateModelMixin, GenericView
                 )
 
             services.update_registration(
-                registration=registration, field_values=serializer.field_values(), actor=self.request.member
+                registration=registration,
+                field_values=serializer.field_values(),
+                actor=self.request.member,
             )
             serializer.information_fields = services.registration_fields(
                 serializer.context["request"], registration=registration

--- a/website/events/api/v1/viewsets/event_registrations.py
+++ b/website/events/api/v1/viewsets/event_registrations.py
@@ -50,7 +50,7 @@ class EventRegistrationViewSet(RetrieveModelMixin, UpdateModelMixin, GenericView
                 )
 
             services.update_registration(
-                registration=registration, field_values=serializer.field_values()
+                registration=registration, field_values=serializer.field_values(), actor=self.request.member
             )
             serializer.information_fields = services.registration_fields(
                 serializer.context["request"], registration=registration

--- a/website/events/api/v2/admin/views.py
+++ b/website/events/api/v2/admin/views.py
@@ -105,7 +105,9 @@ class EventRegistrationAdminFieldsView(AdminPermissionsMixin, APIView):
 
     permission_classes = [IsOrganiser, IsAuthenticatedOrTokenHasScope]
     required_scopes = ["events:admin"]
-    queryset = EventRegistration.objects.filter(event=self.kwargs["event_id"])
+
+    def get_queryset(self):
+        return EventRegistration.objects.filter(event=self.kwargs["event_id"])
 
     def get_object(self):
         event_registration = get_object_or_404(

--- a/website/events/api/v2/admin/views.py
+++ b/website/events/api/v2/admin/views.py
@@ -105,9 +105,7 @@ class EventRegistrationAdminFieldsView(AdminPermissionsMixin, APIView):
 
     permission_classes = [IsOrganiser, IsAuthenticatedOrTokenHasScope]
     required_scopes = ["events:admin"]
-
-    def get_queryset(self):
-        return EventRegistration.objects.filter(event=self.kwargs["event_id"])
+    queryset = EventRegistration.objects.filter(event=self.kwargs["event_id"])
 
     def get_object(self):
         event_registration = get_object_or_404(

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -201,35 +201,34 @@ class EventRegistrationFieldsView(APIView):
         required_keys = set(original.keys()) - set(request.data.keys())
         if len(required_keys) > 0:
             raise ValidationError(
-                f"Missing keys '{', '.join(required_keys)}' in request",
-                status.HTTP_400_BAD_REQUEST,
+                f"Missing keys '{', '.join(required_keys)}' in request"
             )
 
-        if not event_permissions(
-            self.get_object().member, self.get_object().event, self.get_object().name
-        )["update_registration"]:
-            raise PermissionDenied("You cannot update this registration.")
+        try:
+            services.update_registration(
+                registration=self.get_object(), field_values=request.data.items()
+            )
 
-        services.update_registration(
-            registration=self.get_object(), field_values=request.data.items()
-        )
-
-        return Response(
-            data=services.registration_fields(request, registration=self.get_object()),
-            status=status.HTTP_200_OK,
-        )
+            return Response(
+                data=services.registration_fields(
+                    request, registration=self.get_object()
+                ),
+                status=status.HTTP_200_OK,
+            )
+        except RegistrationError as e:
+            raise ValidationError(e)
 
     def patch(self, request, *args, **kwargs):
-        if not event_permissions(
-            self.get_object().member, self.get_object().event, self.get_object().name
-        )["update_registration"]:
-            raise PermissionDenied("You cannot update this registration.")
+        try:
+            services.update_registration(
+                registration=self.get_object(), field_values=request.data.items()
+            )
 
-        services.update_registration(
-            registration=self.get_object(), field_values=request.data.items()
-        )
-
-        return Response(
-            data=services.registration_fields(request, registration=self.get_object()),
-            status=status.HTTP_200_OK,
-        )
+            return Response(
+                data=services.registration_fields(
+                    request, registration=self.get_object()
+                ),
+                status=status.HTTP_200_OK,
+            )
+        except RegistrationError as e:
+            raise ValidationError(e)

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -177,7 +177,7 @@ def cancel_registration(member, event):
 
 
 def update_registration(
-    member=None, event=None, name=None, registration=None, field_values=None
+    member=None, event=None, name=None, registration=None, field_values=None, actor=None
 ):
     """Update a user registration of an event.
 
@@ -186,6 +186,7 @@ def update_registration(
     :param name: the name of a registration not associated with a user
     :param registration: the registration
     :param field_values: values for the information fields
+    :param actor: Member executing this action
     """
     if not registration:
         try:
@@ -201,10 +202,18 @@ def update_registration(
         event = registration.event
         name = registration.name
 
-    if not event_permissions(member, event, name)["update_registration"]:
-        raise RegistrationError(_("You cannot update this registration."))
+    if not actor:
+        actor = member
+
+    permissions = event_permissions(actor, event, name)
+
     if not field_values:
         return
+    if not (
+        permissions["update_registration"]
+        or permissions["manage_event"]
+    ):
+        raise RegistrationError(_("You are not allowed to update this registration."))
 
     for field_id, field_value in field_values:
         field = RegistrationInformationField.objects.get(

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -201,10 +201,9 @@ def update_registration(
         event = registration.event
         name = registration.name
 
-    if (
-        not event_permissions(member, event, name)["update_registration"]
-        or not field_values
-    ):
+    if not event_permissions(member, event, name)["update_registration"]:
+        raise RegistrationError(_("You cannot update this registration."))
+    if not field_values:
         return
 
     for field_id, field_value in field_values:

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -209,10 +209,7 @@ def update_registration(
 
     if not field_values:
         return
-    if not (
-        permissions["update_registration"]
-        or permissions["manage_event"]
-    ):
+    if not (permissions["update_registration"] or permissions["manage_event"]):
         raise RegistrationError(_("You are not allowed to update this registration."))
 
     for field_id, field_value in field_values:


### PR DESCRIPTION
Closes #1754 

### Summary
- The events API will not crash anymore when requesting the fields
- The API users proper DRF Responses
- The API throws an error if you cannot update the fields, rather than ignoring


### How to test
1. Have an event with registration fields
2. Try to update them as user
3. Try to update them as organizer