### PR TITLE
optimize event list queries

### DIFF
--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -19,7 +19,7 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
         return reverse("events:event", kwargs={"pk": instance.id})
 
     def _class_names(self, instance):
-        if self.context["member"] and instance.user_reg:
+        if self.context["member"] and instance.member_registration:
             if services.user_registration_pending(self.context["member"], instance):
                 return ["regular-event-pending-registration"]
             else:
@@ -32,7 +32,7 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
 
     def _registration_info(self, instance: Event):
         # If registered in some way
-        if self.context["member"] and instance.user_reg:
+        if self.context["member"] and instance.member_registration:
             queue_pos = services.user_registration_pending(
                 self.context["member"], instance
             )

--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -48,7 +48,7 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
         elif instance.optional_registration_allowed:
             return _("Registering for this event is optional")
         # No places left
-        elif instance.reached_participants_limit():
+        elif instance.max_participants is not None and instance.max_participants <= instance.number_regs:
             return _("You can put yourself on the waiting list for this event")
         # Registration still possible
         elif instance.registration_allowed:

--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -19,9 +19,7 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
         return reverse("events:event", kwargs={"pk": instance.id})
 
     def _class_names(self, instance):
-        if self.context["member"] and services.is_user_registered(
-            self.context["member"], instance
-        ):
+        if self.context["member"] and instance.user_reg:
             if services.user_registration_pending(self.context["member"], instance):
                 return ["regular-event-pending-registration"]
             else:
@@ -34,9 +32,7 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
 
     def _registration_info(self, instance: Event):
         # If registered in some way
-        if self.context["member"] and services.is_user_registered(
-            self.context["member"], instance
-        ):
+        if self.context["member"] and instance.user_reg:
             queue_pos = services.user_registration_pending(
                 self.context["member"], instance
             )

--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -48,7 +48,10 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
         elif instance.optional_registration_allowed:
             return _("Registering for this event is optional")
         # No places left
