### PR TITLE
Add search filter to event registration admin api

### DIFF
--- a/website/events/api/v2/admin/views.py
+++ b/website/events/api/v2/admin/views.py
@@ -77,10 +77,8 @@ class EventRegistrationAdminListView(AdminListAPIView, AdminCreateAPIView):
     )
     ordering_fields = ("queue_position", "date", "date_cancelled")
     search_fields = (
-        "member__profile__nickname",
         "member__first_name",
         "member__last_name",
-        "member__username",
         "name",
     )
 

--- a/website/events/api/v2/admin/views.py
+++ b/website/events/api/v2/admin/views.py
@@ -72,9 +72,17 @@ class EventRegistrationAdminListView(AdminListAPIView, AdminCreateAPIView):
     required_scopes = ["events:admin"]
     filter_backends = (
         framework_filters.OrderingFilter,
+        framework_filters.SearchFilter,
         filters.EventRegistrationCancelledFilter,
     )
     ordering_fields = ("queue_position", "date", "date_cancelled")
+    search_fields = (
+        "member__profile__nickname",
+        "member__first_name",
+        "member__last_name",
+        "member__username",
+        "name",
+    )
 
     def get_queryset(self):
         event = get_object_or_404(Event, pk=self.kwargs.get("pk"))


### PR DESCRIPTION
Closes #1825.

### Summary
Adds a search parameter to the event registration admin api.

### How to test
Steps to test the changes you made:
1. Check out the search parameter in `api/v2/admin/events/<id>/registrations/`
