### PR TITLE
Add filter/display of members only value to document admin

### DIFF
--- a/website/documents/admin.py
+++ b/website/documents/admin.py
@@ -69,6 +69,7 @@ class AnnualDocumentAdmin(ModelAdmin):
         LectureYearFilter,
         "created",
         "last_updated",
+        "members_only",
     )
     list_display = (
         '__str__',
@@ -84,6 +85,7 @@ class AssociationDocumentAdmin(ModelAdmin):
     list_filter = (
         "created",
         "last_updated",
+        "members_only",
     )
     list_display = (
         '__str__',
@@ -99,6 +101,7 @@ class EventDocumentAdmin(ModelAdmin):
     list_filter = (
         "created",
         "last_updated",
+        "members_only",
     )
     list_display = (
         '__str__',
@@ -126,6 +129,7 @@ class MiscellaneousDocumentAdmin(ModelAdmin):
     list_filter = (
         "created",
         "last_updated",
+        "members_only",
     )
     list_display = (
         '__str__',

--- a/website/documents/admin.py
+++ b/website/documents/admin.py
@@ -72,7 +72,7 @@ class AnnualDocumentAdmin(ModelAdmin):
         "members_only",
     )
     list_display = (
-        '__str__',
+        "__str__",
         "members_only",
     )
 
@@ -88,7 +88,7 @@ class AssociationDocumentAdmin(ModelAdmin):
         "members_only",
     )
     list_display = (
-        '__str__',
+        "__str__",
         "members_only",
     )
 
@@ -104,7 +104,7 @@ class EventDocumentAdmin(ModelAdmin):
         "members_only",
     )
     list_display = (
-        '__str__',
+        "__str__",
         "members_only",
     )
 
@@ -132,6 +132,6 @@ class MiscellaneousDocumentAdmin(ModelAdmin):
         "members_only",
     )
     list_display = (
-        '__str__',
+        "__str__",
         "members_only",
     )

--- a/website/documents/admin.py
+++ b/website/documents/admin.py
@@ -70,6 +70,10 @@ class AnnualDocumentAdmin(ModelAdmin):
         "created",
         "last_updated",
     )
+    list_display = (
+        '__str__',
+        "members_only",
+    )
 
 
 @admin.register(AssociationDocument)
@@ -81,6 +85,10 @@ class AssociationDocumentAdmin(ModelAdmin):
         "created",
         "last_updated",
     )
+    list_display = (
+        '__str__',
+        "members_only",
+    )
 
 
 @admin.register(EventDocument)
@@ -91,6 +99,10 @@ class EventDocumentAdmin(ModelAdmin):
     list_filter = (
         "created",
         "last_updated",
+    )
+    list_display = (
+        '__str__',
+        "members_only",
     )
 
     def has_change_permission(self, request, obj=None):
@@ -114,4 +126,8 @@ class MiscellaneousDocumentAdmin(ModelAdmin):
     list_filter = (
         "created",
         "last_updated",
+    )
+    list_display = (
+        '__str__',
+        "members_only",
     )


### PR DESCRIPTION
Closes #2095 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I added a display to quickly see if a document is members-only in the admin page, I also added a filter to filter on members-only documents.

### How to test
Steps to test the changes you made:
1. Go to documents admin page.
2. Observer that existing documents have a check or cross in the members-only column.
3. On the right click on filter by members-only or public and observe this works.
