### PR TITLE
Display warning in order admin if payer is underage

### DIFF
--- a/website/sales/admin/order_admin.py
+++ b/website/sales/admin/order_admin.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from payments.widgets import PaymentWidget
+from sales import services
 from sales.models.order import Order, OrderItem
 from sales.models.shift import Shift
 from sales.services import is_manager
@@ -220,6 +221,19 @@ class OrderAdmin(admin.ModelAdmin):
             default_fields += ("shift",)
 
         return default_fields
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        if object_id:
+            obj = self.model.objects.get(pk=object_id)
+            if obj.age_restricted and obj.payer and not services.is_adult(obj.payer):
+                self.message_user(
+                    request,
+                    _(
+                        "The payer for this user is under-age while the order is age restricted!"
+                    ),
+                    messages.WARNING,
+                )
+        return super().changeform_view(request, object_id, form_url, extra_context)
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)

--- a/website/sales/admin/order_admin.py
+++ b/website/sales/admin/order_admin.py
@@ -229,7 +229,7 @@ class OrderAdmin(admin.ModelAdmin):
                 self.message_user(
                     request,
                     _(
-                        "The payer for this user is under-age while the order is age restricted!"
+                        "The payer for this order is under-age while the order is age restricted!"
                     ),
                     messages.WARNING,
                 )


### PR DESCRIPTION
Closes #1663

### Summary
Displays a warning in the OrderAdmin if the payer set for an order is under age

### How to test
1. Create an order that is age restricted
2. Set the payer to an under-age member
3. Warning is shown
4. Not age-restricted: no warning, not under-age: no warning