### PR TITLE
Immutable payables

### DIFF
--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -5,7 +5,6 @@ from django.db.models import Q, F, Count
 from django.db.models.functions import NullIf, Greatest
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from django.utils.functional import cached_property
 from queryable_properties.properties import AnnotationProperty
 from queryable_properties.managers import QueryablePropertiesManager
 
@@ -89,6 +88,10 @@ class EventRegistration(models.Model):
         blank=True,
         null=True,
     )
+
+    @property
+    def price(self):
+        return self.event.price
 
     @property
     def phone_number(self):

--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -90,10 +90,6 @@ class EventRegistration(models.Model):
     )
 
     @property
-    def price(self):
-        return self.event.price
-
-    @property
     def phone_number(self):
         if self.member:
             return self.member.profile.phone_number

--- a/website/events/payables.py
+++ b/website/events/payables.py
@@ -1,4 +1,5 @@
 from django.template.defaultfilters import date
+from django.utils.functional import classproperty
 
 from events.models import EventRegistration
 from events.services import is_organiser
@@ -34,6 +35,14 @@ class EventRegistrationPayable(Payable):
     @property
     def tpay_allowed(self):
         return self.model.event.tpay_allowed
+
+    @classproperty
+    def immutable_after_payment(self):
+        return True
+
+    @classproperty
+    def immutable_model_fields_after_payment(self):
+        return ["member", "event", "name", "price"]
 
 
 def register():

--- a/website/events/payables.py
+++ b/website/events/payables.py
@@ -42,7 +42,7 @@ class EventRegistrationPayable(Payable):
 
     @classproperty
     def immutable_model_fields_after_payment(self):
-        return ["member", "event", "name", "price"]
+        return ["member", "event", "name", "payment_amount"]
 
 
 def register():

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -112,7 +112,7 @@ def prevent_saving(sender, instance, **kwargs):
 
     immutable_fields = (
         payable.immutable_model_fields_after_payment[sender]
-        if type(payable.immutable_model_fields_after_payment) is dict
+        if isinstance(payable.immutable_model_fields_after_payment, dict)
         else payable.immutable_model_fields_after_payment
     )
     for field in immutable_fields:
@@ -133,11 +133,13 @@ def prevent_saving_related(foreign_key_field):
         try:
             old_instance = sender.objects.get(pk=instance.pk)
         except sender.DoesNotExist:
-            raise PaymentError("Cannot save this model with foreign key to immutable payment")
+            raise PaymentError(  # pylint: disable=W0707
+                "Cannot save this model with foreign key to immutable payment"
+            )
 
         immutable_fields = (
             payable.immutable_model_fields_after_payment[sender]
-            if type(payable.immutable_model_fields_after_payment) is dict
+            if isinstance(payable.immutable_model_fields_after_payment, dict)
             else []
         )
         for field in immutable_fields:

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Model
 from django.db.models.signals import pre_save
 from django.utils.functional import classproperty
@@ -30,9 +31,12 @@ class Payable:
         self.model.payment = payment
 
     def get_payment(self):
-        if self.model.pk:
+        try:
             self.model.refresh_from_db(fields=["payment"])
-        return self.payment
+        except ObjectDoesNotExist:
+            return None
+        else:
+            return self.payment
 
     @property
     def payment_amount(self):

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -1,6 +1,9 @@
 from functools import lru_cache
 
 from django.db.models import Model
+from django.db.models.signals import pre_save
+
+from payments.exceptions import PaymentError
 
 _registry = {}
 
@@ -48,6 +51,10 @@ class Payable:
     def can_manage_payment(self, member):
         raise NotImplementedError
 
+    @property
+    def immutable_after_payment(self):
+        return False
+
     def __hash__(self):
         return hash((self.payment_amount, self.payment_topic, self.payment_notes))
 
@@ -66,6 +73,23 @@ class Payables:
 
     def register(self, model: Model, payable_class: Payable):
         self._registry[self._get_key(model)] = payable_class
+        pre_save.connect(prevent_saving_paid_after_immutable, sender=model)
 
 
 payables = Payables()
+
+def prevent_saving_paid_after_immutable(sender, instance, **kwargs):
+    """Remove user from the order reminder when saved."""
+    if not payables.get_payable(instance).immutable_after_payment:
+        return
+    try:
+        old_instance = sender.objects.get(pk=instance.pk)
+    except sender.DoesNotExist:
+        return
+
+    immutable_fields = ["payment_payer", "payment_amount", "payment_topic", "payment_notes"]
+
+    if old_instance.payment and any(
+        getattr(payables.get_payable(old_instance), x) != getattr(payables.get_payable(instance), x) for x in immutable_fields
+    ): # THIS DOESNT WORK YET, AS THE OLD AND NEW PAYABLE ARE THE SAME
+        raise PaymentError("Cannot change this model")

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -138,7 +138,6 @@ def prevent_saving(sender, instance, **kwargs):
 
 def prevent_saving_related(foreign_key_field):
     def prevent_related_saving_paid_after_immutable(sender, instance, **kwargs):
