### PR TITLE
Use caption for front page events

### DIFF
--- a/website/events/templates/events/event_cards.html
+++ b/website/events/templates/events/event_cards.html
@@ -27,7 +27,7 @@
 
                                 <h6 class="card-date">{{ next_event.event.start|date:"d F Y" }}</h6>
                                 <h5 class="card-title">{{ next_event.event.title }}</h5>
-                                <p class="card-text">{{ next_event.event.description|striptags|bleach|truncatechars:110 }}</p>
+                                <p class="card-text">{{ next_event.event.caption|striptags|bleach|truncatechars:110 }}</p>
                             </div>
                         </div>
                     </a>


### PR DESCRIPTION
### Summary
The shorter captions are now used for the front page articles. I think this will look nicer than long descriptions that are cut off.

Not that this will display N/A for events that were created before captions were mandatory

### How to test
Steps to test the changes you made:
1. Go to frontpage
2. See short descriptions
