### PR TITLE
Remove multilang fields from partners app

### DIFF
--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -12,7 +12,6 @@ from tinymce.models import HTMLField
 from announcements.models import Slide
 from members.models import Member
 from pushnotifications.models import ScheduledMessage, Category
-from utils.translation import ModelTranslateMeta, MultilingualField
 
 
 class Event(models.Model):

--- a/website/events/models/registration_information_field.py
+++ b/website/events/models/registration_information_field.py
@@ -1,7 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
-from utils.translation import MultilingualField
 from . import Event, EventRegistration
 
 

--- a/website/partners/admin.py
+++ b/website/partners/admin.py
@@ -52,10 +52,10 @@ class PartnerAdmin(admin.ModelAdmin):
 
 
 @admin.register(VacancyCategory)
-class VacancyCategoryAdmin(TranslatedModelAdmin):
+class VacancyCategoryAdmin(admin.ModelAdmin):
     """Class to show vacancy categories in the admin."""
 
-    prepopulated_fields = {"slug": ("name_en",)}
+    prepopulated_fields = {"slug": ("name",)}
     fields = ["name", "slug"]
 
 
@@ -78,7 +78,7 @@ class VacancyAdmin(admin.ModelAdmin):
 
 
 @admin.register(PartnerEvent)
-class PartnerEventAdmin(TranslatedModelAdmin):
+class PartnerEventAdmin(admin.ModelAdmin):
     """Class to show partner events in the admin."""
 
     fields = (

--- a/website/partners/models.py
+++ b/website/partners/models.py
@@ -5,7 +5,6 @@ from django.urls import reverse
 from django.utils.translation import gettext, gettext_lazy as _
 from tinymce.models import HTMLField
 
-from utils.translation import ModelTranslateMeta, MultilingualField
 from utils import countries
 
 

--- a/website/partners/models.py
+++ b/website/partners/models.py
@@ -115,10 +115,10 @@ class PartnerImage(models.Model):
         return gettext("image of {}").format(self.partner.name)
 
 
-class VacancyCategory(models.Model, metaclass=ModelTranslateMeta):
+class VacancyCategory(models.Model):
     """Model describing vacancy categories."""
 
-    name = MultilingualField(models.CharField, max_length=30)
+    name = models.CharField(max_length=30)
     slug = models.SlugField()
 
     def __str__(self):
@@ -218,7 +218,7 @@ class Vacancy(models.Model):
         verbose_name_plural = _("Vacancies")
 
 
-class PartnerEvent(models.Model, metaclass=ModelTranslateMeta):
+class PartnerEvent(models.Model):
     """Model describing partner event."""
 
     partner = models.ForeignKey(
@@ -232,11 +232,11 @@ class PartnerEvent(models.Model, metaclass=ModelTranslateMeta):
 
     other_partner = models.CharField(max_length=255, blank=True)
 
-    title = MultilingualField(models.CharField, _("title"), max_length=100)
+    title = models.CharField(_("title"), max_length=100)
 
-    description = MultilingualField(models.TextField, _("description"))
+    description = models.TextField(_("description"))
 
-    location = MultilingualField(models.CharField, _("location"), max_length=255,)
+    location = models.CharField(_("location"), max_length=255,)
 
     start = models.DateTimeField(_("start time"))
 


### PR DESCRIPTION
Closes #1862

Part of #1200

### Summary
Remove the multilingual fields from the partners app. Thus fixing the issue with the API.

### How to test
Steps to test the changes you made:
1. Go to /api/docs
2. Request the partner events
