### PR TITLE
Update CODEOWNERS for Renovate automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,4 +27,5 @@
 
 # NO CODEOWNERS FOR DEPENDENCY FILES, TO NOT BLOCK RENOVATE AUTOMERGE
 pyproject.toml
+poetry.lock
 .github/workflows/*.yaml

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,7 @@
 
 # ANYTHING WORKFLOW-RELATED
 /.github @svthalia/illuminati
+
+# NO CODEOWNERS FOR DEPENDENCY FILES, TO NOT BLOCK RENOVATE AUTOMERGE
+pyproject.toml
+.github/workflows/*.yaml


### PR DESCRIPTION
### Summary
This will prevent  auto-requesting reviews for changes on pyproject.toml and GitHub workflows, so Renovate can auto-merge again

