### PR TITLE
Enable renovate platformAutomerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,5 +21,6 @@
       "updateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
-  ]
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION

### Summary
Enables this option: https://docs.renovatebot.com/configuration-options/#platformautomerge

This should fix the automerging of renovate