### PR TITLE
registration ical feed is only  registered events

### DIFF
--- a/website/events/feeds.py
+++ b/website/events/feeds.py
@@ -39,11 +39,11 @@ class EventFeed(ICalFeed):
         query = Q(published=True)
 
         if self.user:
-            query &= Q(registration_start__isnull=True) | (
-                Q(eventregistration__member=self.user)
+            query &= (
+                Q(eventregistration__member=self.user) 
                 & Q(eventregistration__date_cancelled=None)
             )
-
+            
         return Event.objects.filter(query).order_by("-start")
 
     def item_title(self, item):

--- a/website/events/feeds.py
+++ b/website/events/feeds.py
@@ -39,11 +39,10 @@ class EventFeed(ICalFeed):
         query = Q(published=True)
 
         if self.user:
-            query &= (
-                Q(eventregistration__member=self.user) 
-                & Q(eventregistration__date_cancelled=None)
+            query &= Q(eventregistration__member=self.user) & Q(
+                eventregistration__date_cancelled=None
             )
-            
+
         return Event.objects.filter(query).order_by("-start")
 
     def item_title(self, item):


### PR DESCRIPTION
Closes #2233 

### Summary
When pressing the "personal" ical feed button in the agenda you now only get your own personal events instead of your personal events + all public events.

### How to test
Steps to test the changes you made:
1. First create four events covering all cases: 
  a. 1 event which you have to register for but you don't
  b. 1 event which you have to register for and you do register for it
  c. 1 open event where you don't register
  d. 1 open event with optional registration where you do register
  It's easier if you give these meaningful names
3. Register for these events accordingly (so register for event b and d)
4. Press the "personal ical feed" button at the top right to download the ical file
5. Open the ical file directly in a text editor or open the ical file in a calendar app and check if only events b and d are in the file.
