### PR TITLE
Fix serializer validation

### DIFF
--- a/website/events/api/v2/admin/serializers/event_registration.py
+++ b/website/events/api/v2/admin/serializers/event_registration.py
@@ -25,14 +25,36 @@ class EventRegistrationAdminSerializer(CleanedModelSerializer):
             "name",
             "special_price",
             "remarks",
+            "queue_position",
+            "is_cancelled",
+            "is_late_cancellation",
         )
         read_only_fields = ("payment",)
+        optional_fields = ["payment", "member", "name", "special_prize", "remarks"]
 
-    payment = PaymentSerializer()
+    payment = PaymentSerializer(required=False)
+    is_cancelled = serializers.SerializerMethodField("_is_cancelled")
+    is_late_cancellation = serializers.SerializerMethodField("_is_late_cancellation")
+    queue_position = serializers.SerializerMethodField("_queue_position")
+
+    def create(self, validated_data):
+        event = self.context["event"]
+        validated_data.update({"event": event})
+        return super().create(validated_data)
+
+    def _is_late_cancellation(self, instance):
+        return instance.is_late_cancellation()
+
+    def _queue_position(self, instance):
+        pos = instance.queue_position
+        return pos if pos and pos > 0 else None
+
+    def _is_cancelled(self, instance):
+        return instance.date_cancelled is not None
 
     def to_internal_value(self, data):
         self.fields["member"] = serializers.PrimaryKeyRelatedField(
-            queryset=Member.objects.all()
+            queryset=Member.objects.all(), required=False
         )
         return super().to_internal_value(data)
 

--- a/website/events/api/v2/admin/serializers/event_registration.py
+++ b/website/events/api/v2/admin/serializers/event_registration.py
@@ -25,32 +25,16 @@ class EventRegistrationAdminSerializer(CleanedModelSerializer):
             "name",
             "special_price",
             "remarks",
-            "queue_position",
-            "is_cancelled",
-            "is_late_cancellation",
         )
         read_only_fields = ("payment",)
         optional_fields = ["payment", "member", "name", "special_prize", "remarks"]
 
     payment = PaymentSerializer(required=False)
-    is_cancelled = serializers.SerializerMethodField("_is_cancelled")
-    is_late_cancellation = serializers.SerializerMethodField("_is_late_cancellation")
-    queue_position = serializers.SerializerMethodField("_queue_position")
 
     def create(self, validated_data):
         event = self.context["event"]
         validated_data.update({"event": event})
         return super().create(validated_data)
-
-    def _is_late_cancellation(self, instance):
-        return instance.is_late_cancellation()
-
-    def _queue_position(self, instance):
-        pos = instance.queue_position
-        return pos if pos and pos > 0 else None
-
-    def _is_cancelled(self, instance):
-        return instance.date_cancelled is not None
 
     def to_internal_value(self, data):
         self.fields["member"] = serializers.PrimaryKeyRelatedField(

--- a/website/events/api/v2/admin/views.py
+++ b/website/events/api/v2/admin/views.py
@@ -90,6 +90,12 @@ class EventRegistrationAdminListView(AdminListAPIView, AdminCreateAPIView):
             )
         return EventRegistration.objects.none()
 