-        nonlocal foreign_key_field
         payable = payables.get_payable(getattr(instance, foreign_key_field))
         if not payable.immutable_after_payment:
             # Do nothing if the parent is not marked as immutable

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -29,6 +29,10 @@ class Payable:
     def payment(self, payment):
         self.model.payment = payment
 
+    def get_payment(self):
+        self.model.refresh_from_db(fields=["payment"])
+        return self.payment
+
     @property
     def payment_amount(self):
         raise NotImplementedError
@@ -102,7 +106,7 @@ def prevent_saving(sender, instance, **kwargs):
     if not payable.immutable_after_payment:
         # Do nothing is the model is not marked as immutable
         return
-    if not payable.payment:
+    if not payable.get_payment():
         # Do nothing is the model is not actually paid
         return
     try:

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -125,10 +125,10 @@ def prevent_saving_related(foreign_key_field):
         nonlocal foreign_key_field
         payable = payables.get_payable(getattr(instance, foreign_key_field))
         if not payable.immutable_after_payment:
-            # Do nothing is the parent is not marked as immutable
+            # Do nothing if the parent is not marked as immutable
             return
         if not payable.payment:
-            # Do nothing is the parent is not actually paid
+            # Do nothing if the parent is not actually paid
             return
         try:
             old_instance = sender.objects.get(pk=instance.pk)

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -133,7 +133,7 @@ def prevent_saving_related(foreign_key_field):
         try:
             old_instance = sender.objects.get(pk=instance.pk)
         except sender.DoesNotExist:
