### PR TITLE
Remove language from v1 profile serializer

### DIFF
--- a/website/members/api/v1/serializers.py
+++ b/website/members/api/v1/serializers.py
@@ -125,7 +125,6 @@ class ProfileEditSerializer(serializers.ModelSerializer):
             "profile_description",
             "nickname",
             "display_name_preference",
-            "language",
             "receive_optin",
             "receive_newsletter",
             "receive_magazine",


### PR DESCRIPTION
Closes #1879

### Summary
Remove language from v1 profile serializer

### How to test
Steps to test the changes you made:
1. Go to /api/docs and select v1
2. No error