### PR TITLE
Fix errors in views

### DIFF
--- a/website/payments/views.py
+++ b/website/payments/views.py
@@ -12,7 +12,7 @@ from django.core.exceptions import (
     SuspiciousOperation,
 )
 from django.db.models import QuerySet, Sum
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
@@ -184,6 +184,8 @@ class PaymentProcessView(SuccessMessageMixin, FormView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
+        if self.payable is None:
+            raise Http404("Payable does not exist")
         context = super().get_context_data(**kwargs)
         context.update({"payable": self.payable})
         context.update(
@@ -210,7 +212,13 @@ class PaymentProcessView(SuccessMessageMixin, FormView):
         payable_pk = request.POST["payable"]
 
         payable_model = apps.get_model(app_label=app_label, model_name=model_name)
-        self.payable = payables.get_payable(payable_model.objects.get(pk=payable_pk))
+
+        try:
+            payable_obj = payable_model.objects.get(pk=payable_pk)
+        except payable_model.DoesNotExist:
+            raise Http404("This payable does not exist.")
+
+        self.payable = payables.get_payable(payable_obj)
 
         if (
             self.payable.payment_payer.pk

--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -161,7 +161,7 @@ class Order(models.Model):
     def payment_url(self):
         return (
             settings.BASE_URL + reverse("sales:order-pay", kwargs={"pk": self.pk})
-            if not self.payment
+            if not self.payment and self.pk
             else None
         )
 


### PR DESCRIPTION
Closes #1923 

### Summary
Fixes three issues with views:
- One with the order create admin view where it would display a 500 error instead of the add screen
- Two fixes with the ThaliaPay screen where a 404 would been displayed if the payable was deleted

### How to test
Steps to test the changes you made:
1. You create a payable (an order)
2. A user tries to pay the payment
3. Meanwhile, the payable is deleted
4. User confirms the payment
5. A 404 is returned
