### PR TITLE
Handle re-reregistrations after profile data minimisation

### DIFF
--- a/website/members/models/profile.py
+++ b/website/members/models/profile.py
@@ -265,6 +265,10 @@ class Profile(models.Model):
         default=False,
     )
 
+    @property
+    def is_minimised(self):
+        return self.address_city == "<removed>"
+
     def display_name(self):
         # pylint: disable=too-many-return-statements
         pref = self.display_name_preference

--- a/website/registrations/tests/test_views.py
+++ b/website/registrations/tests/test_views.py
@@ -651,6 +651,25 @@ class RenewalFormViewTest(TestCase):
                     context = self.view.get_context_data(form=MagicMock())
                     self.assertEqual(context["latest_renewal"], renewal)
 
+                with self.subTest("With minimised data"):
+                    with mock.patch("members.models.Profile.is_minimised") as minimised:
+                        with mock.patch(
+                            "django.contrib.messages.warning"
+                        ) as mock_messages:
+                            minimised.return_value = True
+
+                            self.view.request.member.latest_membership = MagicMock()
+                            self.view.request.member.latest_membership.is_active = (
+                                MagicMock()
+                            )
+                            self.view.request.member.latest_membership.is_active.return_value = (
+                                False
+                            )
+
+                            _ = self.view.get_context_data(form=MagicMock())
+
+                            mock_messages.assert_called_once()
+
     def test_get_form(self):
         self.view.request = self.rf.get("/")
 

--- a/website/registrations/views.py
+++ b/website/registrations/views.py
@@ -238,7 +238,7 @@ class RenewalFormView(FormView):
             messages.warning(
                 self.request,
                 _(
-                    "You seem to have been a member in the past, but your profile data has been minimised. Please contact the board to renew your membership."
+                    "You seem to have been a member in the past, but your profile data has been deleted. Please contact the board to renew your membership."
                 ),
             )
         context["benefactor_type"] = Membership.BENEFACTOR

--- a/website/registrations/views.py
+++ b/website/registrations/views.py
@@ -230,6 +230,17 @@ class RenewalFormView(FormView):
         context["was_member"] = Membership.objects.filter(
             user=self.request.member, type=Membership.MEMBER
         ).exists()
+
+        if (
+            self.request.member.latest_membership
+            and not self.request.member.latest_membership.is_active()
+        ) and self.request.member.profile.is_minimised:
+            messages.warning(
+                self.request,
+                _(
+                    "You seem to have been a member in the past, but your profile data has been minimised. Please contact the board to renew your membership."
+                ),
+            )
         context["benefactor_type"] = Membership.BENEFACTOR
         return context
 


### PR DESCRIPTION
Closes #706 

### Summary
Display a warning to a user when they want to renew while their profile data was minimized 

### How to test
1. Have a member with a membership
2. End the membership
3. Minimise the profile
4. `http://127.0.0.1:8000/user/membership/` should contain warning message. In other cases, there should not be a warning