### PR TITLE
Remove isort config

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,0 @@
-[settings]
-skip=migrations
-multi_line_output=0
-balanced_wrapping=True
-known_third_party=django,rest_framework,sendfile,bs4,django_ical,bleach,factory,faker,requests
-


### PR DESCRIPTION
This file is not used anymore because we use black without ordering the imports