### PR TITLE
Add API endpoint to claim sales orders

### DIFF
--- a/website/sales/api/v2/urls.py
+++ b/website/sales/api/v2/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from sales.api.v2.views import (
-    OrderPaymentView,
+    OrderClaimView,
     UserShiftListView,
     UserShiftDetailView,
     UserOrderListView,
@@ -11,7 +11,7 @@ from sales.api.v2.views import (
 app_name = "sales"
 
 urlpatterns = [
-    path("sales/order/<uuid:pk>/pay/", OrderPaymentView.as_view(), name="order-pay"),
+    path("sales/order/<uuid:pk>/claim/", OrderClaimView.as_view(), name="order-claim"),
     path("sales/shifts/", UserShiftListView.as_view(), name="user-shift-list"),
     path(
         "sales/shifts/<int:pk>/",

--- a/website/sales/api/v2/urls.py
+++ b/website/sales/api/v2/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from sales.api.v2.views import (
+    OrderPaymentView,
     UserShiftListView,
     UserShiftDetailView,
     UserOrderListView,
@@ -10,6 +11,7 @@ from sales.api.v2.views import (
 app_name = "sales"
 
 urlpatterns = [
+    path("sales/order/<uuid:pk>/pay/", OrderPaymentView.as_view(), name="order-pay"),
     path("sales/shifts/", UserShiftListView.as_view(), name="user-shift-list"),
     path(
         "sales/shifts/<int:pk>/",

--- a/website/sales/api/v2/views.py
+++ b/website/sales/api/v2/views.py
@@ -109,7 +109,8 @@ class UserOrderDetailView(OrderDetailView):
         if self.get_object().payment:
             raise PermissionDenied
 
-class OrderPaymentView(RetrieveAPIView):
+
+class OrderClaimView(RetrieveAPIView):
     """Claims an order to be paid by the current user."""
 
     queryset = Order.objects.all()

--- a/website/sales/tests/test_api.py
+++ b/website/sales/tests/test_api.py
@@ -634,7 +634,7 @@ class OrderAPITest(TestCase):
     def test_claim_order(self):
         with self.subTest("Claim a normal order"):
             response = self.client.get(
-                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+                reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
             )
             self.assertEqual(200, response.status_code)
             self.assertEqual(
@@ -649,7 +649,7 @@ class OrderAPITest(TestCase):
             self.o3.save()
 
             response = self.client.get(
-                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+                reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
             )
             self.assertEqual(200, response.status_code)
             self.assertEqual(
@@ -672,7 +672,7 @@ class OrderAPITest(TestCase):
             self.o3.save()
 
             response = self.client.get(
-                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+                reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
             )
             self.assertEqual(403, response.status_code)
             self.o3.refresh_from_db()
@@ -683,7 +683,7 @@ class OrderAPITest(TestCase):
 
         with self.subTest("Claim a paid order"):
             response = self.client.get(
-                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o4.pk})
+                reverse("api:v2:sales:order-claim", kwargs={"pk": self.o4.pk})
             )
             self.assertEqual(403, response.status_code)
 
@@ -694,10 +694,9 @@ class OrderAPITest(TestCase):
             with mock.patch("sales.services.is_adult") as is_adult:
                 is_adult.return_value = False
                 response = self.client.get(
-                    reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+                    reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
                 )
                 self.assertEqual(403, response.status_code)
-                print(response.json)
                 self.o3.refresh_from_db()
                 self.assertEqual(self.o3.payer, self.member)
 

--- a/website/sales/tests/test_api.py
+++ b/website/sales/tests/test_api.py
@@ -633,7 +633,7 @@ class OrderAPITest(TestCase):
 
     def test_claim_order(self):
         with self.subTest("Claim a normal order"):
-            response = self.client.get(
+            response = self.client.patch(
                 reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
             )
             self.assertEqual(200, response.status_code)
@@ -648,7 +648,7 @@ class OrderAPITest(TestCase):
             self.o3.payer = self.member
             self.o3.save()
 
-            response = self.client.get(
+            response = self.client.patch(
                 reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
             )
             self.assertEqual(200, response.status_code)
@@ -671,7 +671,7 @@ class OrderAPITest(TestCase):
             self.o3.payer = member
             self.o3.save()
 
-            response = self.client.get(
+            response = self.client.patch(
                 reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
             )
             self.assertEqual(403, response.status_code)
@@ -682,7 +682,7 @@ class OrderAPITest(TestCase):
         self.o3.save()
 
         with self.subTest("Claim a paid order"):
-            response = self.client.get(
+            response = self.client.patch(
                 reverse("api:v2:sales:order-claim", kwargs={"pk": self.o4.pk})
             )
             self.assertEqual(403, response.status_code)
@@ -693,7 +693,7 @@ class OrderAPITest(TestCase):
         with self.subTest("Claim an age-restricted order as a minor"):
             with mock.patch("sales.services.is_adult") as is_adult:
                 is_adult.return_value = False
-                response = self.client.get(
+                response = self.client.patch(
                     reverse("api:v2:sales:order-claim", kwargs={"pk": self.o3.pk})
                 )
                 self.assertEqual(403, response.status_code)

--- a/website/sales/tests/test_api.py
+++ b/website/sales/tests/test_api.py
@@ -1,19 +1,20 @@
+from unittest import mock
+
+from activemembers.models import Committee, MemberGroupMembership
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
-from rest_framework.test import APIClient
-
-from activemembers.models import Committee, MemberGroupMembership
 from members.models import Member
 from payments.models import Payment
 from payments.services import create_payment
+from rest_framework.test import APIClient
 from sales import payables
 from sales.models.order import Order, OrderItem
 from sales.models.product import Product, ProductList
-from sales.models.shift import Shift, SelfOrderPeriod
+from sales.models.shift import SelfOrderPeriod, Shift
 
 
 @freeze_time("2021-01-01")
@@ -629,6 +630,76 @@ class OrderAPITest(TestCase):
         self.assertEqual(201, response.status_code)
         order = Order.objects.get(pk=response.data["pk"])
         self.assertEqual(order.payer, self.member)
+
+    def test_claim_order(self):
+        with self.subTest("Claim a normal order"):
+            response = self.client.get(
+                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+            )
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(
+                Order.objects.get(pk=response.data["pk"]).payer, self.member
+            )
+
+        self.o3.payer = None
+        self.o3.save()
+
+        with self.subTest("Claim an order that is already yours"):
+            self.o3.payer = self.member
+            self.o3.save()
+
+            response = self.client.get(
+                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+            )
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(
+                Order.objects.get(pk=response.data["pk"]).payer, self.member
+            )
+
+        self.o3.payer = None
+        self.o3.save()
+
+        with self.subTest("Claim an order that is not yours"):
+            member = Member.objects.create(
+                username="test1",
+                first_name="Test1",
+                last_name="Example",
+                email="test1@example.org",
+                is_staff=False,
+                is_superuser=False,
+            )
+            self.o3.payer = member
+            self.o3.save()
+
+            response = self.client.get(
+                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+            )
+            self.assertEqual(403, response.status_code)
+            self.o3.refresh_from_db()
+            self.assertEqual(self.o3.payer, member)
+
+        self.o3.payer = None
+        self.o3.save()
+
+        with self.subTest("Claim a paid order"):
+            response = self.client.get(
+                reverse("api:v2:sales:order-pay", kwargs={"pk": self.o4.pk})
+            )
+            self.assertEqual(403, response.status_code)
+
+        self.o3.payer = None
+        self.o3.save()
+
+        with self.subTest("Claim an age-restricted order as a minor"):
+            with mock.patch("sales.services.is_adult") as is_adult:
+                is_adult.return_value = False
+                response = self.client.get(
+                    reverse("api:v2:sales:order-pay", kwargs={"pk": self.o3.pk})
+                )
+                self.assertEqual(403, response.status_code)
+                print(response.json)
+                self.o3.refresh_from_db()
+                self.assertEqual(self.o3.payer, self.member)
 
 
 class ShiftAPITest(TestCase):


### PR DESCRIPTION
Closes #1785.

### Summary
This adds an endpoint that does pretty much the same as the OrderPaymentView linked to by `order.payment_url` (set `payer` if possible, and warn if under-age for age-restricted orders).

### How to test
Steps to test the changes you made:
1. Create all kinds of orders.
2. Claim the orders from all kinds of users.
