### PR TITLE
Add-categories-to-vacancies-api

### DIFF
--- a/website/partners/api/v2/filters.py
+++ b/website/partners/api/v2/filters.py
@@ -66,11 +66,7 @@ class VacancyCategoryFilter(filters.BaseFilterBackend):
         categories = request.query_params.get("categories", None)
 
         if categories:
-            categories_set = VacancyCategory.objects.filter(
-                slug__in=categories.split(",")
-            ).all()
-
-            queryset = queryset.filter(categories__in=categories_set)
+            queryset = queryset.filter(categories__slug__in=categories.split(","))
 
         return queryset
 

--- a/website/partners/api/v2/filters.py
+++ b/website/partners/api/v2/filters.py
@@ -1,6 +1,7 @@
 from rest_framework import filters
 
 from utils.snippets import extract_date_range
+from partners.models import VacancyCategory
 
 
 class PartnerEventDateFilter(filters.BaseFilterBackend):
@@ -54,5 +55,32 @@ class VacancyPartnerFilter(filters.BaseFilterBackend):
                 "in": "query",
                 "description": "Filter by partner id",
                 "schema": {"type": "number"},
+            }
+        ]
+
+
+class VacancyCategoryFilter(filters.BaseFilterBackend):
+    """Allows you to filter by category slug."""
+
+    def filter_queryset(self, request, queryset, view):
+        categories = request.query_params.get("categories", None)
+
+        if categories:
+            categories_set = VacancyCategory.objects.filter(
+                slug__in=categories.split(",")
+            ).all()
+
+            queryset = queryset.filter(categories__in=categories_set)
+
+        return queryset
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                "name": "categories",
+                "required": False,
+                "in": "query",
+                "description": "Filter by category slugs, accepts a comma separated list. Return vacancies that have at least one of the specified categories",
+                "schema": {"type": "string"},
             }
         ]

--- a/website/partners/api/v2/serializers/__init__.py
+++ b/website/partners/api/v2/serializers/__init__.py
@@ -1,0 +1,4 @@
+from .partner_event import PartnerEventSerializer
+from .partner import PartnerSerializer
+from .vacancy import VacancySerializer
+from .vacancy_category import VacancyCategorySerializer

--- a/website/partners/api/v2/serializers/vacancy.py
+++ b/website/partners/api/v2/serializers/vacancy.py
@@ -1,4 +1,5 @@
 from partners.models import Vacancy
+from .vacancy_category import VacancyCategorySerializer
 from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
     CleanedModelSerializer,
 )
@@ -21,4 +22,7 @@ class VacancySerializer(CleanedModelSerializer):
             "partner",
             "company_name",
             "company_logo",
+            "categories",
         )
+
+    categories = VacancyCategorySerializer(many=True)

--- a/website/partners/api/v2/serializers/vacancy_category.py
+++ b/website/partners/api/v2/serializers/vacancy_category.py
@@ -11,4 +11,3 @@ class VacancyCategorySerializer(serializers.ModelSerializer):
 
         model = VacancyCategory
         fields = ("name", "slug")
-

--- a/website/partners/api/v2/serializers/vacancy_category.py
+++ b/website/partners/api/v2/serializers/vacancy_category.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+
+from partners.models import VacancyCategory
+
+
+class VacancyCategorySerializer(serializers.ModelSerializer):
+    """Vacancy category serializer."""
+
+    class Meta:
+        """Meta class for vacancy category serializer."""
+
+        model = VacancyCategory
+        fields = ("name", "slug")
+

--- a/website/partners/api/v2/urls.py
+++ b/website/partners/api/v2/urls.py
@@ -8,6 +8,7 @@ from partners.api.v2.views import (
     PartnerDetailView,
     VacancyListView,
     VacancyDetailView,
+    VacancyCategoryListView,
 )
 
 app_name = "partners"
@@ -22,6 +23,11 @@ urlpatterns = [
         name="partner-events-detail",
     ),
     path("partners/vacancies/", VacancyListView.as_view(), name="vacancies-list"),
+    path(
+        "partners/vacancies/categories/",
+        VacancyCategoryListView.as_view(),
+        name="vacancy-categories-list",
+    ),
     path(
         "partners/vacancies/<int:pk>/",
         VacancyDetailView.as_view(),

--- a/website/partners/api/v2/views.py
+++ b/website/partners/api/v2/views.py
@@ -3,10 +3,13 @@ from rest_framework import filters as framework_filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 
 from partners.api.v2 import filters
-from partners.api.v2.serializers.partner import PartnerSerializer
-from partners.api.v2.serializers.partner_event import PartnerEventSerializer
-from partners.api.v2.serializers.vacancy import VacancySerializer
-from partners.models import PartnerEvent, Partner, Vacancy
+from partners.api.v2.serializers import (
+    PartnerSerializer,
+    PartnerEventSerializer,
+    VacancySerializer,
+    VacancyCategorySerializer,
+)
+from partners.models import PartnerEvent, Partner, Vacancy, VacancyCategory
 
 
 class PartnerEventListView(ListAPIView):
@@ -67,6 +70,7 @@ class VacancyListView(ListAPIView):
         framework_filters.OrderingFilter,
         framework_filters.SearchFilter,
         filters.VacancyPartnerFilter,
+        filters.VacancyCategoryFilter,
     )
     ordering_fields = ("title", "pk")
     search_fields = (
@@ -82,5 +86,20 @@ class VacancyDetailView(RetrieveAPIView):
 
     serializer_class = VacancySerializer
     queryset = Vacancy.objects.all()
+    permission_classes = [IsAuthenticatedOrTokenHasScope]
+    required_scopes = ["partners:read"]
+
+
+class VacancyCategoryListView(ListAPIView):
+    """Returns an overview of all vacancy categories."""
+
+    serializer_class = VacancyCategorySerializer
+    queryset = VacancyCategory.objects.all()
+    filter_backends = (
+        framework_filters.OrderingFilter,
+        framework_filters.SearchFilter,
+    )
+    ordering_fields = ("name", "slug")
+    search_fields = ("name",)
     permission_classes = [IsAuthenticatedOrTokenHasScope]
     required_scopes = ["partners:read"]


### PR DESCRIPTION
Adds vacancy categories to the api. The categories are added to the vacancy serializer. There is also a filter to get vacancies that have at least one of a comma-separated list of category slugs, and an endpoint for the list of all categories.

## How to test?
Try out the new endpoint,  and the filter.