### PR TITLE
Use event caption for opengraph description

### DIFF
--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -6,7 +6,7 @@
 {% block opengraph_title %}{{ event.title }} — {% trans "Calendar"|capfirst %} — {{ block.super }}{% endblock %}
 
 {% block opengraph %}
-    <meta property="og:description" content="{{ event.description|striptags|truncatewords:10 }}"/>
+    <meta property="og:description" content="{{ event.caption|striptags }}"/>
 {% endblock %}
 
 
@@ -239,7 +239,7 @@
                             </td>
                         </tr>
 
-                        {% if event.food_event %} 
+                        {% if event.food_event %}
                             {% if event.food_event == event.food_event.current or event.food_event.just_ended or event.food_event.in_the_future %}
                                 <tr>
                                     <th>

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -6,7 +6,11 @@
 {% block opengraph_title %}{{ event.title }} — {% trans "Calendar"|capfirst %} — {{ block.super }}{% endblock %}
 
 {% block opengraph %}
-    <meta property="og:description" content="{{ event.caption|striptags }}"/>
+    {% if event.caption != 'N/A' %}
+        <meta property="og:description" content="{{ event.caption|striptags }}"/>
+    {% else %}
+        <meta property="og:description" content="{{ event.description|striptags|truncatewords:10 }}"/>
+    {% endif %}
 {% endblock %}
 
 


### PR DESCRIPTION
### Summary
Use event caption for opengraph description

### How to test
1. Visit the event details page
2. Verify that the `og:description` uses the caption

For example, use https://www.opengraph.xyz