### PR TITLE
Add cancel too late message to API v2

### DIFF
--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -32,6 +32,7 @@ class EventSerializer(serializers.ModelSerializer):
             "num_participants",
             "max_participants",
             "no_registration_message",
+            "cancel_too_late_message",
             "has_fields",
             "food_event",
             "maps_url",


### PR DESCRIPTION
Closes #1383

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
We added this in API v1 while refactoring API v2. So it was missing.

### How to test
Steps to test the changes you made:
1. Go to /api/docs, select v2
2. Check the events for cancel messages
