### PR TITLE
Fix AASA file to not open mark-present url in ThaliApp

### DIFF
--- a/infra/resources/apple-app-site-association.json
+++ b/infra/resources/apple-app-site-association.json
@@ -8,6 +8,7 @@
           "/pizzas",
           "/events",
           "/events/*",
+          "NOT /events/*/mark-present/*",
           "/members/photos",
           "/members/photos/*",
           "/sales/order/*/pay"


### PR DESCRIPTION
### Summary
Instructs your mobile browser to not try and open the mark-presence url in the ThaliApp

### How to test
Use the QR code on iOS