### PR TITLE
Do not update food order if order is paid and payment cannot be deleted

### DIFF
--- a/website/pizzas/api/v2/views.py
+++ b/website/pizzas/api/v2/views.py
@@ -111,11 +111,12 @@ class FoodEventOrderDetailView(
             )
 
     def update(self, request, *args, **kwargs):
-        super().update(request, *args, **kwargs)
         instance = self.get_object()
 
         if instance.payment:
             delete_payment(instance, member=request.member, ignore_change_window=True)
+
+        super().update(request, *args, **kwargs)
 
         return Response(
             FoodOrderSerializer(instance, context=self.get_serializer_context()).data


### PR DESCRIPTION
### Summary
This should resolve a bug that could result in an inconsistency between a food order and its payment, that occurs when someone tries to update their food order while it has already been paid (via Thalia Pay), and the order cannot be deleted

### How to test
1. Have a order
2. Pay it via Thalia Pay
3. Try to update the order
4. The order should not change. If the payment can be deleted, that will just happen, otherwise it will result in an error. But most importantly, the order will not become inconsistent with its payment