### PR TITLE
Fix payment fixtures

### DIFF
--- a/website/utils/management/commands/createfixtures.py
+++ b/website/utils/management/commands/createfixtures.py
@@ -557,10 +557,17 @@ class Command(BaseCommand):
 
         registration = event.registrations.order_by("?")[0]
 
-        processed_by = Member.objects.order_by("?")[0]
+        superusers = Member.objects.filter(is_superuser=True)
+        if not superusers:
+            print(
+                "There is no member which is also a superuser. Creating payments without this isn't possible!"
+            )
+            print("Please add an membership to the superuser.")
+            return
+
         create_payment(
             registration,
-            processed_by,
+            superusers[0],
             random.choice([Payment.CASH, Payment.CARD, Payment.WIRE]),
         )
 


### PR DESCRIPTION
Closes #1895 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Payment fixtures are now always processed by the superuser such that there are no permission issues.

### How to test
1. Run `poetry run website/manage.py createfixtures --payment 1`
2. No crash
