### PR TITLE
Use default admin color for pizza payment widget

### DIFF
--- a/website/pizzas/static/pizzas/css/admin.scss
+++ b/website/pizzas/static/pizzas/css/admin.scss
@@ -49,7 +49,6 @@
 
 select[name=payment] {
     background: var(--message-error-bg);
-    color: white;
 
     &.paid {
         background: var(--message-success-bg);


### PR DESCRIPTION
### Summary
Fix the color for the pizza order admin payment widget in non-light-mode

### How to test
1. Go to the food order admin
2. Set your machine in light mode
3. You can read the text