-            return
+            raise PaymentError("Cannot save this model with foreign key to immutable payment")
 
         immutable_fields = (
             payable.immutable_model_fields_after_payment[sender]

--- a/website/payments/tests/__mocks__.py
+++ b/website/payments/tests/__mocks__.py
@@ -73,7 +73,7 @@ class MockPayable(Payable):
 
     @classproperty
     def immutable_after_payment(self):
-        return True
+        return False
 
     @classproperty
     def immutable_foreign_key_models(self):
@@ -81,4 +81,4 @@ class MockPayable(Payable):
 
     @classproperty
     def immutable_model_fields_after_payment(self):
-        return ["test_field"]
+        return []

--- a/website/payments/tests/__mocks__.py
+++ b/website/payments/tests/__mocks__.py
@@ -1,8 +1,12 @@
 from unittest.mock import MagicMock
 
-from django.db.models import Model
+from django.utils.functional import classproperty
 
 from payments import Payable
+
+
+class MockManager:
+    pass
 
 
 class MockModel:
@@ -12,7 +16,9 @@ class MockModel:
 
     payment = None
     pk = 1
+    test_field = ""
     _meta = Meta()
+    objects = MockManager()
 
     def __init__(
         self,
@@ -64,3 +70,15 @@ class MockPayable(Payable):
 
     def can_manage_payment(self, member):
         return self.model.can_manage
+
+    @classproperty
+    def immutable_after_payment(self):
+        return True
+
+    @classproperty
+    def immutable_foreign_key_models(self):
+        return {}
+
+    @classproperty
+    def immutable_model_fields_after_payment(self):
+        return ["test_field"]

--- a/website/payments/tests/__mocks__.py
+++ b/website/payments/tests/__mocks__.py
@@ -37,6 +37,9 @@ class MockModel:
     def save(self):
         pass
 
+    def refresh_from_db(self):
+        pass
+
 
 class MockPayable(Payable):
     save = MagicMock()

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -174,6 +174,9 @@ class ImmutablePayablesTest(TestCase):
         with self.subTest(
             "Do nothing if related model changed fields are not labelled immutable"
         ):
+            model.payment = Payment.objects.create(
+                type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
+            )
             MockPayable.immutable_after_payment = True
             MockPayable.immutable_model_fields_after_payment = {MockModel2: []}
             prevent_saving_related("test_related_field")(

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock
+
 from django.test import TestCase
 
-from payments import payables, NotRegistered
+from payments import payables, NotRegistered, prevent_saving, PaymentError
+from payments.models import Payment
 from payments.tests.__mocks__ import MockModel, MockPayable
 
 
@@ -15,3 +18,52 @@ class PayablesTest(TestCase):
         payables._registry = {}
         with self.assertRaises(NotRegistered):
             payables.get_payable(MockModel)
+
+
+class ImmutablePayablesTest(TestCase):
+    def setUp(self):
+        payables.register(MockModel, MockPayable)
+
+    def test_prevent_unlinking_payment_from_payable(self):
+        model_before = MockModel(payer=None)
+        model_before.payment = Payment.objects.create(
+            type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
+        )
+
+        model_after = MockModel(payer=None)
+        model_after.payment = None
+
+        MockPayable.get_payment = MagicMock(return_value=model_before.payment)
+        MockModel.objects.get = MagicMock(return_value=model_before)
+
+        with self.assertRaises(PaymentError) as test:
+            prevent_saving(MockModel, model_after)
+
+        exception = test.exception
+        self.assertEqual(
+            str(exception), "You are trying to unlink a payment from its payable."
+        )
+
+    def test_prevent_saving_payable_with_immutable_field(self):
+        model_before = MockModel(payer=None)
+        model_before.payment = Payment.objects.create(
+            type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
+        )
+
+        model_after = MockModel(payer=None)
+        model_after.payment = model_before.payment
+        model_after.test_field = "changed"
+
+        MockModel.objects.get = MagicMock(return_value=model_before)
+
+        with self.assertRaises(PaymentError) as test:
+            prevent_saving(MockModel, model_after)
+
+        exception = test.exception
+        self.assertEqual(str(exception), "Cannot change this model")
+
+    # def test_allow_saving_payable_without_immutable_field(self):
+    #     pass
+    #     # subtest: no payment
+    #     # subtest: unsaved payment
+    #     # subtest: with payment

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -2,7 +2,8 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
-from payments import payables, NotRegistered, prevent_saving, PaymentError
+from payments import payables, NotRegistered, prevent_saving, PaymentError, \
+    Payable
 from payments.models import Payment
 from payments.tests.__mocks__ import MockModel, MockPayable
 
@@ -26,41 +27,53 @@ class ImmutablePayablesTest(TestCase):
 
     def test_prevent_unlinking_payment_from_payable(self):
         model_before = MockModel(payer=None)
+        model_after = MockModel(payer=None)
         model_before.payment = Payment.objects.create(
             type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
         )
-
-        model_after = MockModel(payer=None)
-        model_after.payment = None
-
         MockPayable.get_payment = MagicMock(return_value=model_before.payment)
         MockModel.objects.get = MagicMock(return_value=model_before)
 
-        with self.assertRaises(PaymentError) as test:
-            prevent_saving(MockModel, model_after)
+        with self.subTest("Unlinking a payment"):
+            model_after.payment = None
 
-        exception = test.exception
-        self.assertEqual(
-            str(exception), "You are trying to unlink a payment from its payable."
-        )
+            with self.assertRaises(PaymentError) as test:
+                prevent_saving(MockModel, model_after)
 
-    def test_prevent_saving_payable_with_immutable_field(self):
+            exception = test.exception
+            self.assertEqual(
+                str(exception), "You are trying to unlink a payment from its payable."
+            )
+
+        with self.subTest("Changing an immutable model field after payment"):
+            model_after.payment = model_before.payment
+            model_after.test_field = "changed"
+
+            with self.assertRaises(PaymentError) as test:
+                prevent_saving(MockModel, model_after)
+
+            exception = test.exception
+            self.assertEqual(str(exception), "Cannot change this model")
+
+
+    def test_prevent_saving_no_existing_model(self):
+        model = MockModel(payer=None)
+        model.pk = None
+        prevent_saving(MockModel, model) # this should not crash
+
+
+    def test_allow_adding_a_payment_to_unpaid_model(self):
         model_before = MockModel(payer=None)
-        model_before.payment = Payment.objects.create(
+        model_before.payment = None
+
+        model_after = MockModel(payer=None)
+        model_after.payment = Payment.objects.create(
             type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
         )
 
-        model_after = MockModel(payer=None)
-        model_after.payment = model_before.payment
-        model_after.test_field = "changed"
-
         MockModel.objects.get = MagicMock(return_value=model_before)
+        prevent_saving(MockModel, model_after)
 
-        with self.assertRaises(PaymentError) as test:
-            prevent_saving(MockModel, model_after)
-
-        exception = test.exception
-        self.assertEqual(str(exception), "Cannot change this model")
 
     def test_mutable_model(self):
         payable = payables.get_payable(MockModel)
@@ -69,6 +82,8 @@ class ImmutablePayablesTest(TestCase):
         self.assertFalse(payable.immutable_after_payment)
         MockPayable.immutable_after_payment = True
         self.assertTrue(payable.immutable_after_payment)
+
+        self.assertFalse(Payable.immutable_after_payment)
 
     def test_immutable_fields(self):
         payable = payables.get_payable(MockModel)
@@ -79,6 +94,10 @@ class ImmutablePayablesTest(TestCase):
         )
         MockPayable.immutable_model_fields_after_payment = []
         self.assertEqual([], payable.immutable_model_fields_after_payment)
+
+        self.assertEqual([], Payable.immutable_model_fields_after_payment)
+
+
 
 
 # def test_allow_saving_payable_without_immutable_field(self):

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -62,8 +62,27 @@ class ImmutablePayablesTest(TestCase):
         exception = test.exception
         self.assertEqual(str(exception), "Cannot change this model")
 
-    # def test_allow_saving_payable_without_immutable_field(self):
-    #     pass
-    #     # subtest: no payment
-    #     # subtest: unsaved payment
-    #     # subtest: with payment
+    def test_mutable_model(self):
+        payable = payables.get_payable(MockModel)
+        self.assertTrue(payable.immutable_after_payment)
+        MockPayable.immutable_after_payment = False
+        self.assertFalse(payable.immutable_after_payment)
+        MockPayable.immutable_after_payment = True
+        self.assertTrue(payable.immutable_after_payment)
+
+    def test_immutable_fields(self):
+        payable = payables.get_payable(MockModel)
+        self.assertEqual(["test_field"], payable.immutable_model_fields_after_payment)
+        MockPayable.immutable_model_fields_after_payment = ["test1", "test2"]
+        self.assertEqual(
+            ["test1", "test2"], payable.immutable_model_fields_after_payment
+        )
+        MockPayable.immutable_model_fields_after_payment = []
+        self.assertEqual([], payable.immutable_model_fields_after_payment)
+
+
+# def test_allow_saving_payable_without_immutable_field(self):
+#     pass
+#     # subtest: no payment
+#     # subtest: unsaved payment
+#     # subtest: with payment

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -164,6 +164,13 @@ class ImmutablePayablesTest(TestCase):
                 MockModel2, related_model_after
             )
 
+        with self.subTest("Do nothing if parent is not paid"):
+            MockPayable.immutable_after_payment = True
+            model.payment = None
+            prevent_saving_related("test_related_field")(
+                MockModel2, related_model_after
+            )
+
         with self.subTest(
             "Do nothing if related model changed fields are not labelled immutable"
         ):

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -2,8 +2,7 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
-from payments import payables, NotRegistered, prevent_saving, PaymentError, \
-    Payable
+from payments import payables, NotRegistered, prevent_saving, PaymentError, Payable
 from payments.models import Payment
 from payments.tests.__mocks__ import MockModel, MockPayable
 
@@ -31,36 +30,26 @@ class ImmutablePayablesTest(TestCase):
         model_before.payment = Payment.objects.create(
             type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
         )
+        MockPayable.immutable_after_payment = True
+        MockPayable.immutable_model_fields_after_payment = [
+            "test_field",
+        ]
         MockPayable.get_payment = MagicMock(return_value=model_before.payment)
         MockModel.objects.get = MagicMock(return_value=model_before)
 
         with self.subTest("Unlinking a payment"):
             model_after.payment = None
-
-            with self.assertRaises(PaymentError) as test:
-                prevent_saving(MockModel, model_after)
-
-            exception = test.exception
-            self.assertEqual(
-                str(exception), "You are trying to unlink a payment from its payable."
-            )
+            self.assertRaises(PaymentError, prevent_saving, MockModel, model_after)
 
         with self.subTest("Changing an immutable model field after payment"):
             model_after.payment = model_before.payment
             model_after.test_field = "changed"
-
-            with self.assertRaises(PaymentError) as test:
-                prevent_saving(MockModel, model_after)
-
-            exception = test.exception
-            self.assertEqual(str(exception), "Cannot change this model")
-
+            self.assertRaises(PaymentError, prevent_saving, MockModel, model_after)
 
     def test_prevent_saving_no_existing_model(self):
         model = MockModel(payer=None)
         model.pk = None
-        prevent_saving(MockModel, model) # this should not crash
-
+        prevent_saving(MockModel, model)  # this should not crash
 
     def test_allow_adding_a_payment_to_unpaid_model(self):
         model_before = MockModel(payer=None)
@@ -73,7 +62,6 @@ class ImmutablePayablesTest(TestCase):
 
         MockModel.objects.get = MagicMock(return_value=model_before)
         prevent_saving(MockModel, model_after)
-
 
     def test_mutable_model(self):
         payable = payables.get_payable(MockModel)
@@ -96,8 +84,6 @@ class ImmutablePayablesTest(TestCase):
         self.assertEqual([], payable.immutable_model_fields_after_payment)
 
         self.assertEqual([], Payable.immutable_model_fields_after_payment)
-
-
 
 
 # def test_allow_saving_payable_without_immutable_field(self):

--- a/website/payments/tests/test_payables.py
+++ b/website/payments/tests/test_payables.py
@@ -1,8 +1,16 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 
-from payments import payables, NotRegistered, prevent_saving, PaymentError, Payable
+from payments import (
+    payables,
+    NotRegistered,
+    prevent_saving,
+    PaymentError,
+    Payable,
+    prevent_saving_related,
+)
 from payments.models import Payment
 from payments.tests.__mocks__ import MockModel, MockPayable
 
@@ -23,6 +31,18 @@ class PayablesTest(TestCase):
 class ImmutablePayablesTest(TestCase):
     def setUp(self):
         payables.register(MockModel, MockPayable)
+
+    def test_register(self):
+        with self.subTest("Register not immutable"):
+            MockPayable.immutable_after_payment = False
+            payables.register(MockModel, MockPayable)
+
+        with self.subTest("Register immutable"):
+            MockPayable.immutable_after_payment = True
+            MockPayable.immutable_model_fields_after_payment = [
+                "test_field",
+            ]
+            payables.register(MockModel, MockPayable)
 
     def test_prevent_unlinking_payment_from_payable(self):
         model_before = MockModel(payer=None)
@@ -51,7 +71,26 @@ class ImmutablePayablesTest(TestCase):
         model.pk = None
         prevent_saving(MockModel, model)  # this should not crash
 
+    def test_prevent_saving_not_immutable(self):
+        MockPayable.immutable_after_payment = False
+        model = MockModel(payer=None)
+        model.pk = 1
+        prevent_saving(MockModel, model)  # this should not crash
+
+    def test_prevent_saving_model_with_pk_but_not_in_db(self):
+        MockPayable.immutable_after_payment = True
+        model = MockModel(payer=None)
+        model.payment = Payment.objects.create(
+            type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
+        )
+        MockPayable.get_payment = MagicMock(return_value=model.payment)
+        MockModel.DoesNotExist = ObjectDoesNotExist
+        MockModel.objects.get = MagicMock(side_effect=MockModel.DoesNotExist)
+        model.pk = 1
+        prevent_saving(MockModel, model)  # this should not crash
+
     def test_allow_adding_a_payment_to_unpaid_model(self):
+        MockPayable.immutable_after_payment = True
         model_before = MockModel(payer=None)
         model_before.payment = None
 
@@ -65,7 +104,6 @@ class ImmutablePayablesTest(TestCase):
 
     def test_mutable_model(self):
         payable = payables.get_payable(MockModel)
-        self.assertTrue(payable.immutable_after_payment)
         MockPayable.immutable_after_payment = False
         self.assertFalse(payable.immutable_after_payment)
         MockPayable.immutable_after_payment = True
@@ -75,7 +113,6 @@ class ImmutablePayablesTest(TestCase):
 
     def test_immutable_fields(self):
         payable = payables.get_payable(MockModel)
-        self.assertEqual(["test_field"], payable.immutable_model_fields_after_payment)
         MockPayable.immutable_model_fields_after_payment = ["test1", "test2"]
         self.assertEqual(
             ["test1", "test2"], payable.immutable_model_fields_after_payment
@@ -85,9 +122,67 @@ class ImmutablePayablesTest(TestCase):
 
         self.assertEqual([], Payable.immutable_model_fields_after_payment)
 
+    def test_prevent_saving_changed_related_model_field(self):
+        MockModel2 = MockModel
+        MockPayable.immutable_after_payment = True
+        MockPayable.immutable_model_fields_after_payment = {MockModel2: ["test_field"]}
+        model = MockModel(payer=None)
+        model.payment = Payment.objects.create(
+            type=Payment.CARD, amount=2, notes="test payment", topic="test topic"
+        )
 
-# def test_allow_saving_payable_without_immutable_field(self):
-#     pass
-#     # subtest: no payment
-#     # subtest: unsaved payment
-#     # subtest: with payment
+        related_model_before = MockModel2(payer=None)
+        related_model_before.test_related_field = model
+        related_model_before.test_field = "test"
+
+        related_model_after = MockModel2(payer=None)
+        related_model_after.test_related_field = model
+        related_model_after.test_field = "changed"
+
+        MockPayable.immutable_after_payment = True
+        MockPayable.immutable_foreign_key_models = {MockModel2: ["test_related_field"]}
+
+        with self.subTest("Prevent saving changed field in related model"):
+            MockModel2.objects.get = MagicMock(return_value=related_model_before)
+            self.assertRaises(
+                PaymentError,
+                prevent_saving_related("test_related_field"),
+                MockModel2,
+                related_model_after,
+            )
+
+        with self.subTest("Do nothing if field is not changed related model"):
+            MockModel2.objects.get = MagicMock(return_value=related_model_before)
+            related_model_after.test_field = "test"
+            prevent_saving_related("test_related_field")(
+                MockModel2, related_model_after
+            )
+
+        with self.subTest("Do nothing if parent is not immutable"):
+            MockPayable.immutable_after_payment = False
+            prevent_saving_related("test_related_field")(
+                MockModel2, related_model_after
+            )
+
+        with self.subTest(
+            "Do nothing if related model changed fields are not labelled immutable"
+        ):
+            MockPayable.immutable_after_payment = True
+            MockPayable.immutable_model_fields_after_payment = {MockModel2: []}
+            prevent_saving_related("test_related_field")(
+                MockModel2, related_model_after
+            )
+
+        with self.subTest("Error if model does not exist"):
+            MockPayable.immutable_after_payment = True
+            MockPayable.immutable_foreign_key_models = {
+                MockModel2: ["test_related_field"]
+            }
+            MockModel2.DoesNotExist = ObjectDoesNotExist
+            MockModel2.objects.get = MagicMock(side_effect=MockModel2.DoesNotExist)
+            self.assertRaises(
+                PaymentError,
+                prevent_saving_related("test_related_field"),
+                MockModel2,
+                related_model_after,
+            )

--- a/website/payments/tests/test_widgets.py
+++ b/website/payments/tests/test_widgets.py
@@ -31,6 +31,14 @@ class PaymentWidgetTest(TestCase):
             self.assertEqual(context["app_label"], "mock_app")
             self.assertEqual(context["model_name"], "mock_model")
 
+        with self.subTest("Trying to set payment to none"):
+            self.obj.payment = None
+            widget = PaymentWidget(obj=self.obj)
+            context = widget.get_context("payment", None, {})
+            self.assertEqual(context["obj"].pk, payables.get_payable(self.obj).pk)
+            self.assertEqual(context["app_label"], "mock_app")
+            self.assertEqual(context["model_name"], "mock_model")
+
         with self.subTest("With payment primary key"):
             context = widget.get_context("payment", self.payment.pk, {})
             self.assertEqual(

--- a/website/payments/tests/test_widgets.py
+++ b/website/payments/tests/test_widgets.py
@@ -52,3 +52,20 @@ class PaymentWidgetTest(TestCase):
             context = widget.get_context("payment", None, {})
             self.assertNotIn("url", context)
             self.assertNotIn("payment", context)
+
+    def test_value_from_datadict(self):
+        with self.subTest("Empty value"):
+            widget = PaymentWidget()
+            value = widget.value_from_datadict([], [], None)
+            self.assertIsNone(value)
+
+        with self.subTest("With payment"):
+            widget = PaymentWidget(obj=self.obj)
+            value = widget.value_from_datadict([], [], None)
+            self.assertEqual(value, self.payment.pk)
+
+        with self.subTest("With unpaid payable"):
+            self.obj.payment = None
+            widget = PaymentWidget(obj=self.obj)
+            value = widget.value_from_datadict([], [], None)
+            self.assertIsNone(value)

--- a/website/payments/widgets.py
+++ b/website/payments/widgets.py
@@ -16,6 +16,12 @@ class PaymentWidget(Widget):
 
     def get_context(self, name, value, attrs) -> dict:
         context = super().get_context(name, value, attrs)
+        if self.obj:
+            # Make sure to ALWAYS use committed data from the database, and never invalid data that is not saved, for example from an invalid form
+            self.obj.refresh_from_db()
+            payable = payables.get_payable(self.obj)
+            if payable.payment:
+                value = payable.payment.pk
         if self.obj and not value:
             payable = payables.get_payable(self.obj)
             context["obj"] = payable

--- a/website/payments/widgets.py
+++ b/website/payments/widgets.py
@@ -20,18 +20,17 @@ class PaymentWidget(Widget):
             # Make sure to ALWAYS use committed data from the database, and never invalid data that is not saved, for example from an invalid form
             self.obj.refresh_from_db()
             payable = payables.get_payable(self.obj)
+            context["obj"] = payable
+            context["app_label"] = self.obj._meta.app_label
+            context["model_name"] = self.obj._meta.model_name
             if payable.payment:
                 value = payable.payment.pk
         if self.obj and not value:
-            payable = payables.get_payable(self.obj)
-            context["obj"] = payable
             context["payable_payer"] = (
                 PaymentUser.objects.get(pk=payable.payment_payer.pk)
                 if getattr(payable, "payment_payer", None) is not None
                 else None
             )
-            context["app_label"] = self.obj._meta.app_label
-            context["model_name"] = self.obj._meta.model_name
         elif value:
             payment = Payment.objects.get(pk=value)
             context["url"] = payment.get_admin_url()

--- a/website/payments/widgets.py
+++ b/website/payments/widgets.py
@@ -38,6 +38,13 @@ class PaymentWidget(Widget):
             context["payment"] = payment
         return context
 
+    def value_from_datadict(self, data, files, name):
+        if self.obj:
+            payable = payables.get_payable(self.obj)
+            if payable.payment:
+                return payable.payment.pk
+        return None
+
     class Media:
         js = ("admin/payments/js/payments.js",)
 

--- a/website/pizzas/payables.py
+++ b/website/pizzas/payables.py
@@ -1,4 +1,5 @@
 from django.template.defaultfilters import date
+from django.utils.functional import classproperty
 
 from payments import Payable, payables
 from pizzas.models import FoodOrder
@@ -36,6 +37,14 @@ class FoodOrderPayable(Payable):
     @property
     def tpay_allowed(self):
         return self.model.food_event.tpay_allowed
+
+    @classproperty
+    def immutable_after_payment(self):
+        return True
+
+    @classproperty
+    def immutable_model_fields_after_payment(self):
+        return ["product", "food_event", "name", "member"]
 
 
 def register():

--- a/website/pizzas/payables.py
+++ b/website/pizzas/payables.py
@@ -31,10 +31,6 @@ class FoodOrderPayable(Payable):
         return can_change_order(member, self.model.food_event)
 
     @property
-    def immutable_after_payment(self):
-        return True
-
-    @property
     def tpay_allowed(self):
         return self.model.food_event.tpay_allowed
 

--- a/website/pizzas/payables.py
+++ b/website/pizzas/payables.py
@@ -30,6 +30,10 @@ class FoodOrderPayable(Payable):
         return can_change_order(member, self.model.food_event)
 
     @property
+    def immutable_after_payment(self):
+        return True
+
+    @property
     def tpay_allowed(self):
         return self.model.food_event.tpay_allowed
 

--- a/website/registrations/payables.py
+++ b/website/registrations/payables.py
@@ -1,4 +1,5 @@
 from django.template.defaultfilters import date
+from django.utils.functional import classproperty
 
 from payments.payables import Payable, payables
 from registrations.models import Renewal, Registration, Entry
@@ -25,6 +26,14 @@ class EntryPayable(Payable):
 
     def can_manage_payment(self, member):
         return member and member.has_perm("registrations.change_entry")
+
+    @classproperty
+    def immutable_after_payment(self):
+        return True
+
+    @classproperty
+    def immutable_model_fields_after_payment(self):
+        return ["length", "contribution"]
 
 
 class RegistrationPayable(EntryPayable):

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -199,7 +199,6 @@ def revert_entry(user_id: int or None, entry: Entry) -> None:
     payment = entry.payment
     entry.status = Entry.STATUS_REVIEW
     entry.updated_at = timezone.now()
-    entry.payment = None
     entry.save()
     if payment is not None:
         payment.delete()

--- a/website/registrations/tests/test_admin.py
+++ b/website/registrations/tests/test_admin.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 
 from members.models import Member
 from payments.widgets import PaymentWidget
-from registrations import admin
+from registrations import admin, payables
 from registrations.models import Entry, Registration, Renewal, Reference
 
 
@@ -54,6 +54,7 @@ class RegistrationAdminTest(TestCase):
     def setUp(self):
         self.site = AdminSite()
         self.admin = admin.RegistrationAdmin(Registration, admin_site=self.site)
+        payables.register()
 
     @mock.patch("django.contrib.admin.ModelAdmin.changeform_view")
     @mock.patch("registrations.models.Entry.objects.get")

--- a/website/registrations/tests/test_models.py
+++ b/website/registrations/tests/test_models.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from freezegun import freeze_time
 
 from members.models import Member, Membership, Profile
+from registrations import payables
 from registrations.models import Entry, Registration, Renewal, Reference
 
 
@@ -39,6 +40,9 @@ class EntryTest(TestCase):
             length=Entry.MEMBERSHIP_STUDY,
             membership_type=Membership.MEMBER,
         )
+
+    def setUp(self) -> None:
+        payables.register()
 
     def test_str(self):
         entry = Entry(registration=self.registration)

--- a/website/sales/admin/order_admin.py
+++ b/website/sales/admin/order_admin.py
@@ -206,6 +206,7 @@ class OrderAdmin(admin.ModelAdmin):
         "num_items",
         "subtotal",
         "total_amount",
+        "payment",
         "age_restricted",
         "payment_url",
     )

--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -219,6 +219,8 @@ class OrderItem(models.Model):
     ):
         if self.order.shift.locked:
             raise ValueError("The shift this order belongs to is locked.")
+        if self.order.payment:
+            raise ValueError("This order has already been paid for.")
 
         if not self.total:
             self.total = self.product.price * self.amount

--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -219,8 +219,6 @@ class OrderItem(models.Model):
     ):
         if self.order.shift.locked:
             raise ValueError("The shift this order belongs to is locked.")
