### PR TITLE
Introduce CleanedModelSerializer

### DIFF
--- a/website/activemembers/api/v1/serializers.py
+++ b/website/activemembers/api/v1/serializers.py
@@ -3,9 +3,10 @@ from rest_framework import serializers
 
 from activemembers.models import MemberGroup, MemberGroupMembership
 from members.api.v1.serializers import MemberListSerializer
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class MemberGroupSerializer(serializers.ModelSerializer):
+class MemberGroupSerializer(CleanedModelSerializer):
     """MemberGroup serializer."""
 
     class Meta:

--- a/website/activemembers/api/v2/serializers/member_group.py
+++ b/website/activemembers/api/v2/serializers/member_group.py
@@ -5,9 +5,12 @@ from activemembers.api.v2.serializers.member_group_membership import (
 )
 from activemembers.models import MemberGroup
 from thaliawebsite.api.v2.serializers import ThumbnailSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class MemberGroupSerializer(serializers.ModelSerializer):
+class MemberGroupSerializer(CleanedModelSerializer):
     """API serializer for member groups."""
 
     def __init__(self, *args, **kwargs):

--- a/website/activemembers/api/v2/serializers/member_group_membership.py
+++ b/website/activemembers/api/v2/serializers/member_group_membership.py
@@ -2,9 +2,12 @@ from rest_framework import serializers
 
 from activemembers.models import MemberGroupMembership
 from members.api.v2.serializers.member import MemberSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class MemberGroupMembershipSerializer(serializers.ModelSerializer):
+class MemberGroupMembershipSerializer(CleanedModelSerializer):
     """API serializer for member group memberships."""
 
     class Meta:

--- a/website/announcements/api/v1/serializers.py
+++ b/website/announcements/api/v1/serializers.py
@@ -3,10 +3,11 @@ from django.conf import settings
 from rest_framework import serializers
 
 from announcements.models import Slide
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 from utils.media.services import get_thumbnail_url
 
 
-class SlideSerializer(serializers.ModelSerializer):
+class SlideSerializer(CleanedModelSerializer):
     """Slide serializer."""
 
     class Meta:

--- a/website/announcements/api/v2/serializers.py
+++ b/website/announcements/api/v2/serializers.py
@@ -4,9 +4,12 @@ from rest_framework import serializers
 
 from announcements.models import Slide
 from thaliawebsite.api.v2.serializers import ThumbnailSerializer, CleanedHTMLSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class SlideSerializer(serializers.ModelSerializer):
+class SlideSerializer(CleanedModelSerializer):
     """Slide serializer."""
 
     class Meta:

--- a/website/documents/api/v2/serializers/document.py
+++ b/website/documents/api/v2/serializers/document.py
@@ -1,11 +1,13 @@
 from rest_framework.fields import SerializerMethodField
 from rest_framework.reverse import reverse
-from rest_framework.serializers import ModelSerializer
 
 from documents.models import Document
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class DocumentSerializer(ModelSerializer):
+class DocumentSerializer(CleanedModelSerializer):
     class Meta:
         model = Document
         fields = ("pk", "name", "url", "category", "members_only")

--- a/website/events/api/v1/serializers/event_registrations/list.py
+++ b/website/events/api/v1/serializers/event_registrations/list.py
@@ -9,9 +9,10 @@ from events.models import EventRegistration, RegistrationInformationField
 from payments.api.v1.fields import PaymentTypeField
 from payments.models import Payment
 from thaliawebsite.api.services import create_image_thumbnail_dict
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class EventRegistrationListSerializer(serializers.ModelSerializer):
+class EventRegistrationListSerializer(CleanedModelSerializer):
     """Custom registration list serializer."""
 
     class Meta:

