### PR TITLE
Add alumni domain

### DIFF
--- a/infra/nixos/concrexit.nix
+++ b/infra/nixos/concrexit.nix
@@ -321,6 +321,12 @@ in
             };
             "pizza.${cfg.domain}" = pizzaConfig;
             "xn--vi8h.${cfg.domain}" = pizzaConfig;
+            "alumni.${cfg.domain}" = {
+              enableACME = cfg.ssl;
+              addSSL = cfg.ssl;
+              locations."/".return = "301 https://${cfg.domain}/association/alumni/";
+              extraConfig = securityHeaders;
+            };
 
             # Disallow other Host headers when this server is configured for ssl
             # (so it's not added for local testing in the VM)


### PR DESCRIPTION

### Summary
Rico requested that alumni.thalia.nu point to the alumni overview page.

### How to test

This requires the aws record to exist
