### PR TITLE
Add an admin option to the MemberSerializer for names

### DIFF
--- a/website/events/api/v2/admin/serializers/event_registration.py
+++ b/website/events/api/v2/admin/serializers/event_registration.py
@@ -32,5 +32,7 @@ class EventRegistrationAdminSerializer(serializers.ModelSerializer):
         return super().to_internal_value(data)
 
     def to_representation(self, instance):
-        self.fields["member"] = MemberSerializer(detailed=False, read_only=True)
+        self.fields["member"] = MemberSerializer(
+            admin=True, detailed=False, read_only=True
+        )
         return super().to_representation(instance)

--- a/website/members/api/v2/serializers/member.py
+++ b/website/members/api/v2/serializers/member.py
@@ -10,19 +10,32 @@ class MemberSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         # Don't pass the 'fields' arg up to the superclass
         detailed = kwargs.pop("detailed", True)
+        admin = kwargs.pop("admin", False)
 
         # Instantiate the superclass normally
         super().__init__(*args, **kwargs)
 
+        hidden_fields = set()
         if not detailed:
-            hidden_fields = {"achievements", "societies"}
-            existing = set(self.fields.keys())
-            for field_name in existing & hidden_fields:
-                self.fields.pop(field_name)
+            hidden_fields.update({"achievements", "societies"})
+        if not admin:
+            hidden_fields.update({"first_name", "last_name"})
+
+        existing = set(self.fields.keys())
+        for field_name in existing & hidden_fields:
+            self.fields.pop(field_name)
 
     class Meta:
         model = Member
-        fields = ("pk", "membership_type", "profile", "achievements", "societies")
+        fields = (
+            "pk",
+            "first_name",
+            "last_name",
+            "membership_type",
+            "profile",
+            "achievements",
+            "societies",
+        )
 
     membership_type = serializers.SerializerMethodField("_membership_type")
     profile = ProfileSerializer(

--- a/website/payments/api/v2/admin/serializers/payable_detail.py
+++ b/website/payments/api/v2/admin/serializers/payable_detail.py
@@ -13,7 +13,9 @@ class PayableAdminSerializer(Serializer):
         child=CharField(), default=[Payment.CASH, Payment.CARD, Payment.WIRE,]
     )
     amount = DecimalField(decimal_places=2, max_digits=1000, source="payment_amount")
-    payer = MemberSerializer(detailed=False, read_only=True, source="payment_payer")
+    payer = MemberSerializer(
+        admin=True, detailed=False, read_only=True, source="payment_payer"
+    )
     topic = CharField(source="payment_topic")
     notes = CharField(source="payment_notes")
     payment = PaymentAdminSerializer(read_only=True)

--- a/website/pizzas/api/v2/admin/serializers/order.py
+++ b/website/pizzas/api/v2/admin/serializers/order.py
@@ -25,7 +25,7 @@ class FoodOrderAdminSerializer(serializers.ModelSerializer):
 
     payment = PaymentSerializer()
     product = ProductAdminSerializer()
-    member = MemberSerializer(detailed=False, required=False)
+    member = MemberSerializer(admin=True, detailed=False, required=False)
 
     def to_internal_value(self, data):
         self.fields["member"] = serializers.PrimaryKeyRelatedField(


### PR DESCRIPTION
Closes #2048 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This adds the first and last name from the member model to the API serializer so that the app can show real names.

### How to test
Steps to test the changes you made:
1. Go to any API view that uses the serializer in this mode.
2. Check that the first and last name are in the output
