### PR TITLE
Fix crash on vacancy detail api

### DIFF
--- a/website/partners/api/v2/views.py
+++ b/website/partners/api/v2/views.py
@@ -1,4 +1,3 @@
-from django.db.models import query
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import filters as framework_filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
@@ -82,6 +81,6 @@ class VacancyDetailView(RetrieveAPIView):
     """Returns a single vacancy."""
 
     serializer_class = VacancySerializer
-    queryset = Partner.objects.all()
+    queryset = Vacancy.objects.all()
     permission_classes = [IsAuthenticatedOrTokenHasScope]
     required_scopes = ["partners:read"]


### PR DESCRIPTION
Closes #2054.

It was a single very obvious typo. Test with `/api/v2/partners/vacancies/1/`