### PR TITLE
Use color variable for events admin payment dropdown text

### DIFF
--- a/website/events/static/events/css/admin.scss
+++ b/website/events/static/events/css/admin.scss
@@ -48,7 +48,6 @@
 
         select[name=payment] {
             background: var(--message-error-bg);
-            color: var(--text-color);
 
             &.paid {
                 background: var(--message-success-bg);

--- a/website/events/static/events/css/admin.scss
+++ b/website/events/static/events/css/admin.scss
@@ -48,7 +48,7 @@
 
         select[name=payment] {
             background: var(--message-error-bg);
-            color: white;
+            color: var(--text-color);
 
             &.paid {
                 background: var(--message-success-bg);


### PR DESCRIPTION
Closes #1777

<img width="418" alt="image" src="https://user-images.githubusercontent.com/7915741/123853000-3916b300-d91d-11eb-8576-19e3e1ce889d.png">

### Summary
Changes the payment dropdown in the events admin to use color variables, so the widget is shown correctly in light mode as well

### How to test
1. Visit the events admin in multiple browsers, in dark mode and light mode
2. See the issue for the problematic cases 
3. Don't forget to clear your cache