### PR TITLE
Fix client-credentials authenticated clients accessing the API

### DIFF
--- a/website/activemembers/api/v2/views.py
+++ b/website/activemembers/api/v2/views.py
@@ -5,7 +5,6 @@ from rest_framework.generics import (
     ListAPIView,
     RetrieveAPIView,
 )
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from activemembers.api.v2 import filters
 from activemembers.api.v2.serializers.member_group import (
@@ -31,7 +30,6 @@ class MemberGroupListView(ListAPIView):
     search_fields = ("name",)
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["activemembers:read"]
 
@@ -43,7 +41,6 @@ class MemberGroupDetailView(RetrieveAPIView):
     queryset = MemberGroup.active_objects.all()
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["activemembers:read"]
 

--- a/website/announcements/api/v2/views.py
+++ b/website/announcements/api/v2/views.py
@@ -5,7 +5,6 @@ from rest_framework.generics import (
     ListAPIView,
     RetrieveAPIView,
 )
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from announcements.api.v2.serializers import SlideSerializer, FrontpageArticleSerializer
 from announcements.models import Slide, FrontpageArticle
@@ -14,7 +13,6 @@ from announcements.models import Slide, FrontpageArticle
 class AnnouncementsAPIViewMixin:
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["announcements:read"]
 

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -8,7 +8,6 @@ from rest_framework.generics import (
     RetrieveAPIView,
     UpdateAPIView,
 )
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from members.api.v2 import filters
 from thaliawebsite.api.openapi import OAuthAutoSchema
@@ -28,7 +27,6 @@ class MemberListView(ListAPIView):
     queryset = Member.current_members.all()
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["members:read"]
     filter_backends = (
@@ -54,7 +52,6 @@ class MemberDetailView(RetrieveAPIView):
     queryset = Member.current_members.all()
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["members:read"]
 
@@ -66,7 +63,6 @@ class MemberCurrentView(MemberDetailView, UpdateAPIView):
     schema = OAuthAutoSchema(operation_id_base="CurrentMember")
     permission_classes = [
         IsAuthenticatedOrTokenHasScopeForMethod,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes_per_method = {
         "GET": ["profile:read"],

--- a/website/photos/api/v2/views.py
+++ b/website/photos/api/v2/views.py
@@ -2,7 +2,6 @@ from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScop
 from rest_framework import filters
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import ListAPIView, RetrieveAPIView
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from photos import services
 from photos.api.v2.serializers.album import AlbumListSerializer, AlbumSerializer
@@ -16,7 +15,6 @@ class AlbumListView(ListAPIView):
     queryset = Album.objects.filter(hidden=False)
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["photos:read"]
     filter_backends = (filters.SearchFilter,)
@@ -30,7 +28,6 @@ class AlbumDetailView(RetrieveAPIView):
     queryset = Album.objects.filter(hidden=False)
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["photos:read"]
     lookup_field = "slug"

--- a/website/pizzas/api/v2/views.py
+++ b/website/pizzas/api/v2/views.py
@@ -9,7 +9,6 @@ from rest_framework.generics import (
 )
 
 from rest_framework import filters as framework_filters, status
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from rest_framework.response import Response
 
 from payments.exceptions import PaymentError
@@ -38,7 +37,6 @@ class FoodEventListView(ListAPIView):
     ordering_fields = ("start", "end")
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["food:read"]
 
@@ -50,7 +48,6 @@ class FoodEventDetailView(RetrieveAPIView):
     queryset = FoodEvent.objects.all()
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["food:read"]
 
@@ -64,7 +61,6 @@ class FoodEventProductsListView(ListAPIView):
     search_fields = ("name",)
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes = ["food:read"]
 
@@ -76,7 +72,6 @@ class FoodEventOrderDetailView(
 
     permission_classes = [
         IsAuthenticatedOrTokenHasScopeForMethod,
-        DjangoModelPermissionsOrAnonReadOnly,
     ]
     required_scopes_per_method = {
         "GET": ["food:read"],


### PR DESCRIPTION
### Summary
Fix client-credentials authenticated clients accessing the API. Because this authentication class requires `request.user` to exist and for API clients without a user it does not. And the class actually does not do anything since we already check for authentication and everything is basically made using the scopes unless we are talking about the admin APIs.

### How to test
Steps to test the changes you made:
1. Create client with client credentials
2. Get the members
3. No longer get an error that you have no permissions
