### PR TITLE
Fix ordering summaries front page

### DIFF
--- a/website/education/templatetags/frontpage_summaries.py
+++ b/website/education/templatetags/frontpage_summaries.py
@@ -12,6 +12,8 @@ register = template.Library()
 @register.inclusion_tag("education/frontpage_summaries.html", takes_context=True)
 def render_frontpage_summaries(context, summaries=None):
     if summaries is None:
-        summaries = Summary.objects.filter(accepted=True,).order_by("-uploader_date")[:6]
+        summaries = Summary.objects.filter(accepted=True,).order_by("-uploader_date")[
+            :6
+        ]
 
     return {"summaries": summaries}

--- a/website/education/templatetags/frontpage_summaries.py
+++ b/website/education/templatetags/frontpage_summaries.py
@@ -12,6 +12,6 @@ register = template.Library()
 @register.inclusion_tag("education/frontpage_summaries.html", takes_context=True)
 def render_frontpage_summaries(context, summaries=None):
     if summaries is None:
-        summaries = Summary.objects.filter(accepted=True,).order_by("uploader_date")[:6]
+        summaries = Summary.objects.filter(accepted=True,).order_by("-uploader_date")[:6]
 
     return {"summaries": summaries}


### PR DESCRIPTION


<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Reversed the ordering of the summaries on the front page so actually the newest summaries are shown, not the oldest.

### How to test
Steps to test the changes you made:
1. Add some summaries
2. Change their upload date
3. Check the newest is on top
