### PR TITLE
Fix shift statistics

### DIFF
--- a/website/sales/models/shift.py
+++ b/website/sales/models/shift.py
@@ -153,6 +153,7 @@ class Shift(models.Model):
             .values("order_items__product")
             .distinct()
             .annotate(sold=Sum("order_items__amount"))
+            .order_by()
         )
         return {
             item[0]: item[1]

--- a/website/sales/models/shift.py
+++ b/website/sales/models/shift.py
@@ -151,7 +151,6 @@ class Shift(models.Model):
         qs = (
             self.orders.exclude(order_items__isnull=True)
             .values("order_items__product")
-            .distinct()
             .annotate(sold=Sum("order_items__amount"))
             .order_by()
         )

--- a/website/sales/tests/test_models.py
+++ b/website/sales/tests/test_models.py
@@ -453,6 +453,17 @@ class ShiftTest(TestCase):
         o5.payment = create_payment(o5, processed_by=self.member, pay_type=Payment.CASH)
         o5.save()
 
+        # The test was accidentally passing because orders had the same created at,
+        # resulting in the distinct seeing them as the same order
+        o2.created_at += timezone.timedelta(minutes=1)
+        o3.created_at += timezone.timedelta(minutes=2)
+        o4.created_at += timezone.timedelta(minutes=3)
+        o5.created_at += timezone.timedelta(minutes=4)
+        o2.save()
+        o3.save()
+        o4.save()
+        o5.save()
+
         self.assertEqual(self.shift.total_revenue, 6)
         self.assertEqual(self.shift.total_revenue_paid, 3)
 


### PR DESCRIPTION
Closes #1781 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The sales statistics were incorrect since the results were not grouped by the `product_id` which is now done by using the `order_by()`

### How to test
Steps to test the changes you made:
1. Create a shift
2. Add an order with 5x beer to the shift
3. Add a new order with 3x beer to the shift
4. Go to the shift in the admin and see that there are 8 beer sales
