### PR TITLE
Fix updating event registration fields

### DIFF
--- a/website/events/admin/views.py
+++ b/website/events/admin/views.py
@@ -97,7 +97,9 @@ class RegistrationAdminFields(FormView):
         values = form.field_values()
         try:
             services.update_registration(
-                registration=self.registration, field_values=values
+                registration=self.registration,
+                field_values=values,
+                actor=self.request.user,
             )
             messages.success(self.request, _("Registration successfully saved."))
             if "_save" in self.request.POST:


### PR DESCRIPTION
Closes #1345

### Summary
This fixes a bug in which it was impossible to change info fields from the admin

### How to test
1. Add a manual registration to an event with info fields
2. Try to edit the info fields from the admin
3. It works