### PR TITLE
Add DATETIME_FORMAT

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -627,13 +627,15 @@ REST_FRAMEWORK = {
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 
+DATETIME_FORMAT = 'j M, Y, H:i'
+
 LANGUAGE_CODE = "en"
 
 TIME_ZONE = "Europe/Amsterdam"
 
 USE_I18N = True
 
-USE_L10N = True
+USE_L10N = False
 
 USE_TZ = True
 

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -627,7 +627,7 @@ REST_FRAMEWORK = {
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 
-DATETIME_FORMAT = 'j M, Y, H:i'
+DATETIME_FORMAT = "j M, Y, H:i"
 
 LANGUAGE_CODE = "en"
 


### PR DESCRIPTION
Closes #2087

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Add a DATETIME_FORMAT to change the displayed date and time in documents and events to British English instead of American English (e.g. no a.m and p.m but 24 hour representation and d-m-y instead of m-d-y)

### How to test
Steps to test the changes you made:
1. Go to events
2. Click on any event
3. Observer date time format
4. Do 1-3 for documents
