### PR TITLE
Serialize event registration payment as object

### DIFF
--- a/website/events/api/v2/admin/serializers/event_registration.py
+++ b/website/events/api/v2/admin/serializers/event_registration.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from events.models import EventRegistration
 from members.api.v2.serializers.member import MemberSerializer
 from members.models import Member
+from payments.api.v2.serializers import PaymentSerializer
 
 
 class EventRegistrationAdminSerializer(serializers.ModelSerializer):
@@ -21,6 +22,8 @@ class EventRegistrationAdminSerializer(serializers.ModelSerializer):
             "name",
         )
         read_only_fields = ("payment",)
+
+    payment = PaymentSerializer()
 
     def to_internal_value(self, data):
         self.fields["member"] = serializers.PrimaryKeyRelatedField(

--- a/website/events/api/v2/serializers/event_registration.py
+++ b/website/events/api/v2/serializers/event_registration.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from events.models import EventRegistration
 from members.api.v2.serializers.member import MemberSerializer
+from payments.api.v2.serializers import PaymentSerializer
 
 
 class EventRegistrationSerializer(serializers.ModelSerializer):
@@ -31,4 +32,5 @@ class EventRegistrationSerializer(serializers.ModelSerializer):
             "name",
         )
 
+    payment = PaymentSerializer()
     member = MemberSerializer(detailed=False, read_only=True)


### PR DESCRIPTION
Closes #1817 

### Summary
Serialize event registration payment as object

### How to test
Steps to test the changes you made:
1. Go to an object in the API
2. Check that it contains the payment if available
