### PR TITLE
Set allowed API versions to fix API v1 default pagination

### DIFF
--- a/website/thaliawebsite/api/urls.py
+++ b/website/thaliawebsite/api/urls.py
@@ -13,37 +13,41 @@ urlpatterns = [
         "",
         include(
             [
-                path("v1/", include("thaliawebsite.api.v1.urls", namespace="v1")),
-                path(
-                    "v1/schema",
-                    get_schema_view(
-                        title="API v1",
-                        version=settings.SOURCE_COMMIT,
-                        url="/api/v1/",
-                        urlconf="thaliawebsite.api.v1.urls",
-                        generator_class=OAuthSchemaGenerator,
+                path("v1/", include(([
+                    path("", include("thaliawebsite.api.v1.urls")),
+                    path(
+                        "schema",
+                        get_schema_view(
+                            title="API v1",
+                            version=settings.SOURCE_COMMIT,
+                            url="/api/v1/",
+                            urlconf="thaliawebsite.api.v1.urls",
+                            generator_class=OAuthSchemaGenerator,
+                        ),
+                        name="schema",
                     ),
-                    name="schema-v1",
-                ),
-                path("v2/", include("thaliawebsite.api.v2.urls", namespace="v2")),
-                path(
-                    "v2/schema",
-                    get_schema_view(
-                        title="API v2",
-                        version=settings.SOURCE_COMMIT,
-                        url="/api/v2/",
-                        urlconf="thaliawebsite.api.v2.urls",
-                        generator_class=OAuthSchemaGenerator,
-                        public=True,
+                ], "thaliawebsite"), namespace="v1")),
+                path("v2/", include(([
+                    path("", include("thaliawebsite.api.v2.urls")),
+                    path(
+                        "schema",
+                        get_schema_view(
+                            title="API v2",
+                            version=settings.SOURCE_COMMIT,
+                            url="/api/v2/",
+                            urlconf="thaliawebsite.api.v2.urls",
+                            generator_class=OAuthSchemaGenerator,
+                            public=True,
+                        ),
+                        name="schema",
                     ),
-                    name="schema-v2",
-                ),
+                ], "thaliawebsite"), namespace="v2")),
                 path(
                     "docs",
                     TemplateView.as_view(
                         template_name="swagger/index.html",
                         extra_context={
-                            "schema_urls": ["api:schema-v1", "api:schema-v2"]
+                            "schema_urls": ["api:v1:schema", "api:v2:schema"]
                         },
                     ),
                     name="swagger",

--- a/website/thaliawebsite/api/urls.py
+++ b/website/thaliawebsite/api/urls.py
@@ -13,35 +13,8 @@ urlpatterns = [
         "",
         include(
             [
-                path("v1/", include(([
-                    path("", include("thaliawebsite.api.v1.urls")),
-                    path(
-                        "schema",
-                        get_schema_view(
-                            title="API v1",
-                            version=settings.SOURCE_COMMIT,
-                            url="/api/v1/",
-                            urlconf="thaliawebsite.api.v1.urls",
-                            generator_class=OAuthSchemaGenerator,
-                        ),
-                        name="schema",
-                    ),
-                ], "thaliawebsite"), namespace="v1")),
-                path("v2/", include(([
-                    path("", include("thaliawebsite.api.v2.urls")),
-                    path(
-                        "schema",
-                        get_schema_view(
-                            title="API v2",
-                            version=settings.SOURCE_COMMIT,
-                            url="/api/v2/",
-                            urlconf="thaliawebsite.api.v2.urls",
-                            generator_class=OAuthSchemaGenerator,
-                            public=True,
-                        ),
-                        name="schema",
-                    ),
-                ], "thaliawebsite"), namespace="v2")),
+                path("v1/", include("thaliawebsite.api.v1.urls", namespace="v1")),
+                path("v2/", include("thaliawebsite.api.v2.urls", namespace="v2")),
                 path(
                     "docs",
                     TemplateView.as_view(

--- a/website/thaliawebsite/api/v1/urls.py
+++ b/website/thaliawebsite/api/v1/urls.py
@@ -1,7 +1,9 @@
+from django.conf import settings
 from django.urls import path, include
+from rest_framework.schemas import get_schema_view
 
 from members.views import ObtainThaliaAuthToken
-
+from thaliawebsite.api.openapi import OAuthSchemaGenerator
 
 app_name = "thaliawebsite"
 
@@ -16,4 +18,15 @@ urlpatterns = [
     path("", include("photos.api.v1.urls")),
     path("", include("pushnotifications.api.v1.urls")),
     path("", include("payments.api.v1.urls")),
+    path(
+        "schema",
+        get_schema_view(
+            title="API v1",
+            version=settings.SOURCE_COMMIT,
+            url="/api/v1/",
+            urlconf="thaliawebsite.api.v1.urls",
+            generator_class=OAuthSchemaGenerator,
+        ),
+        name="schema",
+    ),
 ]

--- a/website/thaliawebsite/api/v2/urls.py
+++ b/website/thaliawebsite/api/v2/urls.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from django.urls import path, include
+from rest_framework.schemas import get_schema_view
 
-from thaliawebsite.api.v2 import admin
+from thaliawebsite.api.openapi import OAuthSchemaGenerator
 
 app_name = "thaliawebsite"
 
@@ -15,4 +17,16 @@ urlpatterns = [
     path("", include("photos.api.v2.urls")),
     path("", include("pizzas.api.v2.urls")),
     path("", include("pushnotifications.api.v2.urls")),
+    path(
+        "schema",
+        get_schema_view(
+            title="API v2",
+            version=settings.SOURCE_COMMIT,
+            url="/api/v2/",
+            urlconf="thaliawebsite.api.v2.urls",
+            generator_class=OAuthSchemaGenerator,
+            public=True,
+        ),
+        name="schema",
+    ),
 ]

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -580,6 +580,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_PAGINATION_CLASS": "thaliawebsite.api.pagination.APIv2LimitOffsetPagination",
     "PAGE_SIZE": 50,  # Only for API v2
+    "ALLOWED_VERSIONS": ["v1", "v2"],
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "DEFAULT_SCHEMA_CLASS": "thaliawebsite.api.openapi.OAuthAutoSchema",
     "DEFAULT_THROTTLE_CLASSES": [


### PR DESCRIPTION

### Summary
Set allowed API versions to fix API v1 default pagination

### How to test
Steps to test the changes you made:
1. Go to /api/v1/members/
2. See that it is not paginated by default
3. Go to the v2 version and see that there is pagination