-        if self.order.payment:
-            raise ValueError("This order has already been paid for.")
 
         if not self.total:
             self.total = self.product.price * self.amount

--- a/website/sales/payables.py
+++ b/website/sales/payables.py
@@ -25,6 +25,10 @@ class OrderPayable(Payable):
             "sales.change_order"
         )
 
+    @property
+    def immutable_after_payment(self):
+        return True
+
 
 def register():
     payables.register(Order, OrderPayable)

--- a/website/sales/payables.py
+++ b/website/sales/payables.py
@@ -1,5 +1,7 @@
+from django.utils.functional import classproperty
+
 from payments import Payable, payables
-from sales.models.order import Order
+from sales.models.order import Order, OrderItem
 from sales.services import is_manager
 
 
@@ -25,9 +27,28 @@ class OrderPayable(Payable):
             "sales.change_order"
         )
 
-    @property
+    @classproperty
     def immutable_after_payment(self):
         return True
+
+    @classproperty
+    def immutable_foreign_key_models(self):
+        return {OrderItem: "order"}
+
+    @classproperty
+    def immutable_model_fields_after_payment(self):
+        return {
+            Order: [
+                "items",
+                "discount",
+                "order_description",
+                "subtotal",
+                "total_amount",
+                "payer",
+                "shift",
+            ],
+            OrderItem: ["product", "order", "total", "amount"],
+        }
 
 
 def register():

