### PR TITLE
Increase nginx client_max_body_size

### DIFF
--- a/infra/nixos/concrexit.nix
+++ b/infra/nixos/concrexit.nix
@@ -253,6 +253,8 @@ in
         recommendedOptimisation = true;
         recommendedTlsSettings = true;
 
+        clientMaxBodySize = "2G";
+
         commonHttpConfig = ''
           log_format logfmt 'time="$time_local" client=$remote_addr '
               'method=$request_method url="$request_uri" '


### PR DESCRIPTION
We used to have this in our previous configuration, and I forgot to add it to the nix configs. This allows members to upload photo albums up to 2GiB