### PR TITLE
Fix small bug in events api

### DIFF
--- a/website/events/api/v2/serializers/event_registration.py
+++ b/website/events/api/v2/serializers/event_registration.py
@@ -30,6 +30,8 @@ class EventRegistrationSerializer(serializers.ModelSerializer):
             "payment",
             "member",
             "name",
+            "is_cancelled",
+            "is_late_cancellation",
         )
 
     payment = PaymentSerializer()


### PR DESCRIPTION
In #1870 I missed a bug that breaks the events api: "The field 'is_cancelled' was declared on serializer EventRegistrationSerializer, but has not been included in the 'fields' option.".