### PR TITLE
Fix disabling optional registrations

### DIFF
--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -274,7 +274,11 @@ class Event(models.Model):
 
     @property
     def optional_registration_allowed(self):
-        return not self.registration_required and self.end >= timezone.now()
+        return (
+            self.optional_registrations
+            and not self.registration_required
+            and self.end >= timezone.now()
+        )
 
     @property
     def has_food_event(self):


### PR DESCRIPTION
Closes #1861 

### Summary
Prevents registrations taking place even if optional registrations are disabled

### How to test
1. Have an event
2. No 'real' registration start/end/cancel deadlines
3. Disable optional registrations
4. No registrations are possible in the frontend (while previously this was possible)