### PR TITLE
Fix autofill of event newsletters

### DIFF
--- a/website/newsletters/static/admin/newsletters/js/forms.js
+++ b/website/newsletters/static/admin/newsletters/js/forms.js
@@ -7,8 +7,6 @@ django.jQuery(function () {
     }
 
     function formatDate(dateStr, format) {
-        var currentLang = $('html').attr('lang');
-
         var date = new Date(dateStr);
         var day = date.getDate();
         var month = date.getMonth() + 1;
@@ -20,40 +18,34 @@ django.jQuery(function () {
         if (format === 'time') {
             return pad(hours, 2) + ':' + pad(minutes, 2) + ':' + pad(seconds, 2);
         }
-        if (currentLang === 'nl') {
-            return pad(day, 2) + '-' + pad(month, 2) + '-' + year;
-        }
         return year + '-' + pad(month, 2) + '-' + day;
     }
 
-    function setFields(id, data, lang) {
-        $('#id_newsletterevent_set-' +  id + '-title_' + lang)
+    function setFields(id, data) {
+        $('#id_newsletterevent_set-' +  id + '-title')
             .val(data['title']);
-        tinyMCE.get('id_newsletterevent_set-' +  id + '-description_' + lang)
+        tinyMCE.get('id_newsletterevent_set-' +  id + '-description')
             .setContent(data['description']);
-        $('#id_newsletterevent_set-' +  id + '-what_' + lang)
+        $('#id_newsletterevent_set-' +  id + '-what')
             .val(data['title']);
-        $('#id_newsletterevent_set-' +  id + '-where_' + lang)
+        $('#id_newsletterevent_set-' +  id + '-where')
             .val(data['location']);
-
-        if (lang === 'en') {
-            $('#id_newsletterevent_set-' + id + '-url')
-                .val(window.location.origin + '/events/' + data['pk'] + '/');
-            $('#id_newsletterevent_set-' +  id + '-price')
-                .val(data['price']);
-            $('#id_newsletterevent_set-' +  id + '-penalty_costs')
-                .val(data['fine']);
-            $('#id_newsletterevent_set-' + id + '-show_costs_warning')
-                .prop("checked", data['fine'] !== "0.00");
-            $('#id_newsletterevent_set-' +  id + '-start_datetime_0')
-                .val(formatDate(data['start'], 'date'));
-            $('#id_newsletterevent_set-' +  id + '-start_datetime_1')
-                .val(formatDate(data['start'], 'time'));
-            $('#id_newsletterevent_set-' +  id + '-end_datetime_0')
-                .val(formatDate(data['end'], 'date'));
-            $('#id_newsletterevent_set-' +  id + '-end_datetime_1')
-                .val(formatDate(data['end'], 'time'));
-        }
+        $('#id_newsletterevent_set-' + id + '-url')
+            .val(window.location.origin + '/events/' + data['pk'] + '/');
+        $('#id_newsletterevent_set-' +  id + '-price')
+            .val(data['price']);
+        $('#id_newsletterevent_set-' +  id + '-penalty_costs')
+            .val(data['fine']);
+        $('#id_newsletterevent_set-' + id + '-show_costs_warning')
+            .prop("checked", data['fine'] !== "0.00");
+        $('#id_newsletterevent_set-' +  id + '-start_datetime_0')
+            .val(formatDate(data['start'], 'date'));
+        $('#id_newsletterevent_set-' +  id + '-start_datetime_1')
+            .val(formatDate(data['start'], 'time'));
+        $('#id_newsletterevent_set-' +  id + '-end_datetime_0')
+            .val(formatDate(data['end'], 'date'));
+        $('#id_newsletterevent_set-' +  id + '-end_datetime_1')
+            .val(formatDate(data['end'], 'time'));
     }
 
     function getEvent(pk, success) {
@@ -70,8 +62,8 @@ django.jQuery(function () {
         var id = $(this).attr('name')
             .replace('newsletterevent_set-', '')
             .replace('-event', '');
-        getEvent($(this).val(), function(data, lang) {
-            setFields(id, data, lang);
+        getEvent($(this).val(), function(data) {
+            setFields(id, data);
         });
     });
 });


### PR DESCRIPTION
Closes #1946

### Summary
Autofilling the event information in the newsletter admin no longer worked. This was due to removing the language postfixes for the fields.

### How to test
Steps to test the changes you made:
1. Go to the admin
2. Create a new newsletter event
3. Select an event
4. Works now to 
