### PR TITLE
Add renewal upgrade discount help text

### DIFF
--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -148,7 +148,7 @@ class RenewalForm(forms.ModelForm):
                 reverse_lazy("singlepages:privacy-policy")
             )
         )
-        self.fields["length"].help_text = (
+        self.fields["length"].help_text = _(
             "A discount of €7,50 will be applied if you upgrade your year membership to"
             " a membership until graduation. You will only have to pay €22,50 in that case."
         )

--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -148,6 +148,10 @@ class RenewalForm(forms.ModelForm):
                 reverse_lazy("singlepages:privacy-policy")
             )
         )
+        self.fields["length"].help_text = (
+            "A discount of €7,50 will be applied if you upgrade your year membership to"
+            " a membership until graduation. You will only have to pay €22,50 in that case."
+        )
 
     class Meta:
         model = Renewal


### PR DESCRIPTION
### Summary
Added a simple help text to the renewals model. 

<img width="524" alt="image" src="https://user-images.githubusercontent.com/1576660/122916901-b2326b00-d35d-11eb-828f-628adbcffaf9.png">


### How to test
Steps to test the changes you made:
1. Go to membership renewals (/user/membership/)
2. Notice help text
3. Don't be confused about expected price