--- a/website/sales/tests/test_models.py
+++ b/website/sales/tests/test_models.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 
 from activemembers.models import Committee, MemberGroupMembership
 from members.models import Member
+from payments import PaymentError
 from payments.models import Payment
 from payments.services import create_payment
 from sales.models.order import Order, OrderItem
@@ -254,7 +255,7 @@ class OrderTest(TestCase):
         with self.assertRaises(ValueError):
             order.save()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PaymentError):
             OrderItem.objects.create(
                 order=order,
                 product=self.shift.product_list.product_items.get(product=self.wine),
@@ -262,7 +263,7 @@ class OrderTest(TestCase):
             )
 
         i1.amount = 3
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PaymentError):
             i1.save()
 
         i1.refresh_from_db()

--- a/website/sales/tests/test_models.py
+++ b/website/sales/tests/test_models.py
@@ -255,7 +255,7 @@ class OrderTest(TestCase):
         with self.assertRaises(ValueError):
             order.save()
 
-        with self.assertRaises(PaymentError):
+        with self.assertRaises(ValueError):
             OrderItem.objects.create(
                 order=order,
                 product=self.shift.product_list.product_items.get(product=self.wine),
@@ -263,7 +263,7 @@ class OrderTest(TestCase):
             )
 
         i1.amount = 3
-        with self.assertRaises(PaymentError):
+        with self.assertRaises(ValueError):
             i1.save()
 
         i1.refresh_from_db()


### PR DESCRIPTION
Closes #1766 

### Summary
Connects a model pre_save signal when registering payables. The signal will prevent saving models with certain fields changed if the payable is actually paid. This gives a hard guarantee that payable models are immutable after payment, integrated in the payments app.

### How to test
1. Try to save payable models or fields with a foreign key to payable models, that are marked as immutable, when the payable is paid.
2. Be careful for edge cases: creating new objects that directly have a payment too, what if we try to delete a payment from a model, etc.