### PR TITLE
Fix allow zero value for certain PaymentAmountFields

### DIFF
--- a/website/newsletters/models.py
+++ b/website/newsletters/models.py
@@ -150,11 +150,16 @@ class NewsletterEvent(NewsletterContent):
     )
 
     price = PaymentAmountField(
-        verbose_name=_("Price (in Euro)"), blank=True, null=True, default=None,
+        verbose_name=_("Price (in Euro)"),
+        allow_zero=True,
+        blank=True,
+        null=True,
+        default=None,
     )
 
     penalty_costs = PaymentAmountField(
         verbose_name=_("Costs (in Euro)"),
+        allow_zero=True,
         blank=True,
         null=True,
         default=None,

--- a/website/sales/models/order.py
+++ b/website/sales/models/order.py
@@ -8,7 +8,6 @@ from django.db.models import (
     Sum,
     Value,
     F,
-    DecimalField,
     Q,
     IntegerField,
     BooleanField,
@@ -98,15 +97,21 @@ class Order(models.Model):
 
     subtotal = AnnotationProperty(
         Coalesce(
-            Sum("order_items__total"), Value(0.00), output_field=PaymentAmountField()
+            Sum("order_items__total"),
+            Value(0.00),
+            output_field=PaymentAmountField(allow_zero=True),
         )
     )
 
     total_amount = AnnotationProperty(
         Coalesce(
-            Sum("order_items__total"), Value(0.00), output_field=PaymentAmountField()
+            Sum("order_items__total"),
+            Value(0.00),
+            output_field=PaymentAmountField(allow_zero=True),
         )
-        - Coalesce(F("discount"), Value(0.00), output_field=PaymentAmountField())
+        - Coalesce(
+            F("discount"), Value(0.00), output_field=PaymentAmountField(allow_zero=True)
+        )
     )
 
     num_items = AnnotationProperty(
@@ -197,6 +202,7 @@ class OrderItem(models.Model):
     )
     total = PaymentAmountField(
         verbose_name=_("total"),
+        allow_zero=True,
         null=False,
         blank=True,
         validators=[MinValueValidator(Decimal("0.00"))],

--- a/website/sales/models/product.py
+++ b/website/sales/models/product.py
@@ -66,7 +66,7 @@ class ProductListItem(models.Model):
         on_delete=models.CASCADE,
     )
     price = PaymentAmountField(
-        verbose_name=_("price"), validators=[MinValueValidator(0)],
+        verbose_name=_("price"), allow_zero=True, validators=[MinValueValidator(0)],
     )
 
     def __str__(self):


### PR DESCRIPTION
Closes #2170 and closes #2169 

### Summary
Allows zero again on PaymentAmountFields

### How to test
1. Add free products to a product list and have a free order
2. Try to create a free newsletter event or one without a fine