### PR TITLE
Remove redundant class

### DIFF
--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -36,7 +36,7 @@
 
             {% bootstrap_messages %}
 
-            <div class="my-4 my-lg-4">
+            <div class="my-4">
                 {{ event.description|bleach }}
             </div>
 


### PR DESCRIPTION
### Summary
Remove redundant class since the breakpoint doesn't change the styling anymore

