### PR TITLE
Album title and date on same line

### DIFF
--- a/website/events/templates/events/index.html
+++ b/website/events/templates/events/index.html
@@ -27,7 +27,7 @@
 
                 <a href="{% url 'events:ical-'|add:LANGUAGE_CODE %}"
                    target="_blank"
-                   class="btn btn-primary btn-first"
+                   class="btn btn-primary first-right"
                    data-bs-toggle="tooltip"
                    data-bs-placement="top"
                    title="{% trans 'iCal feed (all events)' %}"
@@ -39,7 +39,7 @@
                        target="_blank"
                        data-bs-toggle="tooltip"
                        data-bs-placement="top"
-                       class="btn btn-primary btn-second"
+                       class="btn btn-primary"
                        title="{% trans 'iCal feed (personal)' %}"
                     >
                         <i class="fas fa-calendar-check"></i>

--- a/website/photos/static/photos/css/style.scss
+++ b/website/photos/static/photos/css/style.scss
@@ -21,10 +21,6 @@
                 }
             }
         }
-
-        h1.section-title {
-            padding: 20px 40px 0 0;
-        }
     }
 
     .search-form {

--- a/website/photos/templates/photos/album.html
+++ b/website/photos/templates/photos/album.html
@@ -9,24 +9,24 @@
 {% block body %}
     <section id="photos-album" class="page-section">
         <div class="container">
-                <h1 style="float: left" class="section-title">
-                    {{ album.title }}
-                </h1>
-                <h1 style="float: right; padding-top: 20px">
-                    {{ album.date|date:"d-m-Y" }}
-                    {% if album.event %}
-                        <a href="{{ album.event.get_absolute_url }}"
-                           class="btn btn-primary btn-first"
-                           data-bs-toggle="tooltip"
-                           data-bs-placement="top"
-                           title=""
-                           data-original-title="{% trans "Event" %}">
-                           <i class="fas fa-calendar"></i>
-                        </a>
-                    {% endif %}
-                </h1>
+            <h1 class="section-title">
+                {{ album.title }}
+                {% if album.event %}
+                    <a href="{{ album.event.get_absolute_url }}"
+                       style="top: auto"
+                       class="btn btn-primary btn-first"
+                       data-bs-toggle="tooltip"
+                       data-bs-placement="top"
+                       title=""
+                       data-original-title="{% trans "Event" %}">
+                        <i class="fas fa-calendar"></i>
+                    </a>
+                    <span style="position: absolute; right: 50px">{{ album.date|date:"d-m-Y" }}</span>
+                {% else %}
+                    <span style="position: absolute; right: 0px">{{ album.date|date:"d-m-Y" }}</span>
+                {% endif %}
+            </h1>
 
-{#            <h2 class="mt-2">{{ album.date|date:"d-m-Y" }}</h2>#}
             {% if album.shareable %}
                 <p>
                     {% trans "Note: This album can be shared with people outside the association by sending them the following link:" %}<br>

--- a/website/photos/templates/photos/album.html
+++ b/website/photos/templates/photos/album.html
@@ -9,21 +9,24 @@
 {% block body %}
     <section id="photos-album" class="page-section">
         <div class="container">
-            <h1 class="section-title">
-                {{ album.title }}
-                {% if album.event %}
-                <a href="{{ album.event.get_absolute_url }}"
-                   class="btn btn-primary btn-first"
-                   data-bs-toggle="tooltip"
-                   data-bs-placement="top"
-                   title=""
-                   data-original-title="{% trans "Event" %}">
-                    <i class="fas fa-calendar"></i>
-                </a>
-                {% endif %}
-            </h1>
+                <h1 style="float: left" class="section-title">
+                    {{ album.title }}
+                </h1>
+                <h1 style="float: right; padding-top: 20px">
+                    {{ album.date|date:"d-m-Y" }}
+                    {% if album.event %}
+                        <a href="{{ album.event.get_absolute_url }}"
+                           class="btn btn-primary btn-first"
+                           data-bs-toggle="tooltip"
+                           data-bs-placement="top"
+                           title=""
+                           data-original-title="{% trans "Event" %}">
+                           <i class="fas fa-calendar"></i>
+                        </a>
+                    {% endif %}
+                </h1>
 
-            <h2 class="mt-2">{{ album.date|date:"d-m-Y" }}</h2>
+{#            <h2 class="mt-2">{{ album.date|date:"d-m-Y" }}</h2>#}
             {% if album.shareable %}
                 <p>
                     {% trans "Note: This album can be shared with people outside the association by sending them the following link:" %}<br>

--- a/website/photos/templates/photos/album.html
+++ b/website/photos/templates/photos/album.html
@@ -11,19 +11,16 @@
         <div class="container">
             <h1 class="section-title">
                 {{ album.title }}
-                {% if album.event %}
+                <span class="first-right">{{ album.date|date:"d-m-Y" }}</span>
+                {% if  album.event %}
                     <a href="{{ album.event.get_absolute_url }}"
-                       style="top: auto"
-                       class="btn btn-primary btn-first"
+                       class="btn btn-primary"
                        data-bs-toggle="tooltip"
                        data-bs-placement="top"
                        title=""
                        data-original-title="{% trans "Event" %}">
                         <i class="fas fa-calendar"></i>
                     </a>
-                    <span style="position: absolute; right: 50px">{{ album.date|date:"d-m-Y" }}</span>
-                {% else %}
-                    <span style="position: absolute; right: 0px">{{ album.date|date:"d-m-Y" }}</span>
                 {% endif %}
             </h1>
 

--- a/website/thaliawebsite/static/css/base.scss
+++ b/website/thaliawebsite/static/css/base.scss
@@ -207,17 +207,12 @@ body {
 
         h1.section-title {
             position: relative;
+            display: flex;
+            gap: 10px;
             margin-bottom: 1.5rem;
             border-top: solid 1px var(--background-shade);
             padding-top: 20px;
-
-            @media(min-width: 992px) {
-                &.center-lg-50 {
-                    padding-left: calc(25% + 6px);
-                    padding-right: calc(25% + 6px);
-                    width: auto;
-                }
-            }
+            align-items: start;
 
             &::before {
                 background: var(--primary);
@@ -228,17 +223,8 @@ body {
                 top: -1px;
             }
 
-            .btn {
-                position: absolute;
-                top: 15px;
-
-                &.btn-first {
-                    right: 0;
-                }
-
-                &.btn-second {
-                    right: 50px
-                }
+            .first-right {
+                margin-left: auto;
             }
         }
     }


### PR DESCRIPTION
Closes #2191 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I added the date as a span in the h1 tag of the album title. Accounting for the case where the button is not visible and the date should be aligned to the very right edge.

### How to test
Steps to test the changes you made:
1. Go to 'The album page'
2. Click on an album (might need to be created first in the admin)
3. See that the date is now on the same line as the title