### PR TITLE
Strip first slash from media migration upload path

### DIFF
--- a/website/thaliawebsite/management/commands/migratemedia.py
+++ b/website/thaliawebsite/management/commands/migratemedia.py
@@ -44,5 +44,5 @@ class Command(BaseCommand):
 
     def _split_path_to_upload(self, full_path: str) -> str:
         media_root = settings.MEDIA_ROOT
-        upload_path = full_path.split(media_root)[-1]
+        upload_path = full_path.split(media_root)[-1][1:]
         return upload_path


### PR DESCRIPTION
### Summary
Fixes an issue with migrating media that adds a `/` to be the S3 root

