### PR TITLE
Add summaries to frontpage, re-show event cards

### DIFF
--- a/website/education/static/education/css/style.scss
+++ b/website/education/static/education/css/style.scss
@@ -2,3 +2,14 @@ img.lang-flag {
     vertical-align: middle;
     width: 20px;
 }
+.frontpage-summaries {
+    .list-group-item {
+        .summary-course-title {
+            color: var(--primary);
+        }
+
+        .summary-name {
+            color: var(--list-background-contrast);
+        }
+    }
+}

--- a/website/education/templates/education/frontpage_summaries.html
+++ b/website/education/templates/education/frontpage_summaries.html
@@ -1,5 +1,5 @@
 {% load i18n bleach_tags alert %}
-<div class="frontpage-vacancies">
+<div class="frontpage-summaries">
     <h1 class="text-center section-title">{% trans "Recent course summaries" %}</h1>
 
     {% if not summaries %}

--- a/website/education/templates/education/frontpage_summaries.html
+++ b/website/education/templates/education/frontpage_summaries.html
@@ -12,8 +12,8 @@
             {% for summary in summaries %}
                 <a class="list-group-item py-3"
                    href="{{ summary.course.get_absolute_url }}">
-                    <span class="vacancy-title mr-3">{{ summary.course.name }}</span>
-                    <span class="vacancy-company" title="{{ summary.name }}">{{ summary.name }}</span>
+                    <span class="summary-course-title mr-3">{{ summary.course.name }}</span>
+                    <span class="summary-name" title="{{ summary.name }}">{{ summary.name }}</span>
                 </a>
             {% endfor %}
         </div>

--- a/website/education/templates/education/frontpage_summaries.html
+++ b/website/education/templates/education/frontpage_summaries.html
@@ -1,0 +1,28 @@
+{% load i18n bleach_tags alert %}
+<div class="frontpage-vacancies">
+    <h1 class="text-center section-title">{% trans "Recent course summaries" %}</h1>
+
+    {% if not summaries %}
+        <div class="mt-4">
+            {% trans 'There are currently no course summaries' as info_text %}
+            {% alert 'info' info_text dismissible=False %}
+        </div>
+    {% else %}
+        <div class="list-group">
+            {% for summary in summaries %}
+                <a class="list-group-item py-3"
+                   href="{{ summary.course.get_absolute_url }}">
+                    <span class="vacancy-title mr-3">{{ summary.course.name }}</span>
+                    <span class="vacancy-company" title="{{ summary.name }}">{{ summary.name }}</span>
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
+    <p class="text-center mt-3">
+        {% url 'education:courses' as courses_index %}
+        {% blocktrans trimmed %}
+            <a href="{{ courses_index }}">Check out the courses page</a>
+            for more.
+        {% endblocktrans %}
+    </p>
+</div>

