### PR TITLE
Show order payment url for free orders to identify

### DIFF
--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -162,7 +162,6 @@ class Order(models.Model):
         return (
             settings.BASE_URL + reverse("sales:order-pay", kwargs={"pk": self.pk})
             if not self.payment
-            and (self.total_amount is not None and self.total_amount != 0)
             else None
         )
 

--- a/website/sales/views.py
+++ b/website/sales/views.py
@@ -23,10 +23,6 @@ class OrderPaymentView(View):
         order.payer = request.member
         order.save()
 
-        if order.total_amount == 0:
-            messages.warning(request, _("This order doesn't require payment."))
-            return redirect("index")
-
         if order.age_restricted and not services.is_adult(request.member):
             messages.error(
                 request,
@@ -35,4 +31,19 @@ class OrderPaymentView(View):
                 ),
             )
             return redirect("index")
+
+        if (
+            order.age_restricted
+            and services.is_adult(request.member)
+            and order.total_amount == 0
+        ):
+            messages.success(
+                request, _("You have successfully identified yourself for this order.")
+            )
+            return redirect("index")
+
+        if order.total_amount == 0:
+            messages.info(request, _("This order doesn't require payment."))
+            return redirect("index")
+
         return render(request, "sales/order_payment.html", {"order": order})


### PR DESCRIPTION
Closes #1779 

### Summary
Right now, the payment url for orders will still work for free orders to identify members if they need to identify for the age check.

### How to test
Steps to test the changes you made:
1. Have a free order that is age restricted
2. The API should still provide a payment URL
3. Visiting the payment URL will show a success message that you successfully identified