### PR TITLE
Fix announcements close button

### DIFF
--- a/website/announcements/static/announcements/css/style.scss
+++ b/website/announcements/static/announcements/css/style.scss
@@ -1,18 +1,20 @@
 #announcements-alerts {
     .announcement {
+        display: flex;
+        justify-content: center;
+        align-items: center;
         background: var(--primary);
         color: var(--primary-contrast);
         text-align: center;
         padding: 0.5rem 1rem;
-        position: relative;
 
-        .close {
+        .btn-close {
             color: var(--primary-contrast);
         }
 
         p {
             display: inline;
-            margin-left: 0.5rem;
+            margin: 0;
             color: var(--primary-contrast);
             font-size: 0.9rem;
             font-weight: $bold;
@@ -28,10 +30,7 @@
         }
 
         button {
-            line-height: 0.8;
-            i {
-                font-size: 1rem;
-            }
+            background-size: .6rem;
         }
     }
 }

--- a/website/announcements/static/announcements/js/announcements.js
+++ b/website/announcements/static/announcements/js/announcements.js
@@ -1,14 +1,18 @@
-(function() {
-    $('.announcement .close').click(function() {
-        $(this).parent().remove();
-        $.ajax({
-            // make sure this matches the url defined in announcements/urls.py
-            url: "/announcements/close-announcement",
-            type: "POST",
-            beforeSend: function(xhr){
-                xhr.setRequestHeader("X-CSRFToken", Cookies.get('csrftoken'));
-            },
-            data: {id: $(this).data('announcement-id')},
+(function () {
+    const announcementClose = document.querySelectorAll(
+        ".announcement .btn-close"
+    );
+    announcementClose.forEach((button) =>
+        button.addEventListener("click", async () => {
+            button.parentElement.parentNode.removeChild(button.parentElement);
+            await fetch("/announcements/close-announcement", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "X-CSRFToken": Cookies.get("csrftoken"),
+                },
+                body: "id=" + button.dataset["announcementId"],
+            });
         })
-    });
+    );
 })();

--- a/website/announcements/templates/announcements/announcement.html
+++ b/website/announcements/templates/announcements/announcement.html
@@ -1,12 +1,10 @@
 {% load bleach_tags %}
 {% for announcement in announcements %}
     <div class="announcement">
-        <i class="fas fa-{{ announcement.icon }}"></i> {{ announcement.content|bleach }}
+        <i class="fas fa-{{ announcement.icon }} me-3"></i> {{ announcement.content|bleach }}
         {% if announcement.closeable %}
-            <button type="button" class="btn-close" aria-label="Close"
-                    data-bs-announcement-id="{{ announcement.pk }}">
-                <i class="fas fa-times"></i>
-            </button>
+            <button type="button" class="btn-close ms-3" aria-label="Close"
+                    data-announcement-id="{{ announcement.pk }}"></button>
         {% endif %}
     </div>
 {% endfor %}


### PR DESCRIPTION

### Summary
This fixes both the styling and the workings of the announcements close button. You can test this by creating a global site announcement in the admin that is closable.

### How to test
Steps to test the changes you made:
1. Create an announcement that is closable
2. Click on the close button
3. The announcement is removed from the DOM and it is not shown again on refresh.
