### PR TITLE
Fix pizza search in the admin

### DIFF
--- a/website/pizzas/admin.py
+++ b/website/pizzas/admin.py
@@ -1,5 +1,4 @@
 """Registers admin interfaces for the pizzas module."""
-from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import PermissionDenied
 from django.forms import Field
@@ -31,7 +30,7 @@ class FoodEventAdmin(admin.ModelAdmin):
     list_display = ("title", "start", "end", "notification_enabled", "orders")
     date_hierarchy = "start"
     exclude = ("end_reminder",)
-    search_fields = [f"event__title_{l[0]}" for l in settings.LANGUAGES]
+    search_fields = ("event__title",)
     autocomplete_fields = ("event",)
 
     def notification_enabled(self, obj):

--- a/website/pizzas/static/pizzas/js/admin.js
+++ b/website/pizzas/static/pizzas/js/admin.js
@@ -91,7 +91,7 @@ django.jQuery(function() {
 
     $('#searchbar').on('input', function() {
         var input = this.value.toLowerCase();
-        $('tbody tr').each(function(i, e) {
+        $('#result_list tbody tr').each(function(i, e) {
             var tr = $(this);
             var show = false;
             $(this).find('td').each(function(j, t) {


### PR DESCRIPTION
Closes #1955

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Fix pizza search in the admin and prevent crashes.

### How to test
Steps to test the changes you made:
1. Go to the pizza events
2. Search and no crash
3. Then go into the orders view and try to search and see that the table of the apps (left side on big screens)
