### PR TITLE
Add endpoint for unpublished external events to CalendarJS API

### DIFF
--- a/website/events/api/calendarjs/serializers.py
+++ b/website/events/api/calendarjs/serializers.py
@@ -87,6 +87,21 @@ class UnpublishedEventsCalenderJSSerializer(CalenderJSSerializer):
     def _registration_info(self, instance):
         return "Unpublished event"
 
+class UnpublishedExternalEventCalendarJSSerializer(CalenderJSSerializer):
+    """See CalenderJSSerializer, customised classes."""
+
+    class Meta(CalenderJSSerializer.Meta):
+        model = Event
+
+    def _class_names(self, instance):
+        return ["unpublished-event"]
+
+    def _url(self, instance):
+        return reverse("admin:events_externalevent_change", kwargs={"object_id": instance.id})
+
+    def _registration_info(self, instance):
+        return "Unpublished event"
+
 
 class ExternalEventCalendarJSSerializer(CalenderJSSerializer):
     """External event calender serializer."""

--- a/website/events/api/calendarjs/urls.py
+++ b/website/events/api/calendarjs/urls.py
@@ -5,6 +5,7 @@ from events.api.calendarjs.views import (
     CalendarJSEventListView,
     CalendarJSUnpublishedEventListView,
     CalendarJSExternalEventListView,
+    CalendarJSUnpublishedExternalEventListView,
 )
 
 app_name = "events"
@@ -25,4 +26,10 @@ urlpatterns = [
         CalendarJSUnpublishedEventListView.as_view(),
         name="calendarjs-unpublished",
     ),
+    path(
+        "external/unpublished/",
+        CalendarJSUnpublishedExternalEventListView.as_view(),
+        name="calendarjs-external-unpublished",
+    ),
+
 ]

--- a/website/events/api/calendarjs/views.py
+++ b/website/events/api/calendarjs/views.py
@@ -7,6 +7,7 @@ from events.api.calendarjs.serializers import (
     EventsCalenderJSSerializer,
     UnpublishedEventsCalenderJSSerializer,
     ExternalEventCalendarJSSerializer,
+    UnpublishedExternalEventCalendarJSSerializer,
 )
 from events.api.calendarjs.permissions import UnpublishedEventPermissions
 from events.api.v2 import filters
@@ -56,8 +57,26 @@ class CalendarJSEventListView(ListAPIView):
 class CalendarJSUnpublishedEventListView(ListAPIView):
     """Define a custom route that outputs the correctly formatted external events information for CalendarJS, unpublished events only."""
 
-    queryset = ExternalEvent.objects.filter(published=False)
+    queryset = Event.objects.filter(published=False)
     serializer_class = UnpublishedEventsCalenderJSSerializer
+    permission_classes = [IsAdminUser, UnpublishedEventPermissions]
+    pagination_class = None
+    filter_backends = (
+        filters.EventDateFilter,
+        filters.CategoryFilter,
+        filters.OrganiserFilter,
+    )
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["member"] = self.request.member
+        return context
+
+class CalendarJSUnpublishedExternalEventListView(ListAPIView):
+    """Define a custom route that outputs the correctly formatted external events information for CalendarJS, unpublished events only."""
+
+    queryset = ExternalEvent.objects.filter(published=False)
+    serializer_class = UnpublishedExternalEventCalendarJSSerializer
     permission_classes = [IsAdminUser, UnpublishedEventPermissions]
     pagination_class = None
     filter_backends = (

--- a/website/events/static/events/js/main.js
+++ b/website/events/static/events/js/main.js
@@ -18,6 +18,10 @@ const SOURCES = {
         id: 'unpublished',
         url: '/api/calendarjs/events/unpublished/',
     },
+    unpublished_external: {
+        id: 'unpublished_external',
+        url: '/api/calendarjs/external/unpublished/',
+    },
 };
 
 function checkViewState(calendar) {
@@ -62,6 +66,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const eventSources = [SOURCES.events, SOURCES.external];
     if (showUnpublished) {
         eventSources.push(SOURCES.unpublished);
+        eventSources.push(SOURCES.unpublished_external);
     }
     if (Cookies.get(BIRTHDAYS_COOKIE)) {
         eventSources.push(SOURCES.birthdays);


### PR DESCRIPTION
Fixes the bug that CalendarJS did not show unpublished internal events, and external events had a wrong link (to the internal event with the same ID).

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add?

### How to test
Steps to test the changes you made:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
