### PR TITLE
Set external-event text color to black/white

### DIFF
--- a/website/events/static/events/css/style.scss
+++ b/website/events/static/events/css/style.scss
@@ -150,11 +150,11 @@
         }
 
         &.external-event {
-            color: var(--primary);
+            color: var(--secondary-contrast);
             background-color: var(--secondary);
 
             &:active, &:hover {
-                color: var(--primary);
+                color: var(--secondary-contrast);
             }
         }
 


### PR DESCRIPTION
Closes #1722 

### Summary
Changed the text color of the external events in the calendar from magenta to white in light mode and dark in dark mode.
This will result in the color schemes of black background/white text in light mode and white background/black text in dark mode. 

### How to test
Steps to test the changes you made:
1. Go to calendar
2. Create / Find an external event
3. Look at the colors
4. If you hover over it, the text color should become slightly darker
