### PR TITLE
Add /sales/orders/*/pay and albums to AASA file

### DIFF
--- a/infra/resources/apple-app-site-association.json
+++ b/infra/resources/apple-app-site-association.json
@@ -4,7 +4,14 @@
     "details": [
       {
         "appID": "FRD6Y7E88Y.com.thaliapp",
-        "paths": [ "/pizzas/", "/events/", "/events/*", "/members/photos/*"]
+        "paths": [
+          "/pizzas",
+          "/events",
+          "/events/*",
+          "/members/photos",
+          "/members/photos/*",
+          "/sales/orders/*/pay"
+        ]
       }
     ]
   }


### PR DESCRIPTION
### Summary
This adds new urls to the AASA file so that ThaliApp will be allowed to handle them on iOS.

### How to test
Steps to test the changes you made:
1. Merge and deploy this.
2. Try it out on an iPhone (possibly wait a bit (an hour? a week?) first because AASA files are cached).
