### PR TITLE
Added option for membership to end in future.

### DIFF
--- a/infra/nixos/concrexit.nix
+++ b/infra/nixos/concrexit.nix
@@ -245,6 +245,7 @@ in
       sendmembershipnotification.calendar = "*-08-31 06:00:00";
       sendinformationcheck.calendar = "*-10-15 06:00:00";
       revokeoldmandates.calendar = "*-*-* 03:00:00";
+      revoke_staff.calendar = "*-*-* 03:00:00";
     };
 
     services = {

--- a/website/activemembers/management/commands/revoke_staff.py
+++ b/website/activemembers/management/commands/revoke_staff.py
@@ -4,7 +4,7 @@ from activemembers.services import revoke_staff_permission_for_users_in_no_commi
 
 
 class Command(BaseCommand):
-    """This command can be executed daily to check group membership and revoke staff permissions when needed"""
+    """This command can be executed daily to check group membership and revoke staff permissions when needed."""
 
     def handle(self, *args, **options):
         revoked = revoke_staff_permission_for_users_in_no_commitee()

--- a/website/activemembers/management/commands/revoke_staff.py
+++ b/website/activemembers/management/commands/revoke_staff.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+
+from activemembers.services import revoke_staff_permission_for_users_in_no_commitee
+
+
+class Command(BaseCommand):
+    """This command can be executed daily to check group membership and revoke staff permissions when needed"""
+
+    def handle(self, *args, **options):
+        revoked = revoke_staff_permission_for_users_in_no_commitee()
+        for member in revoked:
+            self.stdout.write("Revoked staff permissions for {}".format(member))

--- a/website/activemembers/models.py
+++ b/website/activemembers/models.py
@@ -292,8 +292,10 @@ class MemberGroupMembership(models.Model):
                 raise ValidationError(
                     {"until": _("End date can't be before start date")}
                 )
-            if self.until and self.until > timezone.now().date():
-                raise ValidationError({"until": _("End date can't be in the future")})
+            if self.until and self.group.until and self.until > self.group.until:
+                raise ValidationError(
+                    {"until": _("End date can't be after the group end date")}
+                )
             if self.since and self.group.since and self.since < self.group.since:
                 raise ValidationError(
                     {"since": _("Start date can't be before group start date")}

--- a/website/activemembers/services.py
+++ b/website/activemembers/services.py
@@ -2,6 +2,7 @@ from django.db.models import Count, Q
 from django.utils import timezone
 
 from activemembers.models import Committee
+from members.models.member import Member
 
 
 def generate_statistics() -> dict:
@@ -29,3 +30,14 @@ def generate_statistics() -> dict:
         data["datasets"][0]["data"].append(committee.member_count)
 
     return data
+
+
+def revoke_staff_permission_for_users_in_no_commitee():
+    members = Member.objects.filter(is_staff=True)
+    revoked = []
+    for member in members:
+        if member.get_member_groups().count() == 0:
+            revoked.append(member.id)
+            member.is_staff = False
+            member.save()
+    return Member.objects.filter(pk__in=revoked)


### PR DESCRIPTION
Closes #312 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Added funtion to detect if member is not in commitee anymore and revoke staff permissions if this is the case. created job to run daily to execute this command.

### How to test
Steps to test the changes you made:
1. Give member staff permission that is not in a group
2. In the folder website do ./manage.py revoke_staff
3. Observe on website that staff permissions have been revoked from person in step 1
4. Observe in output that the members of who the staff permissions were revoked are printed.
