### PR TITLE
Allow poetry to be found dynamically

### DIFF
--- a/website/manage.py
+++ b/website/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This is the entrypoint for running the django site.
 
 Use ``python ./manage.py help`` for more info.
@@ -11,9 +11,14 @@ if __name__ == "__main__":
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
-        raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
-        ) from exc
+        try:
+            # If Django couldn't be found, we're probably not in the (poetry)
+            # virtualenv. This re-execs the file, but prefixed with `poetry run`
+            # so the script will be running in the poetry virtualenv
+            os.execvp("poetry", ["poetry", "run", *sys.argv])
+        except FileNotFoundError:
+            raise ImportError(
+                "Can't find Django or Poetry. Make sure to install "
+                "the required dependencies from README.md!"
+            ) from exc
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
When someone runs ./website/manage.py help, it can just work
automatically, given we help the user in finding poetry. It's kinda
annoying to have to manually type `poetry run ./website/manage.py` all
the time.


### How to test
Steps to test the changes you made:
1. Run ./website/manage.py help
2. It works by re-execing via poetry