### PR TITLE
Use start date for registration info text in calendar

### DIFF
--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -50,7 +50,7 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
                 return _("You are registered for this event")
         # Optional registration possible
         elif instance.optional_registration_allowed:
-            return _("You can optionally register for this event")
+            return _("Registering for this event is optional")
         # No places left
         elif instance.reached_participants_limit():
             return _("You can put yourself on the waiting list for this event")
@@ -62,13 +62,13 @@ class EventsCalenderJSSerializer(CalenderJSSerializer):
             now = timezone.now()
             if instance.registration_end < now:
                 return _("Registrations have been closed")
-            elif instance.registration_end <= now + timedelta(days=2):
-                return _("You can register {at_time}").format(
-                    at_time=naturaltime(instance.registration_end)
+            elif instance.registration_start <= now + timedelta(days=2):
+                return _("Registrations open {at_time}").format(
+                    at_time=naturaltime(instance.registration_start)
                 )
             else:
-                return _("You can register on {date}").format(
-                    date=date(instance.registration_end)
+                return _("Registrations open {date}").format(
+                    date=date(instance.registration_start)
                 )
 
 


### PR DESCRIPTION
Closes #2008 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This PR changes the messages shown when the registration for an event are not open yet and when registration is optional.

![image](https://user-images.githubusercontent.com/1799914/140101356-d55d5a8b-35bf-4f1b-86c0-bcba27836890.png)
![image](https://user-images.githubusercontent.com/1799914/140101447-056c1b75-610c-4d52-97e6-9b2ba7cf5c4c.png)


### How to test
Steps to test the changes you made:
1. Create events with optional registrations and with registrations that open in the future within 2 days and one more in the future.
2. Go to the calendar view.
3. Check the text shown for each calendar item.