--- a/website/events/api/v1/serializers/events/list.py
+++ b/website/events/api/v1/serializers/events/list.py
@@ -6,9 +6,10 @@ from rest_framework import serializers
 from announcements.api.v1.serializers import SlideSerializer
 from events import services
 from events.models import Event
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class EventListSerializer(serializers.ModelSerializer):
+class EventListSerializer(CleanedModelSerializer):
     """Custom list serializer for events."""
 
     class Meta:

--- a/website/events/api/v1/serializers/events/retrieve.py
+++ b/website/events/api/v1/serializers/events/retrieve.py
@@ -7,11 +7,12 @@ from events.api.v1.serializers.event_registrations.list import (
     EventRegistrationAdminListSerializer,
 )
 from events.models import Event, EventRegistration
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 from thaliawebsite.templatetags.bleach_tags import bleach
 from utils.snippets import create_google_maps_url
 
 
-class EventRetrieveSerializer(serializers.ModelSerializer):
+class EventRetrieveSerializer(CleanedModelSerializer):
     """Serializer for events."""
 
     class Meta:

--- a/website/events/api/v2/admin/serializers/event.py
+++ b/website/events/api/v2/admin/serializers/event.py
@@ -7,10 +7,13 @@ from announcements.models import Slide
 from documents.api.v2.serializers.document import DocumentSerializer
 from documents.models import Document
 from events.models import Event
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 from thaliawebsite.api.v2.serializers.html import CleanedHTMLSerializer
 
 
-class EventAdminSerializer(serializers.ModelSerializer):
+class EventAdminSerializer(CleanedModelSerializer):
     """Serializer for events."""
 
     class Meta:

--- a/website/events/api/v2/admin/serializers/event_registration.py
+++ b/website/events/api/v2/admin/serializers/event_registration.py
@@ -4,9 +4,12 @@ from events.models import EventRegistration
 from members.api.v2.serializers.member import MemberSerializer
 from members.models import Member
 from payments.api.v2.serializers import PaymentSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class EventRegistrationAdminSerializer(serializers.ModelSerializer):
+class EventRegistrationAdminSerializer(CleanedModelSerializer):
     """Serializer for event registrations."""
 
     class Meta:
@@ -36,3 +39,8 @@ class EventRegistrationAdminSerializer(serializers.ModelSerializer):
             admin=True, detailed=False, read_only=True
         )
         return super().to_representation(instance)
+
+    # def validate(self, attrs):
+    #     instance = EventRegistration(**attrs)
+    #     instance.clean()
+    #     return attrs

--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -7,10 +7,13 @@ from events import services
 from events.api.v2.serializers.event_registration import EventRegistrationSerializer
 from events.models import Event, EventRegistration
 from thaliawebsite.api.v2.serializers import CleanedHTMLSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 from utils.snippets import create_google_maps_url
 
 
-class EventSerializer(serializers.ModelSerializer):
+class EventSerializer(CleanedModelSerializer):
     """Serializer for events."""
 
     class Meta:

--- a/website/events/api/v2/serializers/event_registration.py
+++ b/website/events/api/v2/serializers/event_registration.py
@@ -3,9 +3,12 @@ from rest_framework import serializers
 from events.models import EventRegistration
 from members.api.v2.serializers.member import MemberSerializer
 from payments.api.v2.serializers import PaymentSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class EventRegistrationSerializer(serializers.ModelSerializer):
+class EventRegistrationSerializer(CleanedModelSerializer):
     """Serializer for event registrations."""
 
     def __init__(self, *args, **kwargs):

--- a/website/events/models/event_registration.py
+++ b/website/events/models/event_registration.py
@@ -119,6 +119,8 @@ class EventRegistration(models.Model):
             )
 
     def save(self, **kwargs):
+        self.full_clean()
+
         super().save(**kwargs)
 
         if self.event.start_reminder and self.date_cancelled:

