### PR TITLE
Revert "Use latest nixos ami"

### DIFF
--- a/infra/modules/concrexit/main.tf
+++ b/infra/modules/concrexit/main.tf
@@ -40,7 +40,7 @@ data "aws_ami" "nixos" {
 
   filter {
     name   = "name"
-    values = ["NixOS-22.05.*-x86_64-linux"]
+    values = ["NixOS-21.11.*-x86_64-linux"]
   }
 }
 


### PR DESCRIPTION
Reverts svthalia/concrexit#2367

This was a mistake because it forces the instance to be replaced