### PR TITLE
Add education document notification email

### DIFF
--- a/website/education/emails.py
+++ b/website/education/emails.py
@@ -1,0 +1,34 @@
+"""The emails defined by the education package."""
+import logging
+
+from django.conf import settings
+from django.core import mail
+from django.template import loader
+from django.urls import reverse
+
+logger = logging.getLogger(__name__)
+
+
+def send_document_notification(document):
+    """Send an email to a configured email.
+
+    :param document: The document we are sending the email for
+    """
+    info = (document._meta.app_label, document._meta.model_name)
+    admin_url = reverse("admin:%s_%s_change" % info, args=(document.pk,))
+
+    email_body = loader.render_to_string(
+        "education/email/document_notification.txt",
+        {
+            "document": document.name,
+            "uploader": document.uploader.get_full_name(),
+            "url": settings.BASE_URL + admin_url,
+            "course": f"{document.course.name} ({document.course.course_code})",
+        },
+    )
+    mail.EmailMessage(
+        "New document submitted",
+        email_body,
+        settings.DEFAULT_FROM_EMAIL,
+        [settings.EDUCATION_NOTIFICATION_ADDRESS],
+    ).send()

--- a/website/education/emails.py
+++ b/website/education/emails.py
@@ -27,7 +27,7 @@ def send_document_notification(document):
         },
     )
     mail.EmailMessage(
-        "New document submitted",
+        "Education document ready for review",
         email_body,
         settings.DEFAULT_FROM_EMAIL,
         [settings.EDUCATION_NOTIFICATION_ADDRESS],

--- a/website/education/templates/education/email/document_notification.txt
+++ b/website/education/templates/education/email/document_notification.txt
@@ -1,0 +1,5 @@
+Hello,
+
+We have received a new document submission for the education section of the website that requires your attention:
+
+{{document}}, {{course}}, {{uploader}} - {{url}}

--- a/website/education/views.py
+++ b/website/education/views.py
@@ -14,6 +14,7 @@ from django.views.generic import ListView, DetailView, CreateView, TemplateView
 from django_sendfile import sendfile
 
 from members.decorators import membership_required
+from . import emails
 from .forms import AddExamForm, AddSummaryForm
 from .models import Category, Course, Exam, Summary
 
@@ -168,6 +169,7 @@ class ExamCreateView(SuccessMessageMixin, CreateView):
         self.object.uploader = self.request.member
         self.object.uploader_date = datetime.now()
         self.object.save()
+        emails.send_document_notification(self.object)
         return super().form_valid(form)
 
 
@@ -193,6 +195,7 @@ class SummaryCreateView(SuccessMessageMixin, CreateView):
         self.object.uploader = self.request.member
         self.object.uploader_date = datetime.now()
         self.object.save()
+        emails.send_document_notification(self.object)
         return super().form_valid(form)
 
 

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -152,6 +152,9 @@ BOARD_NOTIFICATION_ADDRESS = (
 PARTNER_NOTIFICATION_ADDRESS = (
     f"{os.environ.get('ADDRESS_COLLABORATION', 'samenwerking')}@{SITE_DOMAIN}"
 )
+EDUCATION_NOTIFICATION_ADDRESS = (
+    f"{os.environ.get('ADDRESS_EDUCATION', 'educacie')}@{SITE_DOMAIN}"
+)
 
 # The scheme the app uses for oauth redirection
 APP_OAUTH_SCHEME = os.environ.get("APP_OAUTH_SCHEME", "nu.thalia")


### PR DESCRIPTION
Closes #1725 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This PR introduces a notification email for the Educacie so that they know when new documents have been submitted.

### How to test
Steps to test the changes you made:
1. Go to exam/summary submission
2. Do a new submission
3. Check that an email is sent to the notification address. It is possible that this email address does not exist on staging. Locally the email is shown in the console.
