### PR TITLE
Fix documents year dropdown in admin form

### DIFF
--- a/website/documents/forms.py
+++ b/website/documents/forms.py
@@ -64,6 +64,10 @@ class AnnualDocumentForm(forms.ModelForm):
             for year in range(current + 1, 1989, -1)
         ]
 
+    year = forms.TypedChoiceField(
+        coerce=int, choices=_year_choices.__func__, initial=_current_year.__func__
+    )
+
 
 class AssociationDocumentForm(forms.ModelForm):
     """Form that overrides the widgets for the files."""


### PR DESCRIPTION
Closes #1907

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Fixes the admin dropdown for the year used for annual documents

### How to test
Steps to test the changes you made:
1. Go to the admin
2. Add a new annual document
3. Try to select the year