--- a/website/education/templatetags/frontpage_summaries.py
+++ b/website/education/templatetags/frontpage_summaries.py
@@ -1,0 +1,17 @@
+from django import template
+from django.utils import timezone
+from django.utils.translation import gettext as _
+
+from education.models import Summary
+from events import services
+from events.models import Event
+
+register = template.Library()
+
+
+@register.inclusion_tag("education/frontpage_summaries.html", takes_context=True)
+def render_frontpage_summaries(context, summaries=None):
+    if summaries is None:
+        summaries = Summary.objects.filter(accepted=True,).order_by("uploader_date")[:6]
+
+    return {"summaries": summaries}

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -1,3 +1,49 @@
+#events-cards {
+    .card {
+        -moz-transition: 0.2s ease-in;
+        -o-transition: 0.2s ease-in;
+        -webkit-transition: 0.2s ease-in;
+        -ms-transition: 0.2s ease-in;
+        transition: 0.2s ease-in;
+
+        height: calc(100% - 15px);
+
+        &:hover {
+            background-color: var(--card-background-hover);
+        }
+
+        .card-date {
+            color: var(--primary);
+            margin-bottom: .7rem;
+        }
+
+        .event-indication {
+            float: right;
+            position: absolute;
+            right: 1.25rem;
+            top: 1.25rem;
+
+            .regular-event-registration-open, .regular-event-has-registration .regular-event-pending-registration {
+                border-radius: 20px;
+                width: 12px;
+                height: 12px;
+            }
+
+            .regular-event-registration-open {
+                background-color: $grey;
+            }
+
+            .regular-event-has-registration {
+                background-color: var(--primary);
+            }
+
+            .regular-event-pending-registration {
+                background-color: $yellow;
+            }
+        }
+    }
+}
+
 .frontpage-events {
     .list-group-item {
         .event-date {

--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -1,3 +1,28 @@
+.event-indication {
+    float: right;
+    position: absolute;
+    right: 1.25rem;
+    top: 1.25rem;
+
+    .open-registration, .has-registration, .pending-registration {
+        border-radius: 20px;
+        width: 12px;
+        height: 12px;
+    }
+
+    .open-registration {
+        background-color: $grey;
+    }
+
+    .has-registration {
+        background-color: var(--primary);
+    }
+
+    .pending-registration {
+        background-color: $yellow;
+    }
+}
+
 #events-cards {
     .card {
         -moz-transition: 0.2s ease-in;
@@ -16,31 +41,6 @@
             color: var(--primary);
             margin-bottom: .7rem;
         }
-
-        .event-indication {
-            float: right;
-            position: absolute;
-            right: 1.25rem;
-            top: 1.25rem;
-
-            .regular-event-registration-open, .regular-event-has-registration .regular-event-pending-registration {
-                border-radius: 20px;
-                width: 12px;
-                height: 12px;
-            }
-
-            .regular-event-registration-open {
-                background-color: $grey;
-            }
-
-            .regular-event-has-registration {
-                background-color: var(--primary);
-            }
-
-            .regular-event-pending-registration {
-                background-color: $yellow;
-            }
-        }
     }
 }
 
@@ -58,31 +58,6 @@
             display: inline-block;
             text-overflow: ellipsis;
             line-height: 16px;
-        }
-
-        .event-indication {
-            float: right;
-            width: 12px;
-            height: 12px;
-            margin-top: 6px;
-
-            .open-registration, .has-registration, .pending-registration {
-                border-radius: 20px;
-                width: 12px;
-                height: 12px;
-            }
-
-            .open-registration {
-                background-color: $grey;
-            }
-
-            .has-registration {
-                background-color: var(--primary);
-            }
-
-            .pending-registration {
-                background-color: $yellow;
-            }
         }
     }
 }

--- a/website/events/templates/events/event_cards.html
+++ b/website/events/templates/events/event_cards.html
@@ -15,17 +15,14 @@
                         <div class="card animated fadeIn">
                             <div class="card-body">
                                 {% if next_event.current_user_registration is not None %}
-                                {% if next_event.current_user_registration %}
-                                    <div class="event-indication" data-toggle="tooltip"
-                                     data-placement="top" title="{% trans "Registered for this event" %}">
-                                        <div class="has-registration"></div>
-                                    </div>
-                                {% else %}
-                                    <div class="event-indication" data-toggle="tooltip"
-                                     data-placement="top" title="{%  trans "Not registered for this event" %}">
-                                        <div class="no-registration"></div>
-                                    </div>
-                                {% endif %}
+                                    {% if next_event.current_user_registration %}
+                                        <div class="event-indication"
+                                             data-toggle="tooltip"
+                                             data-placement="top"
+                                             title="{{ next_event.current_user_registration.text }}">
+                                            <div class="{{ next_event.current_user_registration.class }}"></div>
+                                        </div>
+                                    {% endif %}
                                 {% endif %}
 
                                 <h6 class="card-date">{{ next_event.event.start|date:"d F Y" }}</h6>

