### PR TITLE
Use = locations in nginx

### DIFF
--- a/infra/nixos/concrexit.nix
+++ b/infra/nixos/concrexit.nix
@@ -320,17 +320,17 @@ in
                 # Implementing https://github.com/WICG/change-password-url
                 return = "301 https://$host/user/password_change/;";
               };
-              locations."/.well-known/security.txt" = {
+              locations."= /.well-known/security.txt" = {
                 # Implementing https://tools.ietf.org/html/draft-foudil-securitytxt-12
                 alias = ../resources/security.txt;
                 extraConfig = "default_type text/plain;";
               };
-              locations."/security.txt" = {
+              locations."= /security.txt" = {
                 # Implementing https://tools.ietf.org/html/draft-foudil-securitytxt-12
                 alias = ../resources/security.txt;
                 extraConfig = "default_type text/plain;";
               };
-              locations."/pgp-key.txt" = {
+              locations."= /pgp-key.txt" = {
                 alias = ../resources/pgp-key.txt;
                 extraConfig = "default_type text/plain;";
               };


### PR DESCRIPTION
This fixes path traversal, from the nginx checks:

```
[nginx_parser]  WARNING Skip unparseable block: "location"

==================== Results ===================

>> Problem: [alias_traversal] Path traversal via misconfigured alias.
Description: Using alias in a prefixed location that doesn't ends with directory separator could lead to path traversal vulnerability.
Additional info: https://github.com/yandex/gixy/blob/master/docs/en/plugins/aliastraversal.md
Pseudo config:

server {
        server_name staging.thalia.nu;

        location /.well-known/security.txt {
                alias /nix/store/ha2wfkq8d5dgpy14bdlqq8vz22rc0dv1-security.txt;
        }

        location /pgp-key.txt {
                alias /nix/store/mkbdq2wjc4xx57wv7nzfmnqv2430p3w0-pgp-key.txt;
        }

        location /security.txt {
                alias /nix/store/ha2wfkq8d5dgpy14bdlqq8vz22rc0dv1-security.txt;
        }
}

==================== Summary ===================
Total issues:
    Unspecified: 0
    Low: 0
    Medium: 3
    High: 0
```