### PR TITLE
Update privacy_policy.html

### DIFF
--- a/website/singlepages/templates/singlepages/privacy_policy.html
+++ b/website/singlepages/templates/singlepages/privacy_policy.html
@@ -77,7 +77,7 @@
                     Thalia uses the phone number of members, benefactors and honorary members to communicate with members
                     about activities of Thalia.
                     Think about calling a participant who is too late for an activity or communicating a last-minute
-                    change.The processing of phone numbers by Thalia is optional.
+                    change. The processing of phone numbers by Thalia is optional.
                     Processing of these data happens based on consent, which is given implicitly when the phone number
                     is entered during registration or on the user profile on the website.
                 {% endblocktrans %}
@@ -168,18 +168,11 @@
                     Thalia uses photo’s which are made during her events for the promotion of events and the association.
                     These photo's can be made available on the website of Thalia for members or they can be posted on social media accounts of Thalia.
                     If such image is posted on a social media platform other than the website of Thalia, permission will be asked to all recognisable persons in the picture if this is feasible.
-                    It is possible to ask for the removal of a certain photo from social media when someone on that photo desires so, by sending a mail to info@thalia.nu.
+                    It is possible to ask for the removal of a certain photo from social media when someone on that photo desires so, by sending a mail to <a href="mailto:info@thalia.nu">info@thalia.nu</a>.
                     Processing of this data happens on the basis of it being a legitimate interest of Thalia.
 
                     When someone wishes not to be photographed, they can indicate this to the photographer.
-                    A request of deletion of a certain photo can also be made after it has been taken, by sending a mail to info@thalia.nu.
-                {% endblocktrans %}
-            </p>
-
-            <p>
-                {% blocktrans trimmed %}
-                    When someone wishes not to be photographed, he or she can indicate this to the photographer.
-                    It’s also possible to ask for deletion of the photo after it has been taken.
+                    A request of deletion of a certain photo can also be made after it has been taken, by sending a mail to <a href="mailto:info@thalia.nu">info@thalia.nu</a>.
                 {% endblocktrans %}
             </p>
 
@@ -253,7 +246,7 @@
                     Within Thalia, the secretary is the contact person for all matters concerning the processing of
                     personal data.
                     Requests and notifications of leaked data can be sent by email to
-                    <a href="mailto:secretary@thalia.nu">secretary@thalia.nu</a> or by post to
+                    <a href="mailto:info@thalia.nu">info@thalia.nu</a> or by post to
                     <em>Studievereniging Thalia, Toernooiveld 212, 6525EC Nijmegen</em>.
                 {% endblocktrans %}
             </p>


### PR DESCRIPTION
There were still some minor mistakes in the new version of the privacy policy, they have now been corrected

Closes #ISSUE

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Some mistakes were corrected in the privacy policy, namely:

- Under **Phone number**, there was a space missing on line 80 (between "... last-minute change." and "The processing ... ".
- Under **Photos**, there was an superfluous sentence at the end (line 175-182) because it is already incorporated in the text above. it was still there from the previous version.
- Under the same header, the email-address was not a hyperlink (line 171).
- Under **Contact details for Processing of personal data**, there was the mail address secretary@thalia.nu instead of info@thalia.nu. Although both email adresses go to the same inbox, it is neater to mention the same email adress throughout the policy.
