### PR TITLE
Disable pizza button when ordering isn't possible yet. Hide it when the event is far in the past

### DIFF
--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -245,9 +245,20 @@
                                     Pizza
                                 </th>
                                 <td>
-                                    <a href="{% url "pizzas:index" %}" class="btn btn-primary">
-                                        {% trans "Order" context "pizzas" %}
-                                    </a>
+                                    {% if event.food_event.current == event.food_event %}
+                                        <a href="{% url "pizzas:index" %}" class="btn btn-primary">
+                                            {% trans "Order" context "pizzas" %}
+                                        </a>
+                                    {% else %}
+                                    <div>
+                                        <a class="btn btn-primary disabled">
+                                            {% trans "Order" context "pizzas" %}
+                                        </a>
+                                    </div>
+                                    <div class="mt-3">
+                                        <em>Ordering pizza for this event isn't possible yet</em>
+                                    </div>
+                                    {% endif %}
                                 </td>
                             </tr>
                         {% endif %}

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -239,28 +239,35 @@
                             </td>
                         </tr>
 
-                        {% if event.food_event %}
-                            <tr>
-                                <th>
-                                    Pizza
-                                </th>
-                                <td>
-                                    {% if event.food_event.current == event.food_event %}
+                        {% if event.food_event %} 
+                            {% if event.food_event == event.food_event.current or event.food_event.just_ended %}
+                                <tr>
+                                    <th>
+                                        Pizza
+                                    </th>
+                                    <td>
                                         <a href="{% url "pizzas:index" %}" class="btn btn-primary">
                                             {% trans "Order" context "pizzas" %}
                                         </a>
-                                    {% else %}
-                                    <div>
-                                        <a class="btn btn-primary disabled">
-                                            {% trans "Order" context "pizzas" %}
-                                        </a>
-                                    </div>
-                                    <div class="mt-3">
-                                        <em>Ordering pizza for this event isn't possible yet</em>
-                                    </div>
-                                    {% endif %}
-                                </td>
-                            </tr>
+                                    </td>
+                                </tr>
+                            {% elif event.food_event.in_the_future %}
+                                <tr>
+                                    <th>
+                                        Pizza
+                                    </th>
+                                    <td>
+                                        <div>
+                                            <a class="btn btn-primary disabled">
+                                                {% trans "Order" context "pizzas" %}
+                                            </a>
+                                        </div>
+                                        <div class="mt-3">
+                                            <em>Ordering pizza for this event isn't possible yet</em>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endif %}
                         {% endif %}
                         {% if event.album_set.all %}
                         <tr>


### PR DESCRIPTION
Closes #1928 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Changed when the pizza order button is shown in event. There are 3 possibilities:
1. You can currently order pizza for this event, or the pizza event for this event 'just ended', so it ended in the last 8 hours. Then the pizza button is shown.
2. Between now and the pizza event associated with the event there is another pizza event. Then it disabled the button and shows the text: "Ordering pizza for this event isn't possible yet"
3. The pizza event is long past. Then it hides the pizza button entirely.

### How to test
Steps to test the changes you made:
To test situation 1:
- Make an event with a pizza event 
- Check if you see the button
- Make it so the pizza event ended in the last 8 hours
- Check if you still see the button
Situation 2:
- Add another event with a pizza event in the future
- Check that on that event page the pizza button is disabled
Situation 3:
- Make an event with a pizza event long in the past
- Check that the pizza button is hidden
