### PR TITLE
Check invalid payment type, add test to pizzas

### DIFF
--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -27,6 +27,9 @@ def create_payment(
     :param pay_type: Payment type
     :return: Payment object
     """
+    if pay_type not in (Payment.CASH, Payment.CARD, Payment.WIRE, Payment.TPAY):
+        raise PaymentError("Invalid payment type")
+
     if isinstance(model_payable, Payable):
         payable = model_payable
     else:

--- a/website/payments/tests/test_services.py
+++ b/website/payments/tests/test_services.py
@@ -66,6 +66,14 @@ class ServicesTest(TestCase):
                     Payment.TPAY,
                 )
 
+        with self.subTest("Only allow valid payment types"):
+            with self.assertRaises(PaymentError):
+                services.create_payment(
+                    MockPayable(MockModel(payer=self.member, amount=0)),
+                    self.member,
+                    "no_payment",
+                )
+
     def test_delete_payment(self):
         existing_payment = MagicMock(batch=None)
         payable = MockPayable(MockModel(payer=self.member, payment=existing_payment))

--- a/website/pizzas/admin.py
+++ b/website/pizzas/admin.py
@@ -2,12 +2,14 @@
 from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import PermissionDenied
+from django.forms import Field
 from django.urls import reverse, path
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from events import services
 from events.services import is_organiser
+from payments.widgets import PaymentWidget
 from pizzas import admin_views
 from utils.admin import DoNextModelAdmin
 from .models import FoodOrder, FoodEvent, Product
@@ -87,7 +89,23 @@ class FoodOrderAdmin(DoNextModelAdmin):
         "product",
         "payment",
     )
-    exclude = ("payment",)
+
+    fields = (
+        "food_event",
+        "member",
+        "name",
+        "product",
+        "payment",
+    )
+
+    def formfield_for_dbfield(self, db_field, request, obj=None, **kwargs):
+        """Payment field widget."""
+        field = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if db_field.name == "payment":
+            return Field(
+                widget=PaymentWidget(obj=obj), initial=field.initial, required=False,
+            )
+        return field
 
     def save_model(self, request, obj, form, change):
         """You can only save the orders if you have permission."""

--- a/website/pizzas/api/v1/viewsets.py
+++ b/website/pizzas/api/v1/viewsets.py
@@ -110,6 +110,6 @@ class OrderViewset(ModelViewSet):
     def _update_payment(order, payment_type=None, processed_by=None):
         if order.payment and payment_type == PaymentTypeField.NO_PAYMENT:
             delete_payment(order, processed_by)
-        else:
+        elif payment_type != PaymentTypeField.NO_PAYMENT:
             order.payment = create_payment(order, processed_by, payment_type)
             order.save()


### PR DESCRIPTION
Closes #1956 and provides a workaround for #1931 while awaiting #1948

### Summary
Apparently on production, python type annotations are not checked. This combined with a bug from pizzas API v1 could result in cases where payments actually had type None. This PR resolves that, and it also provides a workaround for #1931 (because Im lazy and didnt want to separate things)

### How to test
1. Try to create a `NO_PAYMENT` payment for an order that does not have a payment.