### PR TITLE
Backport "Increase nginx client_max_body_size" for 40.1

### DIFF
--- a/infra/nixos/concrexit.nix
+++ b/infra/nixos/concrexit.nix
@@ -253,6 +253,8 @@ in
         recommendedOptimisation = true;
         recommendedTlsSettings = true;
 
+        clientMaxBodySize = "2G";
+
         commonHttpConfig = ''
           log_format logfmt 'time="$time_local" client=$remote_addr '
               'method=$request_method url="$request_uri" '


### PR DESCRIPTION
I think usually we do the release branches different, but I just wanna make this available on production in a clean way