--- a/website/members/api/v1/serializers.py
+++ b/website/members/api/v1/serializers.py
@@ -5,9 +5,10 @@ from rest_framework import serializers
 from members.models import Member, Profile
 from members.services import member_achievements, member_societies
 from thaliawebsite.api.services import create_image_thumbnail_dict
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class ProfileRetrieveSerializer(serializers.ModelSerializer):
+class ProfileRetrieveSerializer(CleanedModelSerializer):
     """Serializer that renders a member profile."""
 
     class Meta:
@@ -101,7 +102,7 @@ class MemberListSerializer(serializers.ModelSerializer):
         return None
 
 
-class ProfileEditSerializer(serializers.ModelSerializer):
+class ProfileEditSerializer(CleanedModelSerializer):
     """Serializer that renders a profile to be edited."""
 
     class Meta:

--- a/website/members/api/v2/serializers/member.py
+++ b/website/members/api/v2/serializers/member.py
@@ -4,9 +4,12 @@ from rest_framework.exceptions import ValidationError
 from members.api.v2.serializers.profile import ProfileSerializer
 from members.models import Member
 from members.services import member_achievements, member_societies
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class MemberSerializer(serializers.ModelSerializer):
+class MemberSerializer(CleanedModelSerializer):
     def __init__(self, *args, **kwargs):
         # Don't pass the 'fields' arg up to the superclass
         detailed = kwargs.pop("detailed", True)

--- a/website/members/api/v2/serializers/profile.py
+++ b/website/members/api/v2/serializers/profile.py
@@ -3,9 +3,12 @@ from rest_framework import serializers
 
 from members.models import Profile
 from thaliawebsite.api.v2.serializers import ThumbnailSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class ProfileSerializer(serializers.ModelSerializer):
+class ProfileSerializer(CleanedModelSerializer):
     def __init__(self, *args, **kwargs):
         # Don't pass the 'fields' arg up to the superclass
         fields = kwargs.pop("fields", None)

--- a/website/partners/api/v1/serializers.py
+++ b/website/partners/api/v1/serializers.py
@@ -4,9 +4,10 @@ from django.utils.html import strip_tags
 from rest_framework import serializers
 
 from partners.models import PartnerEvent, Partner
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class PartnerSerializer(serializers.ModelSerializer):
+class PartnerSerializer(CleanedModelSerializer):
     """Partner serializer."""
 
     class Meta:
@@ -25,7 +26,7 @@ class PartnerSerializer(serializers.ModelSerializer):
         )
 
 
-class PartnerEventSerializer(serializers.ModelSerializer):
+class PartnerEventSerializer(CleanedModelSerializer):
     """Partner events serializer."""
 
     class Meta:

--- a/website/partners/api/v2/serializers/partner.py
+++ b/website/partners/api/v2/serializers/partner.py
@@ -2,9 +2,12 @@ from rest_framework import serializers
 
 from partners.models import Partner
 from thaliawebsite.api.v2.serializers import CleanedHTMLSerializer, ThumbnailSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class PartnerSerializer(serializers.ModelSerializer):
+class PartnerSerializer(CleanedModelSerializer):
     """Partner serializer."""
 
     class Meta:

--- a/website/partners/api/v2/serializers/partner_event.py
+++ b/website/partners/api/v2/serializers/partner_event.py
@@ -1,10 +1,11 @@
-from rest_framework import serializers
-
 from partners.models import PartnerEvent
 from thaliawebsite.api.v2.serializers import CleanedHTMLSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class PartnerEventSerializer(serializers.ModelSerializer):
+class PartnerEventSerializer(CleanedModelSerializer):
     """Partner events serializer."""
 
     class Meta:

--- a/website/partners/api/v2/serializers/vacancy.py
+++ b/website/partners/api/v2/serializers/vacancy.py
@@ -1,9 +1,10 @@
-from rest_framework import serializers
-
 from partners.models import Vacancy
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class VacancySerializer(serializers.ModelSerializer):
+class VacancySerializer(CleanedModelSerializer):
     """Vacancy serializer."""
 
     class Meta:

