### PR TITLE
add padding for vertical row representation

### DIFF
--- a/website/members/templates/members/user/profile.html
+++ b/website/members/templates/members/user/profile.html
@@ -15,7 +15,7 @@
             </h1>
 
             <div class="row">
-                <div class="col-12 col-lg-7 text-center">
+                <div class="pb-4 pb-lg-0 col-12 col-lg-7 text-center">
                     {% if not member.profile.photo %}
                         <img src="{% static "members/images/default-avatar.jpg" %}"
                              alt="{{ member.profile.display_name }}"/>


### PR DESCRIPTION
Closes #1918

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Add bottom padding to profile image for vertical row presentation at smaller than lg viewports

### How to test
Steps to test the changes you made:
1. Go to 'https://thalia.nu/members/profile/'
2. Change viewport from lg to <lg
3. See some space between image and ABOUT <shortname>
