### PR TITLE
Add user registration to events API v2 for cancelled situations

### DIFF
--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -58,12 +58,20 @@ class EventSerializer(serializers.ModelSerializer):
         try:
             if self.context["request"].member:
                 reg = instance.eventregistration_set.get(
-                    member=self.context["request"].member, date_cancelled=None
+                    member=self.context["request"].member
                 )
                 return EventRegistrationSerializer(
                     reg,
                     context=self.context,
-                    fields=("pk", "present", "queue_position", "date", "payment"),
+                    fields=(
+                        "pk",
+                        "present",
+                        "queue_position",
+                        "is_cancelled",
+                        "is_late_cancellation",
+                        "date",
+                        "payment",
+                    ),
                 ).data
         except EventRegistration.DoesNotExist:
             pass

--- a/website/events/api/v2/serializers/event_registration.py
+++ b/website/events/api/v2/serializers/event_registration.py
@@ -34,3 +34,16 @@ class EventRegistrationSerializer(serializers.ModelSerializer):
 
     payment = PaymentSerializer()
     member = MemberSerializer(detailed=False, read_only=True)
+    is_cancelled = serializers.SerializerMethodField("_is_cancelled")
+    is_late_cancellation = serializers.SerializerMethodField("_is_late_cancellation")
+    queue_position = serializers.SerializerMethodField("_queue_position")
+
+    def _is_late_cancellation(self, instance):
+        return instance.is_late_cancellation()
+
+    def _queue_position(self, instance):
+        pos = instance.queue_position
+        return pos if pos and pos > 0 else None
+
+    def _is_cancelled(self, instance):
+        return instance.date_cancelled is not None


### PR DESCRIPTION
Closes #1863

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Add user registration to events API v2 for cancelled situations

### How to test
Steps to test the changes you made:
1. Go to /api/docs
2. Check api v2 event registrations for users in the event serializer
