### PR TITLE
fix the width of the member search form in mobile layout

### DIFF
--- a/website/members/templates/members/index.html
+++ b/website/members/templates/members/index.html
@@ -19,7 +19,7 @@
                         {% endblocktrans %}
                     </p>
 
-                    <form class="search-form form-inline col-6 mt-4 mt-lg-0 mb-4" method="get"
+                    <form class="search-form form-inline col-12 col-lg-6 mt-4 mt-lg-0 mb-4" method="get"
                       action="#members-directory">
                         <input class="form-control col-12 col-md-9" name="keywords" type="text" value="{{ keys|default_if_none:'' }}"
                                placeholder="{% trans "Who are you looking for?" %}"/>


### PR DESCRIPTION
Closes #2157

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Changed the search form in `members/index.html` so that it no longer gets cut off in mobile layout. I copied the form class from the photos search field.

### How to test
Steps to test the changes you made:
1. Go to the member list, either on mobile, or using a mobile layout in the browser.
2. Compare this to the search field on the 'photos' page, which is the desired implementation.
