### PR TITLE
Use correct permission classes in sales admin API for token scope check

### DIFF
--- a/website/sales/api/v2/admin/views.py
+++ b/website/sales/api/v2/admin/views.py
@@ -16,7 +16,6 @@ from thaliawebsite.api.v2.admin import (
     AdminUpdateAPIView,
     AdminDestroyAPIView,
 )
-from thaliawebsite.api.v2.permissions import IsAuthenticatedOrTokenHasScopeForMethod
 
 
 class ShiftListView(AdminListAPIView):
@@ -71,7 +70,7 @@ class OrderListView(AdminListAPIView, AdminCreateAPIView):
         ("POST",): OrderSerializer,
     }
     permission_classes = [
-        IsAuthenticatedOrTokenHasScopeForMethod,
+        IsAuthenticatedOrTokenHasScope,
         DjangoModelPermissions,
         IsManager,
     ]
@@ -123,7 +122,7 @@ class OrderDetailView(AdminRetrieveAPIView, AdminUpdateAPIView, AdminDestroyAPIV
     serializer_class = OrderSerializer
     queryset = Order.objects.all()
     permission_classes = [
-        IsAuthenticatedOrTokenHasScopeForMethod,
+        IsAuthenticatedOrTokenHasScope,
         DjangoModelPermissions,
         IsManager,
     ]


### PR DESCRIPTION
Closes #1812 

### Summary
Change the permission classes in the sales admin API to not use per-method scopes, after #1775 

### How to test
1. Run thadmin
2. Try to place an order
3. No 500