### PR TITLE
Fix missing true name in foodorder admin serializer

### DIFF
--- a/website/pizzas/api/v2/admin/serializers/order.py
+++ b/website/pizzas/api/v2/admin/serializers/order.py
@@ -7,7 +7,7 @@ from payments.api.v2.serializers import PaymentSerializer
 from pizzas.api.v2.admin.serializers.product import ProductAdminSerializer
 from pizzas.api.v2.admin.validators import MutuallyExclusiveValidator
 from pizzas.api.v2.serializers import Product
-from pizzas.models import FoodOrder, FoodEvent
+from pizzas.models import FoodOrder
 from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
     CleanedModelSerializer,
 )
@@ -39,6 +39,8 @@ class FoodOrderAdminSerializer(CleanedModelSerializer):
         return super().to_internal_value(data)
 
     def to_representation(self, instance):
-        self.fields["member"] = MemberSerializer(detailed=False, read_only=True)
         self.fields["product"] = ProductAdminSerializer(read_only=True)
+        self.fields["member"] = MemberSerializer(
+            admin=True, detailed=False, read_only=True
+        )
         return super().to_representation(instance)


### PR DESCRIPTION
Fixes a small mistake in #2049.

### How to test
Try out the food order admin and see that true names are now returned.
