### PR TITLE
Remove cache from payable registry

### DIFF
--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -52,6 +52,7 @@ class Payable:
 class Payables:
     _registry = {}
 
+    @lru_cache(maxsize=None)
     def _get_key(self, model):
         return f"{model._meta.app_label}_{model._meta.model_name}"
 

--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -52,11 +52,9 @@ class Payable:
 class Payables:
     _registry = {}
 
-    @lru_cache(maxsize=None)
     def _get_key(self, model):
         return f"{model._meta.app_label}_{model._meta.model_name}"
 
-    @lru_cache(maxsize=None)
     def get_payable(self, model: Model) -> Payable:
         if self._get_key(model) not in self._registry:
             raise NotRegistered(f"No Payable registered for {self._get_key(model)}")

--- a/website/payments/tests/test_views.py
+++ b/website/payments/tests/test_views.py
@@ -580,7 +580,7 @@ class PaymentProcessViewTest(TestCase):
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(
-            payables.get_payable(self.model), response.context_data["payable"]
+            payables.get_payable(self.model).pk, response.context_data["payable"].pk
         )
         self.assertContains(response, "Please confirm your payment.")
         self.assertContains(response, 'name="_save"')
@@ -594,9 +594,8 @@ class PaymentProcessViewTest(TestCase):
             data={**self.test_body, "_save": True},
         )
 
-        create_payment.assert_called_with(
-            payables.get_payable(self.model), self.user, Payment.TPAY
-        )
+        create_payment.assert_called_with(ANY, self.user, Payment.TPAY)
+        self.assertEqual(create_payment.call_args.args[0].pk, self.model.pk)
 
         messages_success.assert_called_with(
             ANY, "Your payment has been processed successfully."

--- a/website/payments/tests/test_widgets.py
+++ b/website/payments/tests/test_widgets.py
@@ -27,7 +27,7 @@ class PaymentWidgetTest(TestCase):
 
         with self.subTest("With object only"):
             context = widget.get_context("payment", None, {})
-            self.assertEqual(context["obj"], payables.get_payable(self.obj))
+            self.assertEqual(context["obj"].pk, payables.get_payable(self.obj).pk)
             self.assertEqual(context["app_label"], "mock_app")
             self.assertEqual(context["model_name"], "mock_model")
 


### PR DESCRIPTION
Closes #1865

### Summary
The payable registry could use old data when querying a payable while a payment was deleted for that object. This lead to weird behavior.

### How to test
Previously:

1. Have a payable object, for example an event registration
2. Add a payment for it (write down the uuid and created_at if you want to see something funny)
3. Delete the payment
4. Inspect that the payment is really really deleted
5. Re-create a payment
6. The same payment with the same uuid and created_at re-appears in the database 🤯 

Now:

1. Have a payable object, for example an event registration
2. Add a payment for it
3. Delete the payment
4. Re-create the payment
5. The payment is re-created and has a different uuid and created_at field

Also:

1. Have a payable object, for example an event registration
2. Add a payment for it
3. Delete the payment
4. Trying to re-create the payment via API will not give errors saying that it is already paid!