+    def get_serializer_context(self):
+        context = super(EventRegistrationAdminListView, self).get_serializer_context()
+        event = get_object_or_404(Event, pk=self.kwargs.get("pk"))
+        context.update({"event": event})
+        return context
+
 
 class EventRegistrationAdminDetailView(
     AdminRetrieveAPIView, AdminUpdateAPIView, AdminDestroyAPIView
@@ -103,7 +109,7 @@ class EventRegistrationAdminDetailView(
     event_lookup_field = "event_id"
 
     def get_queryset(self):
-        return super().get_queryset().filter(event=self.kwargs["event_id"])
+        return super().get_queryset().filter(event=self.kwargs[self.event_lookup_field])
 
 
 class EventRegistrationAdminFieldsView(AdminPermissionsMixin, APIView):

--- a/website/thaliawebsite/api/v2/serializers/cleaned_model_serializer.py
+++ b/website/thaliawebsite/api/v2/serializers/cleaned_model_serializer.py
@@ -9,14 +9,22 @@ class CleanedModelSerializer(serializers.ModelSerializer):
     """Custom ModelSerializer that explicitly clean's a model before it is saved."""
 
     def create(self, validated_data):
-        """Reraise ValidationErrors as DRF validation errors. No need to explicitly clean(), because under the hood, DRF uses .create() which does perform a clean()."""
+        """Reraise ValidationErrors as DRF validation errors.
+
+        No need to explicitly clean(), because under the hood, DRF uses
+        .create() which does perform a clean().
+        """
         try:
             return super().create(validated_data)
         except ValidationError as e:
             raise DRFValidationError(e)
 
     def update(self, instance, validated_data, **kwargs):
-        """Overriding the default implementation of DRF's ModelSerializer, adding `instance.clean()`."""
+        """Override the default implementation of DRF's ModelSerializer.
+
+        Adds `instance.clean()` to make sure all updates still clean().
+        Also re-raises ValidationErrors to DRF ValidationErrors.
+        """
         raise_errors_on_nested_writes("update", self, validated_data)
         info = model_meta.get_field_info(instance)
 

--- a/website/thaliawebsite/api/v2/serializers/cleaned_model_serializer.py
+++ b/website/thaliawebsite/api/v2/serializers/cleaned_model_serializer.py
@@ -1,15 +1,48 @@
+from django.core.exceptions import ValidationError
 from rest_framework import serializers
+from rest_framework.serializers import raise_errors_on_nested_writes
+from rest_framework.utils import model_meta
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 
 class CleanedModelSerializer(serializers.ModelSerializer):
     """Custom ModelSerializer that explicitly clean's a model before it is saved."""
 
-    def create(self, validated_data, **kwargs):
-        self.Meta.model(**validated_data).clean()
-        return super().create(validated_data)
+    def create(self, validated_data):
+        """Reraise ValidationErrors as DRF validation errors. No need to explicitly clean(), because under the hood, DRF uses .create() which does perform a clean()."""
+        try:
+            return super().create(validated_data)
+        except ValidationError as e:
+            raise DRFValidationError(e)
 
     def update(self, instance, validated_data, **kwargs):
-        for key, val in validated_data.items():
-            setattr(instance, key, val)
-        instance.clean()
-        return super().update(instance, validated_data)
+        """Overriding the default implementation of DRF's ModelSerializer, adding `instance.clean()`."""
+        raise_errors_on_nested_writes("update", self, validated_data)
+        info = model_meta.get_field_info(instance)
+
+        # Simply set each attribute on the instance, and then save it.
+        # Note that unlike `.create()` we don't need to treat many-to-many
+        # relationships as being a special case. During updates we already
+        # have an instance pk for the relationships to be associated with.
+        m2m_fields = []
+        for attr, value in validated_data.items():
+            if attr in info.relations and info.relations[attr].to_many:
+                m2m_fields.append((attr, value))
+            else:
+                setattr(instance, attr, value)
+
+        try:
+            instance.clean()
+        except ValidationError as e:
+            raise DRFValidationError(e)
+
+        instance.save()
+
+        # Note that many-to-many fields are set after updating instance.
+        # Setting m2m fields triggers signals which could potentially change
+        # updated instance and we do not want it to collide with .update()
+        for attr, value in m2m_fields:
+            field = getattr(instance, attr)
+            field.set(value)
+
+        return instance


### PR DESCRIPTION
### Summary
Thoroughly fixes model validation after API updates, and changes some things to the EventRegistrationAdminSerializer to make it more convenient.

### How to test
1. Try to POST, PUT and PATCH to the API, bot things that should and should not clean. For example, an Event Registration with both a `member` and `name` field.