-        elif instance.max_participants is not None and instance.max_participants <= instance.number_regs:
+        elif (
+            instance.max_participants is not None
+            and instance.max_participants <= instance.number_regs
+        ):
             return _("You can put yourself on the waiting list for this event")
         # Registration still possible
         elif instance.registration_allowed:

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -35,7 +35,7 @@ class CalendarJSEventListView(ListAPIView):
         )
         if self.request.member:
             events = events.annotate(
-                user_reg=Subquery(
+                member_registration=Subquery(
                     EventRegistration.objects.filter(
                         event=OuterRef("id"), member=self.request.member
                     ).values("member")

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -26,20 +26,18 @@ class CalendarJSEventListView(ListAPIView):
 
     def get_queryset(self):
         start, end = extract_date_range(self.request)
+        objects = Event.objects.filter(
+            end__gte=start, start__lte=end, published=True
+        ).annotate(
+            number_regs=Count('eventregistration', filter=Q(eventregistration__date_cancelled=None))
+        )
         if self.request.member:
-            objects = Event.objects.filter(
-                end__gte=start, start__lte=end, published=True
-            ).annotate(
+            objects = objects.annotate(
                 user_reg=Subquery(
                     EventRegistration.objects.filter(
                         event=OuterRef("id"), member=self.request.member
                     ).values("member")
                 )
-            )
-            # .annotate(user_reg=Count('eventregistration', filter=Q(member=self.request.member)))
-        else:
-            objects = Event.objects.filter(
-                end__gte=start, start__lte=end, published=True
             )
         return objects
 

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -27,13 +27,20 @@ class CalendarJSEventListView(ListAPIView):
     def get_queryset(self):
         start, end = extract_date_range(self.request)
         if self.request.member:
-            objects = Event.objects.filter(end__gte=start, start__lte=end, published=True)\
-                .annotate(user_reg=Subquery(EventRegistration.objects
-                                            .filter(event=OuterRef('id'), member=self.request.member)
-                                            .values('member')))
-                # .annotate(user_reg=Count('eventregistration', filter=Q(member=self.request.member)))
+            objects = Event.objects.filter(
+                end__gte=start, start__lte=end, published=True
+            ).annotate(
+                user_reg=Subquery(
+                    EventRegistration.objects.filter(
+                        event=OuterRef("id"), member=self.request.member
+                    ).values("member")
+                )
+            )
+            # .annotate(user_reg=Count('eventregistration', filter=Q(member=self.request.member)))
         else:
-            objects = Event.objects.filter(end__gte=start, start__lte=end, published=True)
+            objects = Event.objects.filter(
+                end__gte=start, start__lte=end, published=True
+            )
         return objects
 
 

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -1,3 +1,5 @@
+from django.db.models import Q, Count, OuterRef, Subquery
+
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAdminUser, IsAuthenticatedOrReadOnly
 
@@ -6,7 +8,7 @@ from events.api.calendarjs.serializers import (
     UnpublishedEventsCalenderJSSerializer,
 )
 from events.api.calendarjs.permissions import UnpublishedEventPermissions
-from events.models import Event
+from events.models import Event, EventRegistration
 from utils.snippets import extract_date_range
 
 
@@ -24,7 +26,12 @@ class CalendarJSEventListView(ListAPIView):
 
     def get_queryset(self):
         start, end = extract_date_range(self.request)
-        return Event.objects.filter(end__gte=start, start__lte=end, published=True)
+        objects = Event.objects.filter(end__gte=start, start__lte=end, published=True)\
+            .annotate(user_reg=Subquery(EventRegistration.objects
+                                        .filter(event=OuterRef('id'), member=self.request.member)
+                                        .values('member')))
+            # .annotate(user_reg=Count('eventregistration', filter=Q(member=self.request.member)))
+        return objects
 
 
 class CalendarJSUnpublishedEventListView(ListAPIView):

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -26,11 +26,14 @@ class CalendarJSEventListView(ListAPIView):
 
     def get_queryset(self):
         start, end = extract_date_range(self.request)
-        objects = Event.objects.filter(end__gte=start, start__lte=end, published=True)\
-            .annotate(user_reg=Subquery(EventRegistration.objects
-                                        .filter(event=OuterRef('id'), member=self.request.member)
-                                        .values('member')))
-            # .annotate(user_reg=Count('eventregistration', filter=Q(member=self.request.member)))
+        if self.request.member:
+            objects = Event.objects.filter(end__gte=start, start__lte=end, published=True)\
+                .annotate(user_reg=Subquery(EventRegistration.objects
+                                            .filter(event=OuterRef('id'), member=self.request.member)
+                                            .values('member')))
+                # .annotate(user_reg=Count('eventregistration', filter=Q(member=self.request.member)))
+        else:
+            objects = Event.objects.filter(end__gte=start, start__lte=end, published=True)
         return objects
 
 

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -29,7 +29,9 @@ class CalendarJSEventListView(ListAPIView):
         objects = Event.objects.filter(
             end__gte=start, start__lte=end, published=True
         ).annotate(
-            number_regs=Count('eventregistration', filter=Q(eventregistration__date_cancelled=None))
+            number_regs=Count(
+                "eventregistration", filter=Q(eventregistration__date_cancelled=None)
+            )
         )
         if self.request.member:
             objects = objects.annotate(

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -26,7 +26,7 @@ class CalendarJSEventListView(ListAPIView):
 
     def get_queryset(self):
         start, end = extract_date_range(self.request)
-        objects = Event.objects.filter(
+        events = Event.objects.filter(
             end__gte=start, start__lte=end, published=True
         ).annotate(
             number_regs=Count(
@@ -34,14 +34,14 @@ class CalendarJSEventListView(ListAPIView):
             )
         )
         if self.request.member:
-            objects = objects.annotate(
+            events = events.annotate(
                 user_reg=Subquery(
                     EventRegistration.objects.filter(
                         event=OuterRef("id"), member=self.request.member
                     ).values("member")
                 )
             )
-        return objects
+        return events
 
 
 class CalendarJSUnpublishedEventListView(ListAPIView):

--- a/website/events/api/v1/serializers/events/retrieve.py
+++ b/website/events/api/v1/serializers/events/retrieve.py
@@ -58,10 +58,10 @@ class EventRetrieveSerializer(serializers.ModelSerializer):
         return strip_spaces_between_tags(bleach(instance.description))
 
     def _num_participants(self, instance):
-        p_count = instance.participants.count()
-        if instance.max_participants and p_count > instance.max_participants:
+        participant_count = instance.participants.count()
+        if instance.max_participants and participant_count > instance.max_participants:
             return instance.max_participants
-        return p_count
+        return participant_count
 
     def _user_registration(self, instance):
         try:

--- a/website/events/api/v1/serializers/events/retrieve.py
+++ b/website/events/api/v1/serializers/events/retrieve.py
@@ -58,12 +58,13 @@ class EventRetrieveSerializer(serializers.ModelSerializer):
         return strip_spaces_between_tags(bleach(instance.description))
 
     def _num_participants(self, instance):
+        p_count = instance.participants.count()
         if (
             instance.max_participants
-            and instance.participants.count() > instance.max_participants
+            and p_count > instance.max_participants
         ):
             return instance.max_participants
-        return instance.participants.count()
+        return p_count
 
     def _user_registration(self, instance):
         try:

--- a/website/events/api/v1/serializers/events/retrieve.py
+++ b/website/events/api/v1/serializers/events/retrieve.py
@@ -59,10 +59,7 @@ class EventRetrieveSerializer(serializers.ModelSerializer):
 
     def _num_participants(self, instance):
         p_count = instance.participants.count()
-        if (
-            instance.max_participants
-            and p_count > instance.max_participants
-        ):
+        if instance.max_participants and p_count > instance.max_participants:
             return instance.max_participants
         return p_count
 

--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -78,12 +78,13 @@ class EventSerializer(serializers.ModelSerializer):
         return None
 
     def _num_participants(self, instance):
+        p_count = instance.participants.count()
         if (
             instance.max_participants
-            and instance.participants.count() > instance.max_participants
+            and p_count > instance.max_participants
         ):
             return instance.max_participants
-        return instance.participants.count()
+        return p_count
 
     def _user_permissions(self, instance):
         member = self.context["request"].member

--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -78,10 +78,10 @@ class EventSerializer(serializers.ModelSerializer):
         return None
 
     def _num_participants(self, instance):
-        p_count = instance.participants.count()
-        if instance.max_participants and p_count > instance.max_participants:
+        participant_count = instance.participants.count()
+        if instance.max_participants and participant_count > instance.max_participants:
             return instance.max_participants
-        return p_count
+        return participant_count
 
     def _user_permissions(self, instance):
         member = self.context["request"].member

--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -79,10 +79,7 @@ class EventSerializer(serializers.ModelSerializer):
 
     def _num_participants(self, instance):
         p_count = instance.participants.count()
-        if (
-            instance.max_participants
-            and p_count > instance.max_participants
-        ):
+        if instance.max_participants and p_count > instance.max_participants:
             return instance.max_participants
         return p_count
 

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -26,7 +26,9 @@ class EventListView(ListAPIView):
     """Returns an overview of all upcoming events."""
 
     serializer_class = EventSerializer
-    queryset = Event.objects.filter(published=True).select_related("organiser", "food_event")
+    queryset = Event.objects.filter(published=True).select_related(
+        "organiser", "food_event"
+    )
     filter_backends = (
         framework_filters.OrderingFilter,
         framework_filters.SearchFilter,

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -26,7 +26,7 @@ class EventListView(ListAPIView):
     """Returns an overview of all upcoming events."""
 
     serializer_class = EventSerializer
-    queryset = Event.objects.filter(published=True)
+    queryset = Event.objects.filter(published=True).select_related("organiser", "food_event")
     filter_backends = (
         framework_filters.OrderingFilter,
         framework_filters.SearchFilter,

--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -64,7 +64,9 @@ class EventRegistration(models.Model):
     def queue_position(self):
         if self.event.max_participants is not None:
             try:
-                queue_ids = [r.member_id for r in self.event.queue]
+                queue_ids = [
+                    registration.member_id for registration in self.event.queue
+                ]
                 return list(queue_ids).index(self.member_id) + 1
             except ValueError:
                 pass

--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -60,7 +60,7 @@ class EventRegistration(models.Model):
     def is_registered(self):
         return self.date_cancelled is None
 
-    @cached_property
+    @property
     def queue_position(self):
         if self.event.max_participants is not None:
             try:

--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -63,7 +63,8 @@ class EventRegistration(models.Model):
     def queue_position(self):
         if self.event.max_participants is not None:
             try:
-                return list(self.event.queue).index(self) + 1
+                queue_ids = [r.member_id for r in self.event.queue]
+                return list(queue_ids).index(self.member_id) + 1
             except ValueError:
                 pass
         return None

--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from django.utils.functional import cached_property
 
 from .event import Event
 
@@ -59,7 +60,7 @@ class EventRegistration(models.Model):
     def is_registered(self):
         return self.date_cancelled is None
 
-    @property
+    @cached_property
     def queue_position(self):
         if self.event.max_participants is not None:
             try:

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -37,6 +37,8 @@ def user_registration_pending(member, event):
         return False
     if not member.is_authenticated:
         return None
+    if event.max_participants is None:
+        return False
 
     try:
         registration = event.registrations.get(member=member, date_cancelled=None)

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -313,7 +313,7 @@
             <div class="container">
                 <h1 class="text-center section-title">{% trans "Registrations" %}</h1>
                 <div id="results" class="row mt-4">
-                    {% for registration in event.participants %}
+                    {% for registration in participants %}
                         <div class="col-4 col-md-3 my-3">
                             {% if registration.is_external %}
                                 {% static 'members/images/default-avatar.jpg' as image %}

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -79,7 +79,7 @@
                                 <tr>
                                     <th>{% trans "number of registrations"|capfirst %}</th>
                                     <td>
-                                        {% blocktrans count counter=event.participants|length trimmed %}
+                                        {% blocktrans count counter=participants|length trimmed %}
                                             {{ counter }} registration
                                         {% plural %}
                                             {{ counter }} registrations
@@ -308,7 +308,7 @@
         </section>
     {% endif %}
 
-    {% if user.is_authenticated and event.participants|length > 0 %}
+    {% if user.is_authenticated and participants|length > 0 %}
         <section class="page-section" id="events-registrations">
             <div class="container">
                 <h1 class="text-center section-title">{% trans "Registrations" %}</h1>

--- a/website/events/views.py
+++ b/website/events/views.py
@@ -66,6 +66,8 @@ class EventDetail(DetailView):
 
         context["slide_size"] = settings.THUMBNAIL_SIZES["slide"]
 
+        context["participtants"] = event.participants.select_related("members")
+
         return context
 
 

--- a/website/events/views.py
+++ b/website/events/views.py
@@ -66,10 +66,11 @@ class EventDetail(DetailView):
 
         context["slide_size"] = settings.THUMBNAIL_SIZES["slide"]
 
-        context["participants"] = event.participants.select_related('member', 'member__profile')
+        context["participants"] = event.participants.select_related(
+            "member", "member__profile"
+        )
 
         return context
-
 
 
 class AlumniEventsView(TemplateView):

--- a/website/events/views.py
+++ b/website/events/views.py
@@ -66,9 +66,10 @@ class EventDetail(DetailView):
 
         context["slide_size"] = settings.THUMBNAIL_SIZES["slide"]
 
-        context["participtants"] = event.participants.select_related("members")
+        context["participants"] = event.participants.select_related('member', 'member__profile')
 
         return context
+
 
 
 class AlumniEventsView(TemplateView):


### PR DESCRIPTION
Currently, the calendar is quite slow, since for each event we query twice to check if the logged in user is registered for that particular event. This is obviously really efficient, since it's 2n+1 queries. This PR aims to solve this.

So far I have annotated the registrations; which means that while there are extra queries to check for cancellation it's already a lot more efficient, since events for which the current user is not registered do not require extra queries anymore.

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Add an annotation to check if the current user is registered

### How to test
Steps to test the changes you made:
1. Go to Calendar
2. Check if all events and registrations appear properly
