### PR TITLE
Fix membership type displaying wrong initial date

### DIFF
--- a/website/members/models/member.py
+++ b/website/members/models/member.py
@@ -118,6 +118,17 @@ class Member(User):
         return self.membership_set.latest("since")
 
     @property
+    def oldest_membership_of_current_type(self):
+        """Get the first membership of the most recent membership's type."""
+        if not self.membership_set.exists():
+            return None
+        return (
+            self.membership_set.filter(type=self.latest_membership.type)
+            .order_by("since")
+            .first()
+        )
+
+    @property
     def earliest_membership(self):
         """Get the earliest membership of this user."""
         if not self.membership_set.exists():

--- a/website/members/templates/members/user/profile.html
+++ b/website/members/templates/members/user/profile.html
@@ -17,7 +17,7 @@
             <div class="row">
                 <div class="pb-4 pb-lg-0 col-12 col-lg-7 text-center">
                     {% if not member.profile.photo %}
-                        <img src="{% static "members/images/default-avatar.jpg" %}"
+                        <img src="{% static 'members/images/default-avatar.jpg' %}"
                              alt="{{ member.profile.display_name }}"/>
                     {% else %}
                         <img src="{{ member.profile.photo.url }}"
@@ -40,7 +40,7 @@
                     <h4>{% trans "Personal information" %}</h4>
                     <ul class="list-unstyled">
                         <li>
-                            <strong>{% trans "Membership type" %}: </strong> {{ membership_type }} (since {{ member.latest_membership.since }})<br>
+                            <strong>{% trans "Membership type" %}: </strong> {{ membership_type }} (since {{ member.oldest_membership_of_current_type.since }})<br>
                         </li>
 
                         {% if member.profile.starting_year %}


### PR DESCRIPTION
Closes #1929 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Now shows the first since date of the current membership type.
Useful for members who have yearly subscriptions for Thalia.

### How to test
Steps to test the changes you made:
1. Go to '/members/profile'
2. Click on 'see your membership type's since is correct.'
3. Test for multiple configurations of memberships.
