### PR TITLE
Fix local partners in newsletter

### DIFF
--- a/website/newsletters/emails.py
+++ b/website/newsletters/emails.py
@@ -1,6 +1,5 @@
 """The emails defined by the newsletters package."""
 import logging
-import math
 from smtplib import SMTPException
 
 from django.conf import settings
@@ -42,16 +41,7 @@ def send_newsletter(newsletter):
     text_template = get_template("newsletters/email.txt")
 
     main_partner = Partner.objects.filter(is_main_partner=True).first()
-    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
-    local_partner_count = len(all_local_partners)
-    local_partners = []
-    for i in range(math.floor(local_partner_count / 2)):
-        local_partners.append(
-            [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
-        )
-
-    if local_partner_count % 2 != 0:
-        local_partners.append([all_local_partners[local_partner_count - 1]])
+    local_partners = services.split_local_partners()
 
     with mail.get_connection() as connection:
         language = ("en", "English")

--- a/website/newsletters/emails.py
+++ b/website/newsletters/emails.py
@@ -1,5 +1,6 @@
 """The emails defined by the newsletters package."""
 import logging
+import math
 from smtplib import SMTPException
 
 from django.conf import settings
@@ -41,7 +42,14 @@ def send_newsletter(newsletter):
     text_template = get_template("newsletters/email.txt")
 
     main_partner = Partner.objects.filter(is_main_partner=True).first()
-    local_partners = Partner.objects.filter(is_local_partner=True)
+    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
+    local_partner_count = len(all_local_partners)
+    local_partners = []
+    for i in range(math.floor(local_partner_count/2)):
+        local_partners.append([all_local_partners[i*2], all_local_partners[i*2 + 1]])
+
+    if local_partner_count % 2 != 0:
+        local_partners.append([all_local_partners[local_partner_count-1]])
 
     with mail.get_connection() as connection:
         language = ("en", "English")

--- a/website/newsletters/emails.py
+++ b/website/newsletters/emails.py
@@ -45,11 +45,13 @@ def send_newsletter(newsletter):
     all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
     local_partner_count = len(all_local_partners)
     local_partners = []
-    for i in range(math.floor(local_partner_count/2)):
-        local_partners.append([all_local_partners[i*2], all_local_partners[i*2 + 1]])
+    for i in range(math.floor(local_partner_count / 2)):
+        local_partners.append(
+            [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
+        )
 
     if local_partner_count % 2 != 0:
-        local_partners.append([all_local_partners[local_partner_count-1]])
+        local_partners.append([all_local_partners[local_partner_count - 1]])
 
     with mail.get_connection() as connection:
         language = ("en", "English")

--- a/website/newsletters/services.py
+++ b/website/newsletters/services.py
@@ -37,11 +37,13 @@ def save_to_disk(newsletter):
     all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
     local_partner_count = len(all_local_partners)
     local_partners = []
-    for i in range(math.floor(local_partner_count/2)):
-        local_partners.append([all_local_partners[i*2], all_local_partners[i*2 + 1]])
+    for i in range(math.floor(local_partner_count / 2)):
+        local_partners.append(
+            [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
+        )
 
     if local_partner_count % 2 != 0:
-        local_partners.append([all_local_partners[local_partner_count-1]])
+        local_partners.append([all_local_partners[local_partner_count - 1]])
 
     html_template = get_template("newsletters/email.html")
 

--- a/website/newsletters/services.py
+++ b/website/newsletters/services.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import math
 import os
 from io import BytesIO
 
@@ -33,7 +34,14 @@ def write_to_file(pk, lang, html_message):
 def save_to_disk(newsletter):
     """Write the newsletter as HTML to file (in all languages)."""
     main_partner = Partner.objects.filter(is_main_partner=True).first()
-    local_partners = Partner.objects.filter(is_local_partner=True)
+    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
+    local_partner_count = len(all_local_partners)
+    local_partners = []
+    for i in range(math.floor(local_partner_count/2)):
+        local_partners.append([all_local_partners[i*2], all_local_partners[i*2 + 1]])
+
+    if local_partner_count % 2 != 0:
+        local_partners.append([all_local_partners[local_partner_count-1]])
 
     html_template = get_template("newsletters/email.html")
 

--- a/website/newsletters/services.py
+++ b/website/newsletters/services.py
@@ -34,16 +34,7 @@ def write_to_file(pk, lang, html_message):
 def save_to_disk(newsletter):
     """Write the newsletter as HTML to file (in all languages)."""
     main_partner = Partner.objects.filter(is_main_partner=True).first()
-    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
-    local_partner_count = len(all_local_partners)
-    local_partners = []
-    for i in range(math.floor(local_partner_count / 2)):
-        local_partners.append(
-            [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
-        )
-
-    if local_partner_count % 2 != 0:
-        local_partners.append([all_local_partners[local_partner_count - 1]])
+    local_partners = split_local_partners()
 
     html_template = get_template("newsletters/email.html")
 
@@ -116,3 +107,18 @@ def send_newsletter(newsletter):
     message.send()
 
     save_to_disk(newsletter)
+
+
+def split_local_partners():
+    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
+    local_partner_count = len(all_local_partners)
+    local_partners = []
+    for i in range(math.floor(local_partner_count / 2)):
+        local_partners.append(
+            [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
+        )
+
+    if local_partner_count % 2 != 0:
+        local_partners.append([all_local_partners[local_partner_count - 1]])
+
+    return local_partners

--- a/website/newsletters/templates/newsletters/email.html
+++ b/website/newsletters/templates/newsletters/email.html
@@ -200,35 +200,33 @@
         </table>
     </div>
     {% endif %}
-    {% if local_partners.exists %}
-    <div style="width: 700px ; margin-top: 30px; margin-left: auto ; margin-right: auto;">
-        <table cellspacing="0" cellpadding="0">
-            {% if local_partners|length < 2 %}
-                <col width="700px">
-            {% elif local_partners|length < 3 %}
-                <col width="350px">
-                <col width="350px">
-            {% else %}
-                <col width="233px">
-                <col width="234px">
-                <col width="233px">
-            {% endif %}
-            <tr>
-                {% for local_partner in local_partners %}
-                    {% if local_partner and local_partner.is_active %}
-                    <td align="center" style="color: black; font-size: 12px;">
-                        <p style="margin: 10px; font-family: 'Gill Sans', 'Trebuchet MS', sans-serif;">
-                            <a href="{{ local_partner.link }}">
-                                <img src="{% baseurl %}{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}" height="70" style="height: 70px; margin-bottom: 25px" alt="{{ local_partner.name }}"/>
-                            </a><br/>
-                            {% trans "our local partner"|upper %}
-                        </p>
-                    </td>
+    {% if local_partners|length > 0 %}
+        {% for local_partner_group in local_partners %}
+            <div style="width: 700px ; margin-top: 30px; margin-left: auto ; margin-right: auto;">
+                <table cellspacing="0" cellpadding="0">
+                    {% if local_partner_group|length < 2 %}
+                        <col width="700px">
+                    {% elif local_partner_group|length < 3 %}
+                        <col width="350px">
+                        <col width="350px">
                     {% endif %}
-                {% endfor %}
-            </tr>
-        </table>
-    </div>
+                    <tr>
+                        {% for local_partner in local_partner_group %}
+                            {% if local_partner and local_partner.is_active %}
+                            <td align="center" style="color: black; font-size: 12px;">
+                                <p style="margin: 10px; font-family: 'Gill Sans', 'Trebuchet MS', sans-serif;">
+                                    <a href="{{ local_partner.link }}">
+                                        <img src="{% baseurl %}{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}" height="70" style="height: 70px; margin-bottom: 25px" alt="{{ local_partner.name }}"/>
+                                    </a><br/>
+                                    {% trans "our local partner"|upper %}
+                                </p>
+                            </td>
+                            {% endif %}
+                        {% endfor %}
+                    </tr>
+                </table>
+            </div>
+        {% endfor %}
     {% endif %}
 </body>
 </html>

--- a/website/newsletters/views.py
+++ b/website/newsletters/views.py
@@ -1,4 +1,5 @@
 """Views provided by the newsletters package."""
+import math
 import os
 
 from django.contrib.admin.views.decorators import staff_member_required
@@ -40,6 +41,14 @@ def preview(request, pk, lang=None):
 
     newsletter = get_object_or_404(Newsletter, pk=pk)
     events = services.get_agenda(newsletter.date) if newsletter.date else None
+    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
+    local_partner_count = len(all_local_partners)
+    local_partners = []
+    for i in range(math.floor(local_partner_count/2)):
+        local_partners.append([all_local_partners[i*2], all_local_partners[i*2 + 1]])
+
+    if local_partner_count % 2 != 0:
+        local_partners.append([all_local_partners[local_partner_count-1]])
 
     return render(
         request,
@@ -48,7 +57,7 @@ def preview(request, pk, lang=None):
             "newsletter": newsletter,
             "agenda_events": events,
             "main_partner": Partner.objects.filter(is_main_partner=True).first(),
-            "local_partners": Partner.objects.filter(is_local_partner=True),
+            "local_partners": local_partners,
             "lang_code": lang_code,
         },
     )

--- a/website/newsletters/views.py
+++ b/website/newsletters/views.py
@@ -44,11 +44,13 @@ def preview(request, pk, lang=None):
     all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
     local_partner_count = len(all_local_partners)
     local_partners = []
-    for i in range(math.floor(local_partner_count/2)):
-        local_partners.append([all_local_partners[i*2], all_local_partners[i*2 + 1]])
+    for i in range(math.floor(local_partner_count / 2)):
+        local_partners.append(
+            [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
+        )
 
     if local_partner_count % 2 != 0:
-        local_partners.append([all_local_partners[local_partner_count-1]])
+        local_partners.append([all_local_partners[local_partner_count - 1]])
 
     return render(
         request,

--- a/website/newsletters/views.py
+++ b/website/newsletters/views.py
@@ -1,5 +1,4 @@
 """Views provided by the newsletters package."""
-import math
 import os
 
 from django.contrib.admin.views.decorators import staff_member_required
@@ -41,16 +40,7 @@ def preview(request, pk, lang=None):
 
     newsletter = get_object_or_404(Newsletter, pk=pk)
     events = services.get_agenda(newsletter.date) if newsletter.date else None
-    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
-    local_partner_count = len(all_local_partners)
-    local_partners = []
-    for i in range(math.floor(local_partner_count / 2)):
-        local_partners.append(
-            [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
-        )
-
-    if local_partner_count % 2 != 0:
-        local_partners.append([all_local_partners[local_partner_count - 1]])
+    local_partners = services.split_local_partners()
 
     return render(
         request,


### PR DESCRIPTION
### Summary
With this fix we can show an infinite number of local partners in the newsletter!

### How to test
Steps to test the changes you made:
1. Create a newsletter
2. Have _i_ local partners
3. See _i_ local partners in sent and previewed email
4. Use _i_ from 0 to like 5
