### PR TITLE
Fix getting board for a certain year when creating mailinglists

### DIFF
--- a/website/mailinglists/models.py
+++ b/website/mailinglists/models.py
@@ -31,7 +31,7 @@ def get_automatic_mailinglists():
     ]
     if Board.objects.exists():
         for year in range(Board.objects.earliest("since").since.year, lectureyear):
-            board = Board.objects.get(since__year=year)
+            board = Board.objects.filter(since__year=year).first()
             if board is not None:
                 years = str(board.since.year)[-2:] + str(board.until.year)[-2:]
                 list_names += [f"bestuur{years}", f"board{years}"]


### PR DESCRIPTION
### Summary
The range loop here used the lecture year and thus if a board group for the latest year does not exist this  function will instantly break. Aka :boom: .


### How to test
Steps to test the changes you made:
1. Delete a couple of board groups that should exist
2. Try to create a mailing list.
3. Error
