### PR TITLE
Fix societies page template

### DIFF
--- a/website/activemembers/templates/activemembers/society_index.html
+++ b/website/activemembers/templates/activemembers/society_index.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "simple_page.html" %}
 {% load i18n thumbnail static activemembers_cards alert %}
 
 {% block title %}{% trans 'societies'|capfirst %} — {{ block.super }}{% endblock %}


### PR DESCRIPTION
Closes #2439

### Summary
Fixes a wrong template extension breaking the societies overview page

### How to test
1. Check out the societies page