### PR TITLE
Make API v2 default in swagger

### DIFF
--- a/website/thaliawebsite/api/urls.py
+++ b/website/thaliawebsite/api/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
                     TemplateView.as_view(
                         template_name="swagger/index.html",
                         extra_context={
-                            "schema_urls": ["api:v1:schema", "api:v2:schema"]
+                            "schema_urls": ["api:v2:schema", "api:v1:schema"]
                         },
                     ),
                     name="swagger",


### PR DESCRIPTION
### Summary
Make API v2 default in swagger

### How to test
1. Go to /api/docs and observe v2 schema is selected by default