--- a/website/payments/api/v1/serializers/payments.py
+++ b/website/payments/api/v1/serializers/payments.py
@@ -1,9 +1,8 @@
-from rest_framework.serializers import ModelSerializer
-
 from payments.models import Payment
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class PaymentSerializer(ModelSerializer):
+class PaymentSerializer(CleanedModelSerializer):
     class Meta:
         model = Payment
         fields = ["pk", "get_type_display", "amount", "created_at", "topic", "notes"]

--- a/website/payments/api/v2/admin/serializers/payment.py
+++ b/website/payments/api/v2/admin/serializers/payment.py
@@ -1,12 +1,14 @@
 from rest_framework.fields import HiddenField
-from rest_framework.serializers import ModelSerializer
 
 from members.api.v2.serializers.member import MemberSerializer
 from payments.models import Payment
 from thaliawebsite.api.v2.fields import CurrentMemberDefault
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class PaymentCreateSerializer(ModelSerializer):
+class PaymentCreateSerializer(CleanedModelSerializer):
     class Meta:
         model = Payment
         fields = (
@@ -24,7 +26,7 @@ class PaymentCreateSerializer(ModelSerializer):
     processed_by = HiddenField(default=CurrentMemberDefault())
 
 
-class PaymentAdminSerializer(ModelSerializer):
+class PaymentAdminSerializer(CleanedModelSerializer):
     class Meta:
         model = Payment
         fields = (

--- a/website/payments/api/v2/serializers/payment.py
+++ b/website/payments/api/v2/serializers/payment.py
@@ -1,9 +1,10 @@
-from rest_framework.serializers import ModelSerializer
-
 from payments.models import Payment
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class PaymentSerializer(ModelSerializer):
+class PaymentSerializer(CleanedModelSerializer):
     class Meta:
         model = Payment
         fields = ["pk", "type", "amount", "created_at", "topic", "notes"]

--- a/website/photos/api/v1/serializers.py
+++ b/website/photos/api/v1/serializers.py
@@ -3,9 +3,10 @@ from rest_framework import serializers
 from thaliawebsite.api.services import create_image_thumbnail_dict
 from photos import services
 from photos.models import Photo, Album
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class PhotoRetrieveSerializer(serializers.ModelSerializer):
+class PhotoRetrieveSerializer(CleanedModelSerializer):
     """ModelSerializer class to get a Photo object set."""
 
     file = serializers.SerializerMethodField("_file")
@@ -25,7 +26,7 @@ class PhotoRetrieveSerializer(serializers.ModelSerializer):
         fields = ("pk", "rotation", "hidden", "album", "file")
 
 
-class PhotoCreateSerializer(serializers.ModelSerializer):
+class PhotoCreateSerializer(CleanedModelSerializer):
     """ModelSerializer class to create or update a Photo object set."""
 
     class Meta:
@@ -35,7 +36,7 @@ class PhotoCreateSerializer(serializers.ModelSerializer):
         fields = ("pk", "rotation", "hidden", "album", "file")
 
 
-class AlbumSerializer(serializers.ModelSerializer):
+class AlbumSerializer(CleanedModelSerializer):
     """ModelSerializer for an Album object."""
 
     photos = serializers.SerializerMethodField("_photos")
@@ -74,7 +75,7 @@ class AlbumSerializer(serializers.ModelSerializer):
         fields = ("pk", "title", "date", "hidden", "shareable", "accessible", "photos")
 
 
-class AlbumListSerializer(serializers.ModelSerializer):
+class AlbumListSerializer(CleanedModelSerializer):
     """ModelSerializer class for a list of Albums."""
 
     cover = PhotoRetrieveSerializer()

--- a/website/photos/api/v2/serializers/album.py
+++ b/website/photos/api/v2/serializers/album.py
@@ -3,9 +3,12 @@ from rest_framework import serializers
 from photos import services
 from photos.api.v2.serializers.photo import PhotoSerializer, PhotoListSerializer
 from photos.models import Album
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class AlbumSerializer(serializers.ModelSerializer):
+class AlbumSerializer(CleanedModelSerializer):
     """API serializer for albums."""
 
     class Meta:

--- a/website/photos/api/v2/serializers/photo.py
+++ b/website/photos/api/v2/serializers/photo.py
@@ -1,10 +1,11 @@
-from rest_framework import serializers
-
 from photos.models import Photo
 from thaliawebsite.api.v2.serializers import ThumbnailSerializer
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class PhotoSerializer(serializers.ModelSerializer):
+class PhotoSerializer(CleanedModelSerializer):
     """API serializer for photos."""
 
     class Meta:

--- a/website/pizzas/api/v1/serializers.py
+++ b/website/pizzas/api/v1/serializers.py
@@ -9,15 +9,16 @@ from payments.api.v1.fields import PaymentTypeField
 from payments.models import Payment
 from pizzas.models import Product, FoodEvent, FoodOrder
 from pizzas.services import can_change_order
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class PizzaSerializer(serializers.ModelSerializer):
+class PizzaSerializer(CleanedModelSerializer):
     class Meta:
         model = Product
         fields = ("pk", "name", "description", "price", "available")
 
 
-class PizzaEventSerializer(serializers.ModelSerializer):
+class PizzaEventSerializer(CleanedModelSerializer):
     class Meta:
         model = FoodEvent
         fields = ("start", "end", "event", "title", "is_admin")
@@ -30,7 +31,7 @@ class PizzaEventSerializer(serializers.ModelSerializer):
         return can_change_order(member, instance)
 
 
-class OrderSerializer(serializers.ModelSerializer):
+class OrderSerializer(CleanedModelSerializer):
     class Meta:
         model = FoodOrder
         fields = ("pk", "payment", "product", "name", "member")
@@ -41,7 +42,7 @@ class OrderSerializer(serializers.ModelSerializer):
     )
 
 
-class AdminOrderSerializer(serializers.ModelSerializer):
+class AdminOrderSerializer(CleanedModelSerializer):
     class Meta:
         model = FoodOrder
         fields = ("pk", "payment", "product", "name", "member", "display_name")

--- a/website/pizzas/api/v2/admin/serializers/food_event.py
+++ b/website/pizzas/api/v2/admin/serializers/food_event.py
@@ -3,9 +3,12 @@ from rest_framework import serializers
 from events.api.v2.serializers.event import EventSerializer
 from events.models import Event
 from pizzas.models import FoodEvent
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class FoodEventAdminSerializer(serializers.ModelSerializer):
+class FoodEventAdminSerializer(CleanedModelSerializer):
     class Meta:
         model = FoodEvent
         fields = (

--- a/website/pizzas/api/v2/admin/serializers/order.py
+++ b/website/pizzas/api/v2/admin/serializers/order.py
@@ -4,14 +4,16 @@ from rest_framework.validators import UniqueTogetherValidator
 from members.api.v2.serializers.member import MemberSerializer
 from members.models import Member
 from payments.api.v2.serializers import PaymentSerializer
-from pizzas.api.v2.admin.serializers.food_event import FoodEventAdminSerializer
 from pizzas.api.v2.admin.serializers.product import ProductAdminSerializer
 from pizzas.api.v2.admin.validators import MutuallyExclusiveValidator
 from pizzas.api.v2.serializers import Product
 from pizzas.models import FoodOrder, FoodEvent
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class FoodOrderAdminSerializer(serializers.ModelSerializer):
+class FoodOrderAdminSerializer(CleanedModelSerializer):
     class Meta:
         model = FoodOrder
         fields = ("pk", "payment", "product", "name", "member", "food_event")

--- a/website/pizzas/api/v2/admin/serializers/product.py
+++ b/website/pizzas/api/v2/admin/serializers/product.py
@@ -1,9 +1,10 @@
-from rest_framework import serializers
-
 from pizzas.models import Product
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class ProductAdminSerializer(serializers.ModelSerializer):
+class ProductAdminSerializer(CleanedModelSerializer):
     class Meta:
         model = Product
         fields = ("pk", "name", "available", "restricted", "description", "price")

--- a/website/pushnotifications/api/v1/serializers.py
+++ b/website/pushnotifications/api/v1/serializers.py
@@ -1,10 +1,10 @@
 from rest_framework.relations import ManyRelatedField, PrimaryKeyRelatedField
-from rest_framework.serializers import ModelSerializer
 
 from pushnotifications.models import Device, Category, Message
+from thaliawebsite.api.v1.cleaned_model_serializer import CleanedModelSerializer
 
 
-class DeviceSerializer(ModelSerializer):
+class DeviceSerializer(CleanedModelSerializer):
 
     receive_category = ManyRelatedField(
         allow_empty=True,
@@ -30,14 +30,14 @@ class DeviceSerializer(ModelSerializer):
         extra_kwargs = {"active": {"default": True}}
 
 
-class CategorySerializer(ModelSerializer):
+class CategorySerializer(CleanedModelSerializer):
     class Meta:
         model = Category
 
         fields = ("key", "name", "description")
 
 
-class MessageSerializer(ModelSerializer):
+class MessageSerializer(CleanedModelSerializer):
     class Meta:
         model = Message
 

--- a/website/pushnotifications/api/v2/serializers.py
+++ b/website/pushnotifications/api/v2/serializers.py
@@ -1,11 +1,13 @@
 """Serializers for the pushnotifications app."""
 from rest_framework.relations import ManyRelatedField, PrimaryKeyRelatedField
-from rest_framework.serializers import ModelSerializer
 
 from pushnotifications.models import Device, Category, Message
+from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
+    CleanedModelSerializer,
+)
 
 
-class DeviceSerializer(ModelSerializer):
+class DeviceSerializer(CleanedModelSerializer):
     """Device serializer."""
 
     class Meta:
@@ -40,7 +42,7 @@ class DeviceSerializer(ModelSerializer):
     )
 
 
-class CategorySerializer(ModelSerializer):
+class CategorySerializer(CleanedModelSerializer):
     """Category serializers."""
 
     class Meta:
@@ -50,7 +52,7 @@ class CategorySerializer(ModelSerializer):
         fields = ("key", "name", "description")
 
 
-class MessageSerializer(ModelSerializer):
+class MessageSerializer(CleanedModelSerializer):
     class Meta:
         """Meta for the serializer."""
 

--- a/website/thaliawebsite/api/v1/cleaned_model_serializer.py
+++ b/website/thaliawebsite/api/v1/cleaned_model_serializer.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+
+class CleanedModelSerializer(serializers.ModelSerializer):
+    """Custom ModelSerializer that explicitly clean's a model before it is saved."""
+
+    def validate(self, attrs):
+        super().validate(attrs)
+        instance = self.Meta.model(**attrs)
+        instance.clean()
+        return attrs

--- a/website/thaliawebsite/api/v2/serializers/cleaned_model_serializer.py
+++ b/website/thaliawebsite/api/v2/serializers/cleaned_model_serializer.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+
+class CleanedModelSerializer(serializers.ModelSerializer):
+    """Custom ModelSerializer that explicitly clean's a model before it is saved."""
+
+    def validate(self, attrs):
+        super().validate(attrs)
+        instance = self.Meta.model(**attrs)
+        instance.clean()
+        return attrs


### PR DESCRIPTION
### Summary
Django rest framework's ModelSerializer does not `clean()` it's instances before saving. This introduces a CeanedModelSerializer that does do this.

Note that the sales app does not use these serializers, as the update and create method there already have been overwritten (and using validate actually breaks stuff)

### How to test
1. All API's should be tested...