### PR TITLE
Do not submit form onload if tpay not enabled

### DIFF
--- a/website/payments/templates/payments/templatetags/payment_button.html
+++ b/website/payments/templates/payments/templatetags/payment_button.html
@@ -28,15 +28,17 @@
                      data-html="true" title="To start using Thalia Pay, you need to <a href='{% url 'payments:bankaccount-add' %}' target='_blank'>sign a direct debit mandate</a>."
                 >
                     <input
-                    type="submit"
-                    disabled="disabled"
-                    class="btn btn-primary"
-                    style="pointer-events: none;"
-                    value="{% trans "Pay with Thalia Pay" %}"
+                        id="tpay-submit-button"
+                        type="submit"
+                        disabled="disabled"
+                        class="btn btn-primary"
+                        style="pointer-events: none;"
+                        value="{% trans "Pay with Thalia Pay" %}"
                     />
                 </span>
             {% else %}
                 <input
+                    id="tpay-submit-button"
                     type="submit"
                     class="btn btn-primary"
                     value="{% trans "Pay with Thalia Pay" %}"

--- a/website/sales/templates/sales/order_payment.html
+++ b/website/sales/templates/sales/order_payment.html
@@ -20,8 +20,9 @@
     {{ block.super }}
     <script type="text/javascript">
         window.onload=function() {
-            if (!document.getElementById("tpay-submit-button").disabled)
+            if (!document.getElementById("tpay-submit-button").disabled) {
                 document.forms['tpay-payment-form'].submit();
+            }
         }
     </script>
 {% endblock %}

--- a/website/sales/templates/sales/order_payment.html
+++ b/website/sales/templates/sales/order_payment.html
@@ -20,7 +20,8 @@
     {{ block.super }}
     <script type="text/javascript">
         window.onload=function() {
-            document.forms['tpay-payment-form'].submit();
+            if (!document.getElementById("tpay-submit-button").disabled)
+                document.forms['tpay-payment-form'].submit();
         }
     </script>
 {% endblock %}


### PR DESCRIPTION
Closes #1780 

### Summary
The javascript in the sales order payment view will not automatically try to POST a payment if the user does not have TPAY enabled

### How to test
1. Have a sales order
2. Don't have tpay enabled
3. Try to scan the QR code
4. It will not crash 