### PR TITLE
Fix photo album event title save

### DIFF
--- a/website/photos/models.py
+++ b/website/photos/models.py
@@ -155,7 +155,7 @@ class Album(models.Model):
             self.dirname = self.slug
 
         if not self.title and self.event:
-            self.title = self.event.title_en
+            self.title = self.event.title
 
         if not self.date:
             self.date = self.event.start.date()


### PR DESCRIPTION
Closes #1801 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Fix the usage of the attribute. Was renamed and probably caused by 


### How to test
Steps to test the changes you made:
1. Create a new photo album and connect an event
