### PR TITLE
Change scopes for sales API

### DIFF
--- a/website/sales/api/v2/admin/views.py
+++ b/website/sales/api/v2/admin/views.py
@@ -30,7 +30,7 @@ class ShiftListView(AdminListAPIView):
     )
     ordering_fields = ("start", "end")
     permission_classes = [IsAuthenticatedOrTokenHasScope, DjangoModelPermissions]
-    required_scopes = ["sales:read"]
+    required_scopes = ["sales:admin"]
 
     def get_queryset(self):
         queryset = super().get_queryset().filter(locked=False)
@@ -62,7 +62,7 @@ class ShiftDetailView(AdminRetrieveAPIView):
         DjangoModelPermissions,
         IsManager,
     ]
-    required_scopes = ["sales:read"]
+    required_scopes = ["sales:admin"]
 
 
 class OrderListView(AdminListAPIView, AdminCreateAPIView):
@@ -75,10 +75,7 @@ class OrderListView(AdminListAPIView, AdminCreateAPIView):
         DjangoModelPermissions,
         IsManager,
     ]
-    required_scopes_per_method = {
-        "GET": ["sales:read"],
-        "POST": ["sales:write"],
-    }
+    required_scopes = ["sales:admin"]
     shift_lookup_field = "pk"
 
     def get_serializer_class(self):
@@ -130,12 +127,7 @@ class OrderDetailView(AdminRetrieveAPIView, AdminUpdateAPIView, AdminDestroyAPIV
         DjangoModelPermissions,
         IsManager,
     ]
-    required_scopes_per_method = {
-        "GET": ["sales:read"],
-        "PATCH": ["sales:write"],
-        "PUT": ["sales:write"],
-        "DELETE": ["sales:write"],
-    }
+    required_scopes = ["sales:admin"]
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -533,7 +533,8 @@ OAUTH2_PROVIDER = {
         "payments:write": "Write access to payments",
         "payments:admin": "Admin access to payments",
         "sales:read": "Read access to Point of Sale orders",
-        "sales:write": "Write access to Point of Sale orders",
+        "sales:order": "Write access to Point of Sale orders",
+        "sales:admin": "Admin access to Point of Sale orders",
     },
 }
 

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -532,8 +532,8 @@ OAUTH2_PROVIDER = {
         "payments:read": "Read access to payments",
         "payments:write": "Write access to payments",
         "payments:admin": "Admin access to payments",
-        "sales:read": "Read access to Point of Sale orders",
-        "sales:order": "Write access to Point of Sale orders",
+        "sales:read": "Read access to your Point of Sale orders",
+        "sales:order": "Place Point of Sale orders on your behalf",
         "sales:admin": "Admin access to Point of Sale orders",
     },
 }


### PR DESCRIPTION
Closes #1775 

### Summary
Use a consistent scopes in the sales app as in other apps 

### How to test
1. Check that the sales API still works (every view is still accessible if you have the `sales:admin` scope)