### PR TITLE
Catch possible ValueError in sales order serializer

### DIFF
--- a/website/sales/api/v2/admin/serializers/order.py
+++ b/website/sales/api/v2/admin/serializers/order.py
@@ -1,6 +1,7 @@
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.utils.encoding import smart_str
 from rest_framework import serializers
+from rest_framework.settings import api_settings
 
 from members.api.v2.serializers.member import MemberSerializer
 from payments.api.v2.serializers import PaymentSerializer
@@ -63,7 +64,10 @@ class OrderItemSerializer(serializers.ModelSerializer):
         order = self.context["order"]
         instance.order = order
         instance.total = None  # Always recalculate the total amount if updating using API (note the difference from the model that only recalculates if the total is None, to deal with historic data and allow for special discounts)
-        super().update(instance, validated_data)
+        try:
+            super().update(instance, validated_data)
+        except ValueError as e:
+            raise ValidationError({api_settings.NON_FIELD_ERRORS_KEY: [e]})
         return instance
 
 


### PR DESCRIPTION
Closes #1848 and #1849

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Catch possible ValueError in sales order serializer

### How to test
Steps to test the changes you made:
1. Change an order in the API that has already been paid or lock the shift.
2. Receive a validation error response
