### PR TITLE
Add support for multiple local partners

### DIFF
--- a/website/partners/models.py
+++ b/website/partners/models.py
@@ -54,8 +54,6 @@ class Partner(models.Model):
         if self.is_main_partner:
             self.is_local_partner = False
             self._reset_main_partner()
-        if self.is_local_partner:
-            self._reset_local_partner()
 
         super().save(**kwargs)
 
@@ -70,20 +68,6 @@ class Partner(models.Model):
             if self != current_main_partner:
                 current_main_partner.is_main_partner = False
                 current_main_partner.save()
-        except Partner.DoesNotExist:
-            pass
-
-    def _reset_local_partner(self):
-        """Reset the local partner status.
-
-        If this partner is not local partner,
-        remove the local partner status from the local partner.
-        """
-        try:
-            current_local_partner = Partner.objects.get(is_local_partner=True)
-            if self != current_local_partner:
-                current_local_partner.is_local_partner = False
-                current_local_partner.save()
         except Partner.DoesNotExist:
             pass
 

--- a/website/partners/templates/partners/index.html
+++ b/website/partners/templates/partners/index.html
@@ -20,29 +20,34 @@
                 {% endblocktrans %}
             </p>
 
-            <div class="row mt-4">
+            <div class="row mt-4 justify-content-center">
                 <div class="col-12 col-md-6 mt-auto">
-                <div class="text-center">
-                    <img src="{% thumbnail main_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}"/>
-                </div>
-                <div class="mt-3">
-                    <h2>{% trans "our main partner"|capfirst %}</h2>
-                    <h3>{{ main_partner.name }}</h3>
-                    <p>{{ main_partner.company_profile|striptags|bleach|truncatechars:425 }}</p>
-                    <a href="{{ main_partner.get_absolute_url }}" class="btn btn-primary">{% trans "Learn more" %}</a>
-                </div>
+                    <div class="text-center">
+                        <img src="{% thumbnail main_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}"/>
                     </div>
-                <div class="col-12 col-md-6 mt-auto">
-                <div class="text-center">
-                    <img src="{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}"/>
+                    <div class="mt-3">
+                        <h2>{% trans "our main partner"|capfirst %}</h2>
+                        <h3>{{ main_partner.name }}</h3>
+                        <p>{{ main_partner.company_profile|striptags|bleach|truncatechars:425 }}</p>
+                        <a href="{{ main_partner.get_absolute_url }}" class="btn btn-primary">{% trans "Learn more" %}</a>
+                    </div>
                 </div>
-                <div class="mt-3">
-                    <h2>{% trans "our local partner"|capfirst %}</h2>
-                    <h3>{{ local_partner.name }}</h3>
-                    <p>{{ local_partner.company_profile|striptags|bleach|truncatechars:425 }}</p>
-                    <a href="{{ local_partner.get_absolute_url }}" class="btn btn-primary">{% trans "Learn more" %}</a>
-                </div>
-                </div>
+            </div>
+
+            <div class="row mt-4 justify-content-center">
+                {% for local_partner in local_partners %}
+                    <div class="col-12 col-md-6 mt-auto">
+                        <div class="text-center">
+                            <img src="{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}"/>
+                        </div>
+                        <div class="mt-3">
+                            <h2>{% trans "our local partner"|capfirst %}</h2>
+                            <h3>{{ local_partner.name }}</h3>
+                            <p>{{ local_partner.company_profile|striptags|bleach|truncatechars:425 }}</p>
+                            <a href="{{ local_partner.get_absolute_url }}" class="btn btn-primary">{% trans "Learn more" %}</a>
+                        </div>
+                    </div>
+                {% endfor %}
             </div>
 
             <div class="row mt-4">

--- a/website/partners/views.py
+++ b/website/partners/views.py
@@ -11,11 +11,11 @@ def index(request):
         is_active=True, is_main_partner=False, is_local_partner=False
     )
     main_partner = Partner.objects.filter(is_main_partner=True).first()
-    local_partner = Partner.objects.filter(is_local_partner=True).first()
+    local_partners = Partner.objects.filter(is_local_partner=True)
 
     context = {
         "main_partner": main_partner,
-        "local_partner": local_partner,
+        "local_partners": local_partners,
         "partners": sorted(partners, key=lambda x: random()),
     }
     return render(request, "partners/index.html", context)


### PR DESCRIPTION
See #2041 

### Summary
Add support for multiple local partners instead of just one.

### How to test
Steps to test the changes you made:
1. Go to 'site admin -> partners'
2. Make sure two or more partners are set as local partner
3. Go to the partner page on the website
4. See two local partners on the website
7. Check if steps 3-4 work with one local partner
