### PR TITLE
removed "Summary" prefix from course summaries

### DIFF
--- a/website/education/views.py
+++ b/website/education/views.py
@@ -82,7 +82,7 @@ class CourseDetailView(DetailView):
                 items[summary.year]["summaries"].append(
                     {
                         "year": summary.year,
-                        "name": f'{_("Summary")} {summary.name}',
+                        "name": summary.name,
                         "language": summary.language,
                         "id": summary.id,
                     }


### PR DESCRIPTION
Closes #1988

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Removes "Summary" prefix from summary names. This prevents titles as "Summary mathematical structures summary"

### How to test
Steps to test the changes you made:
1. Go to Education
2. Click on Summaries & exams
3. Go to a course 
4. Click on a year, and see the changed titles
