### PR TITLE
Add vacancies API

### DIFF
--- a/website/partners/api/v2/filters.py
+++ b/website/partners/api/v2/filters.py
@@ -33,3 +33,26 @@ class PartnerEventDateFilter(filters.BaseFilterBackend):
                 "schema": {"type": "string",},
             },
         ]
+
+
+class VacancyPartnerFilter(filters.BaseFilterBackend):
+    """Allows you to filter by partner pk."""
+
+    def filter_queryset(self, request, queryset, view):
+        partner = request.query_params.get("partner", None)
+
+        if partner is not None:
+            queryset = queryset.filter(partner__pk=partner)
+
+        return queryset
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                "name": "partner",
+                "required": False,
+                "in": "query",
+                "description": "Filter by partner id",
+                "schema": {"type": "number"},
+            }
+        ]

--- a/website/partners/api/v2/serializers/vacancy.py
+++ b/website/partners/api/v2/serializers/vacancy.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+
+from partners.models import Vacancy
+
+
+class VacancySerializer(serializers.ModelSerializer):
+    """Vacancy serializer."""
+
+    class Meta:
+        """Meta class for vacancy serializer."""
+
+        model = Vacancy
+        fields = (
+            "pk",
+            "title",
+            "description",
+            "location",
+            "keywords",
+            "link",
+            "partner",
+            "company_name",
+            "company_logo",
+        )

--- a/website/partners/api/v2/urls.py
+++ b/website/partners/api/v2/urls.py
@@ -5,6 +5,9 @@ from partners.api.v2.views import (
     PartnerEventListView,
     PartnerListView,
     PartnerEventDetailView,
+    PartnerDetailView,
+    VacancyListView,
+    VacancyDetailView,
 )
 
 app_name = "partners"
@@ -18,5 +21,12 @@ urlpatterns = [
         PartnerEventDetailView.as_view(),
         name="partner-events-detail",
     ),
+    path("partners/vacancies/", VacancyListView.as_view(), name="vacancies-list"),
+    path(
+        "partners/vacancies/<int:pk>/",
+        VacancyDetailView.as_view(),
+        name="vacancies-detail",
+    ),
     path("partners/", PartnerListView.as_view(), name="partners-list"),
+    path("partners/<int:pk>/", PartnerDetailView.as_view(), name="partners-detail"),
 ]

--- a/website/partners/api/v2/views.py
+++ b/website/partners/api/v2/views.py
@@ -1,3 +1,4 @@
+from django.db.models import query
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import filters as framework_filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
@@ -5,7 +6,8 @@ from rest_framework.generics import ListAPIView, RetrieveAPIView
 from partners.api.v2 import filters
 from partners.api.v2.serializers.partner import PartnerSerializer
 from partners.api.v2.serializers.partner_event import PartnerEventSerializer
-from partners.models import PartnerEvent, Partner
+from partners.api.v2.serializers.vacancy import VacancySerializer
+from partners.models import PartnerEvent, Partner, Vacancy
 
 
 class PartnerEventListView(ListAPIView):
@@ -34,6 +36,8 @@ class PartnerEventDetailView(RetrieveAPIView):
 
 
 class PartnerListView(ListAPIView):
+    """Returns an overview of all partners."""
+
     serializer_class = PartnerSerializer
     queryset = Partner.objects.filter(is_active=True)
     filter_backends = (
@@ -42,5 +46,42 @@ class PartnerListView(ListAPIView):
     )
     ordering_fields = ("name", "pk")
     search_fields = ("name",)
+    permission_classes = [IsAuthenticatedOrTokenHasScope]
+    required_scopes = ["partners:read"]
+
+
+class PartnerDetailView(RetrieveAPIView):
+    """Returns a single partner."""
+
+    serializer_class = PartnerSerializer
+    queryset = Partner.objects.filter(is_active=True)
+    permission_classes = [IsAuthenticatedOrTokenHasScope]
+    required_scopes = ["partners:read"]
+
+
+class VacancyListView(ListAPIView):
+    """Returns an overview of all vacancies."""
+
+    serializer_class = VacancySerializer
+    queryset = Vacancy.objects.all()
+    filter_backends = (
+        framework_filters.OrderingFilter,
+        framework_filters.SearchFilter,
+        filters.VacancyPartnerFilter,
+    )
+    ordering_fields = ("title", "pk")
+    search_fields = (
+        "title",
+        "company_name",
+    )
+    permission_classes = [IsAuthenticatedOrTokenHasScope]
+    required_scopes = ["partners:read"]
+
+
+class VacancyDetailView(RetrieveAPIView):
+    """Returns a single vacancy."""
+
+    serializer_class = VacancySerializer
+    queryset = Partner.objects.all()
     permission_classes = [IsAuthenticatedOrTokenHasScope]
     required_scopes = ["partners:read"]


### PR DESCRIPTION
Closes #1642

### Summary
Adds `partners/vacancies/` and `/partners/vacancies/<int:pk>/` endpoints. Includes search on title and company name, and filtering on partner pk. Also adds `/partners/<int:pk>/`.

### How to test
Steps to test the changes you made:
1. Try out the new API and its filters.
