### PR TITLE
Add missing fancybox import on the vacancies page

### DIFF
--- a/website/partners/templates/partners/vacancies.html
+++ b/website/partners/templates/partners/vacancies.html
@@ -73,6 +73,7 @@
 
 {% block js_body %}
     {{ block.super }}
+    <script src="{% static "js/fancybox.umd.js" %}"></script>
     {% compress js %}
         <script type="text/javascript" src="{% static 'js/mixitup.min.js' %}"></script>
         <script type="text/javascript" src="{% static 'partners/js/main.js' %}"></script>


### PR DESCRIPTION
Closes #2467 and #2455 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Add missing fancybox import on the vacancies page

### How to test
Steps to test the changes you made:
1. Go to the vacancies page
2. See that there is no longer an error in the console
3. Use the filters or the learn more button and see that they work
