### PR TITLE
Don't continue concrexit service if migrations fail

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -62,7 +62,7 @@ let
   concrexit-uwsgi = writeScriptBin "concrexit-uwsgi" ''
     #! ${pkgs.runtimeShell}
     cd ${concrexit}/website
-    MANAGE_PY=1 ${concrexit-env}/bin/python ${concrexit}/website/manage.py migrate
+    MANAGE_PY=1 ${concrexit-env}/bin/python ${concrexit}/website/manage.py migrate || exit 1
 
     ${uwsgi-python}/bin/uwsgi "$@" \
       --plugins python3 \


### PR DESCRIPTION

### Summary
If migrations fail the database is not in the state that the code expects, this means stuff won't work anyway and it's better to not start the service

### How to test

N/A