### PR TITLE
Do not send push notification to non-members

### DIFF
--- a/website/pizzas/models.py
+++ b/website/pizzas/models.py
@@ -116,9 +116,9 @@ class FoodEvent(models.Model):
 
             if self.event.registration_required:
                 end_reminder.users.set(
-                    self.event.registrations.select_related("member").values_list(
-                        "member", flat=True
-                    )
+                    self.event.registrations.filter(member__isnull=False)
+                    .select_related("member")
+                    .values_list("member", flat=True)
                 )
             else:
                 end_reminder.users.set(Member.current_members.all())


### PR DESCRIPTION
Closes #1901 

### Summary
Prevents pizza event trying to schedule a push notification for an event with non-members registered.

### How to test
1. Have an event
2. With an food event
3. Make it have non-member registrations (registrations should be required)
4. Save the event
5. No crash