### PR TITLE
Skip file checking on thumbnail url generation

### DIFF
--- a/website/thaliawebsite/templates/includes/grid_item.html
+++ b/website/thaliawebsite/templates/includes/grid_item.html
@@ -4,7 +4,7 @@
         <a class="d-flex" href="{{ url }}" {{ anchor_attrs|safe }}>
     {% endif %}
     <div class="image">
-        <img alt="{{ title }}" src="{{ image_url }}"/>
+        <img alt="{{ title }}" src="{{ image_url }}" loading="lazy" />
     </div>
     <div class="name">
         <span>{{ title }}</span>

--- a/website/thaliawebsite/urls.py
+++ b/website/thaliawebsite/urls.py
@@ -53,7 +53,7 @@ from singlepages.sitemaps import sitemap as singlepages_sitemap
 from thabloid.sitemaps import sitemap as thabloid_sitemap
 from thaliawebsite.forms import AuthenticationForm
 from thaliawebsite.views import TestCrashView, IndexView
-from utils.media.views import generate_thumbnail, private_media
+from utils.media.views import get_thumbnail, private_media
 from .sitemaps import StaticViewSitemap
 
 __all__ = ["urlpatterns"]
@@ -176,9 +176,9 @@ urlpatterns = [
     path("crash/", TestCrashView.as_view()),
     # Custom media paths
     re_path(
-        r"^media/generate-thumbnail/(?P<request_path>.*)",
-        generate_thumbnail,
-        name="generate-thumbnail",
+        r"^media/thumbnail/(?P<request_path>.*)",
+        get_thumbnail,
+        name="get-thumbnail",
     ),
     re_path(
         r"^media/private/(?P<request_path>.*)$", private_media, name="private-media"

--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -54,7 +54,7 @@ def get_thumbnail_url(file, size, fit=True):
     :param file: the file field
     :param size: size of the image
     :param fit: False to keep the aspect ratio, True to crop
-    :return: direct media url or generate-thumbnail path
+    :return: get-thumbnail path
     """
     storage = DefaultStorage()
     name = file
@@ -78,23 +78,10 @@ def get_thumbnail_url(file, size, fit=True):
         "storage": f"{storage.__class__.__module__}.{storage.__class__.__name__}",
     }
 
-    # Check if we need to generate, then redirect to the generating route,
-    # otherwise just return the serving file path
-    if not storage.exists(sig_info["thumb_path"]) or (
-        storage.exists(name)
-        and storage.get_modified_time(name)
-        > storage.get_modified_time(sig_info["thumb_path"])
-    ):
-        # Put all image info in signature for the generate view
-        query = f"?sig={signing.dumps(sig_info)}"
-        # We provide a URL instead of calling it as a function, so that using
-        # it means kicking off a new GET request. If we would generate all
-        # thumbnails inline, loading an album overview would have high latency.
-        return (
-            reverse(
-                "generate-thumbnail", args=[os.path.join(size_fit, sig_info["name"])]
-            )
-            + query
-        )
-
-    return storage.url(sig_info["serve_path"])
+    # We provide a URL instead of calling it as a function, so that using
+    # it means kicking off a new GET request. If we would need to check all files for the
+    # thumbnails inline, loading an album overview would have high latency.
+    return (
+        reverse("get-thumbnail", args=[os.path.join(size_fit, sig_info["name"])])
+        + f"?sig={signing.dumps(sig_info)}"
+    )

--- a/website/utils/media/views.py
+++ b/website/utils/media/views.py
@@ -2,13 +2,13 @@
 from datetime import timedelta
 
 from PIL import Image, ImageOps
-from django.conf import settings
 from django.core import signing
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import get_storage_class
 from django.core.signing import BadSignature
 from django.http import Http404
 from django.shortcuts import redirect
+from django.utils import timezone
 from django_sendfile import sendfile
 
 from utils.media.services import save_image
@@ -71,24 +71,30 @@ def get_thumbnail(request, request_path):
     """
     # Get image information from signature
     # raises PermissionDenied if bad signature
-    query = ""
     sig_info = _get_signature_info(request)
     storage = get_storage_class(sig_info["storage"])()
-    is_public = sig_info["storage"] == settings.PUBLIC_FILE_STORAGE
 
     if not sig_info["thumb_path"].endswith(request_path):
         # 404 if the file does not exist
         raise Http404("Media not found.")
 
-    if not storage.exists(sig_info["name"]):
+    original_modified_time = timezone.make_aware(timezone.datetime.min)
+    thumb_modified_time = original_modified_time
+    # noinspection PyBroadException
+    try:
+        original_modified_time = storage.get_modified_time(sig_info["name"])
+        thumb_modified_time = storage.get_modified_time(sig_info["thumb_path"])
+    except:
+        # One of the files probably does not exist
+        pass
+
+    if original_modified_time.timestamp() == 0:
         raise Http404
 
     # Check if directory for thumbnail exists, if not create it
     # os.makedirs(os.path.dirname(full_thumb_path), exist_ok=True)
     # Skip generating the thumbnail if it exists
-    if not storage.exists(sig_info["thumb_path"]) or storage.get_modified_time(
-        sig_info["name"]
-    ) > storage.get_modified_time(sig_info["thumb_path"]):
+    if original_modified_time > thumb_modified_time:
         storage.delete(sig_info["thumb_path"])
 
         # Create a thumbnail from the original_path, saved to thumb_path

--- a/website/utils/media/views.py
+++ b/website/utils/media/views.py
@@ -10,8 +10,24 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.utils import timezone
 from django_sendfile import sendfile
+from django.core.cache import cache
 
 from utils.media.services import save_image
+
+
+def get_thumb_modified_time(storage, path):
+    storage_value = cache.get(
+        f"thumbnails_{path}", timezone.make_aware(timezone.datetime.min)
+    )
+    if storage_value.timestamp() <= 0:
+        # noinspection PyBroadException
+        try:
+            storage_value = storage.get_modified_time(path)
+            cache.set(f"thumbnails_{path}", storage_value, 60 * 60)
+        except:
+            # File probably does not exist
+            pass
+    return storage_value
 
 
 def _get_signature_info(request):
@@ -78,17 +94,10 @@ def get_thumbnail(request, request_path):
         # 404 if the file does not exist
         raise Http404("Media not found.")
 
-    original_modified_time = timezone.make_aware(timezone.datetime.min)
-    thumb_modified_time = original_modified_time
-    # noinspection PyBroadException
-    try:
-        original_modified_time = storage.get_modified_time(sig_info["name"])
-        thumb_modified_time = storage.get_modified_time(sig_info["thumb_path"])
-    except:
-        # One of the files probably does not exist
-        pass
+    original_modified_time = get_thumb_modified_time(storage, sig_info["name"])
+    thumb_modified_time = get_thumb_modified_time(storage, sig_info["thumb_path"])
 
-    if original_modified_time.timestamp() == 0:
+    if original_modified_time.timestamp() <= 0:
         raise Http404
 
     # Check if directory for thumbnail exists, if not create it
@@ -110,6 +119,9 @@ def get_thumbnail(request, request_path):
                 image = ImageOps.fit(image, size, Image.ANTIALIAS)
 
             save_image(storage, image, sig_info["thumb_path"], format)
+            cache.set(
+                f"thumbnails_{sig_info['thumb_path']}", original_modified_time, 60 * 60
+            )
 
     # Redirect to the serving url of the image
     # for public images this goes via a static file server (i.e. nginx)

--- a/website/utils/media/views.py
+++ b/website/utils/media/views.py
@@ -57,7 +57,7 @@ def private_media(request, request_path):
     )
 
 
-def generate_thumbnail(request, request_path):
+def get_thumbnail(request, request_path):
     """Generate thumbnail and redirect user to new location.
 
     The thumbnails are generated with this route. Because the


### PR DESCRIPTION

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This removes checking for the thumbnail on page load and moves the completely 'do we need a thumbnail generated' to the image url.

### How to test
Steps to test the changes you made:
1. Go to staging.thalia.nu
2. Notice that the page loading is not blocked and images load slightly after we open the page
