### PR TITLE
Make the OIDC_RSA_PRIVATE_KEY setting base64

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -514,9 +514,13 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r"^/(?:api/v1|api/v2|user/oauth)/.*"
 
 # OAuth configuration
+OIDC_RSA_PRIVATE_KEY = from_env("OIDC_RSA_PRIVATE_KEY", testing=None)
+if OIDC_RSA_PRIVATE_KEY is not None:
+    OIDC_RSA_PRIVATE_KEY = base64.urlsafe_b64decode(OIDC_RSA_PRIVATE_KEY)
+
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,
-    "OIDC_RSA_PRIVATE_KEY": from_env("OIDC_RSA_PRIVATE_KEY", testing=None),
+    "OIDC_RSA_PRIVATE_KEY": OIDC_RSA_PRIVATE_KEY,
     "ALLOWED_REDIRECT_URI_SCHEMES": setting(
         production=["https", APP_OAUTH_SCHEME],
         staging=["http", "https", APP_OAUTH_SCHEME],

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -516,7 +516,7 @@ CORS_URLS_REGEX = r"^/(?:api/v1|api/v2|user/oauth)/.*"
 # OAuth configuration
 OIDC_RSA_PRIVATE_KEY = from_env("OIDC_RSA_PRIVATE_KEY", testing=None)
 if OIDC_RSA_PRIVATE_KEY is not None:
-    OIDC_RSA_PRIVATE_KEY = base64.urlsafe_b64decode(OIDC_RSA_PRIVATE_KEY)
+    OIDC_RSA_PRIVATE_KEY = base64.b64decode(OIDC_RSA_PRIVATE_KEY)
 
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -516,7 +516,7 @@ CORS_URLS_REGEX = r"^/(?:api/v1|api/v2|user/oauth)/.*"
 # OAuth configuration
 OIDC_RSA_PRIVATE_KEY = from_env("OIDC_RSA_PRIVATE_KEY", testing=None)
 if OIDC_RSA_PRIVATE_KEY is not None:
-    OIDC_RSA_PRIVATE_KEY = base64.b64decode(OIDC_RSA_PRIVATE_KEY)
+    OIDC_RSA_PRIVATE_KEY = base64.urlsafe_b64decode(OIDC_RSA_PRIVATE_KEY)
 
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,


### PR DESCRIPTION
Closes #1993 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Make the OIDC_RSA_PRIVATE_KEY setting a value that must be provided in Base64.

### How to test
Steps to test the changes you made:
1. Provide the setting in non-base64
2. Error
3. Provide in Base64
4. Works
