### PR TITLE
Hotfix payment amount 0 for free events

### DIFF
--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -134,12 +134,14 @@ class Event(models.Model):
 
     price = PaymentAmountField(
         verbose_name=_("price"),
+        allow_zero=True,
         default=0,
         validators=[validators.MinValueValidator(0)],
     )
 
     fine = PaymentAmountField(
         verbose_name=_("fine"),
+        allow_zero=True,
         default=0,
         # Minimum fine is checked in this model's clean(), as it is only for
         # events that require registration.

--- a/website/payments/models.py
+++ b/website/payments/models.py
@@ -30,8 +30,9 @@ class PaymentAmountField(models.DecimalField):
     def __init__(self, **kwargs):
         kwargs["max_digits"] = 8
         kwargs["decimal_places"] = 2
+        allow_zero = kwargs.pop("allow_zero", False)
         validators = kwargs.pop("validators", [])
-        if validate_not_zero not in validators:
+        if not allow_zero and validate_not_zero not in validators:
             validators.append(validate_not_zero)
         kwargs["validators"] = validators
         super().__init__(**kwargs)


### PR DESCRIPTION
### Summary
Fixes a bug that events cannot be free, because PaymentAmountFields cannot be null

### How to test
1. Make a 'free' event
2. Make sure it clean()'s and it still appears as a free event everywhere on the website