### PR TITLE
Fix event registration admin serializer to not throw a 404 on schema generation

### DIFF
--- a/website/events/api/v2/admin/serializers/event_registration.py
+++ b/website/events/api/v2/admin/serializers/event_registration.py
@@ -27,7 +27,7 @@ class EventRegistrationAdminSerializer(CleanedModelSerializer):
             "remarks",
         )
         read_only_fields = ("payment",)
-        optional_fields = ["payment", "member", "name", "special_prize", "remarks"]
+        optional_fields = ["payment", "member", "name", "special_price", "remarks"]
 
     payment = PaymentSerializer(required=False)
 

--- a/website/events/api/v2/admin/views.py
+++ b/website/events/api/v2/admin/views.py
@@ -91,8 +91,8 @@ class EventRegistrationAdminListView(AdminListAPIView, AdminCreateAPIView):
         return EventRegistration.objects.none()
 
     def get_serializer_context(self):
-        context = super(EventRegistrationAdminListView, self).get_serializer_context()
-        event = get_object_or_404(Event, pk=self.kwargs.get("pk"))
+        context = super().get_serializer_context()
+        event = Event.objects.filter(pk=self.kwargs.get("pk")).first()
         context.update({"event": event})
         return context
 


### PR DESCRIPTION
### Summary
`/api/docs` is broken because the schema url throws a 404. This is because the 404 is thrown in one of the views during the schema generation step.

### How to test
Steps to test the changes you made:
1. Go to `/api/docs`
2. You have a schema, instead of none