--- a/website/events/templates/events/event_cards.html
+++ b/website/events/templates/events/event_cards.html
@@ -1,0 +1,48 @@
+{% load i18n bleach_tags alert %}
+<section id="events-cards" class="page-section">
+    <div class="container">
+        <h1 class="text-center section-title">{% trans "Upcoming events" %}</h1>
+        <div class="row">
+            {% if not events %}
+                <div class="mt-4 col-12">
+                    {% trans 'There are currently no events planned' as info_text %}
+                    {% alert 'info' info_text dismissible=False %}
+                </div>
+            {% else %}
+                {% for next_event in events %}
+                <div class="col-md-6 col-lg-4">
+                    <a href="{{ next_event.event.get_absolute_url }}">
+                        <div class="card animated fadeIn">
+                            <div class="card-body">
+                                {% if next_event.current_user_registration is not None %}
+                                {% if next_event.current_user_registration %}
+                                    <div class="event-indication" data-toggle="tooltip"
+                                     data-placement="top" title="{% trans "Registered for this event" %}">
+                                        <div class="has-registration"></div>
+                                    </div>
+                                {% else %}
+                                    <div class="event-indication" data-toggle="tooltip"
+                                     data-placement="top" title="{%  trans "Not registered for this event" %}">
+                                        <div class="no-registration"></div>
+                                    </div>
+                                {% endif %}
+                                {% endif %}
+
+                                <h6 class="card-date">{{ next_event.event.start|date:"d F Y" }}</h6>
+                                <h5 class="card-title">{{ next_event.event.title }}</h5>
+                                <p class="card-text">{{ next_event.event.description|striptags|bleach|truncatechars:110 }}</p>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                {% endfor %}
+            {% endif %}
+        </div>
+        <p class="text-center">
+            {% url 'events:index' as events_index %}
+            {% blocktrans trimmed %}
+                Searching for another event? <a href="{{ events_index }}">Take a look at the entire agenda.</a>
+            {% endblocktrans %}
+        </p>
+    </div>
+</section>

--- a/website/events/templatetags/event_cards.py
+++ b/website/events/templatetags/event_cards.py
@@ -1,0 +1,32 @@
+from django import template
+from django.utils import timezone
+
+from events import services
+from events.models import Event
+
+register = template.Library()
+
+
+@register.inclusion_tag("events/event_cards.html", takes_context=True)
+def render_event_cards(context, events=None):
+    if events is None:
+        events = Event.objects.filter(
+            published=True,
+            start__gte=timezone.now() - timezone.timedelta(hours=24),
+            end__gte=timezone.now(),
+        ).order_by("start")[:6]
+
+    try:
+        cards = [
+            {
+                "event": x,
+                "current_user_registration": services.is_user_registered(
+                    context["user"], x
+                ),
+            }
+            for x in events
+        ]
+    except AttributeError:
+        cards = [{"event": x, "current_user_registration": None} for x in events]
+
+    return {"events": cards}

--- a/website/events/templatetags/event_cards.py
+++ b/website/events/templatetags/event_cards.py
@@ -1,32 +1,9 @@
 from django import template
-from django.utils import timezone
-
-from events import services
-from events.models import Event
+from events.templatetags.frontpage_events import render_frontpage_events
 
 register = template.Library()
 
 
 @register.inclusion_tag("events/event_cards.html", takes_context=True)
 def render_event_cards(context, events=None):
-    if events is None:
-        events = Event.objects.filter(
-            published=True,
-            start__gte=timezone.now() - timezone.timedelta(hours=24),
-            end__gte=timezone.now(),
-        ).order_by("start")[:6]
-
-    try:
-        cards = [
-            {
-                "event": x,
-                "current_user_registration": services.is_user_registered(
-                    context["user"], x
-                ),
-            }
-            for x in events
-        ]
-    except AttributeError:
-        cards = [{"event": x, "current_user_registration": None} for x in events]
-
-    return {"events": cards}
+    return render_frontpage_events(context, events)

--- a/website/thaliawebsite/templates/index.html
+++ b/website/thaliawebsite/templates/index.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n alert frontpage_events frontpage_articles partner_banners frontpage_vacancies slider %}
+{% load i18n alert event_cards frontpage_events frontpage_articles frontpage_summaries partner_banners frontpage_vacancies slider %}
 
 {% block body_class %}home{% endblock %}
 
@@ -26,11 +26,13 @@
 
     {% render_frontpage_articles %}
 
+    {% render_event_cards %}
+
     <section class="page-section">
         <div class="container">
             <div class="row">
                 <div class="col-12 col-md-6">
-                    {% render_frontpage_events %}
+                    {% render_frontpage_summaries %}
                 </div>
                 <div class="col-12 col-md-6 mt-5 mt-md-0">
                     {% render_frontpage_vacancies %}


### PR DESCRIPTION
### Summary
In #1974, the way events were displayed on the front page changed. We did not deploy this, because we did not like the new design, as it did not show the first lines of the description anymore.
This PR fixes that the event cards are displayed 'as normal' again. Moreover, it adds the latest course summaries to the front page, next to the vacancies.

### How to test
1. Visit the home page