### PR TITLE
add check for age restriction and age on orders

### DIFF
--- a/website/payments/payables.py
+++ b/website/payments/payables.py
@@ -56,6 +56,10 @@ class Payable:
     def tpay_allowed(self):
         return True
 
+    @property
+    def paying_allowed(self):
+        return True
+
     def can_manage_payment(self, member):
         raise NotImplementedError
 

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -55,6 +55,9 @@ def create_payment(
     if pay_type == Payment.TPAY and not payer.tpay_enabled:
         raise PaymentError(_("This user does not have Thalia Pay enabled"))
 
+    if not payable.paying_allowed:
+        raise PaymentError(_("Payment restricted"))
+
     if payable.payment is not None:
         payable.payment.amount = payable.payment_amount
         payable.payment.notes = payable.payment_notes

--- a/website/payments/tests/__mocks__.py
+++ b/website/payments/tests/__mocks__.py
@@ -28,6 +28,7 @@ class MockModel:
         notes="mock notes",
         payment=None,
         can_manage=True,
+        paying_allowed=True,
     ) -> None:
         self.payer = payer
         self.amount = amount
@@ -35,6 +36,7 @@ class MockModel:
         self.notes = notes
         self.payment = payment
         self.can_manage = can_manage
+        self.paying_allowed = paying_allowed
 
         # Because we have to do as if this is a model sometimes
         self.verbose_name = "MockPayable"
@@ -67,6 +69,10 @@ class MockPayable(Payable):
     @property
     def payment_payer(self):
         return self.model.payer
+
+    @property
+    def paying_allowed(self):
+        return self.model.paying_allowed
 
     def can_manage_payment(self, member):
         return self.model.can_manage

--- a/website/payments/tests/test_services.py
+++ b/website/payments/tests/test_services.py
@@ -69,9 +69,17 @@ class ServicesTest(TestCase):
         with self.subTest("Only allow valid payment types"):
             with self.assertRaises(PaymentError):
                 services.create_payment(
-                    MockPayable(MockModel(payer=self.member, amount=0)),
+                    MockPayable(MockModel(payer=self.member)),
                     self.member,
                     "no_payment",
+                )
+
+        with self.subTest("Do not allow creating payment when not paying_allowed"):
+            with self.assertRaises(PaymentError):
+                services.create_payment(
+                    MockPayable(MockModel(payer=self.member, paying_allowed=False)),
+                    self.member,
+                    Payment.CASH,
                 )
 
     def test_delete_payment(self):

--- a/website/sales/payables.py
+++ b/website/sales/payables.py
@@ -2,7 +2,7 @@ from django.utils.functional import classproperty
 
 from payments import Payable, payables
 from sales.models.order import Order, OrderItem
-from sales.services import is_manager
+from sales.services import is_manager, is_adult
 
 
 class OrderPayable(Payable):
@@ -21,6 +21,14 @@ class OrderPayable(Payable):
     @property
     def payment_payer(self):
         return self.model.payer
+
+    @property
+    def paying_allowed(self):
+        return not (
+            self.model.age_restricted
+            and self.model.payer
+            and not is_adult(self.model.payer)
+        )
 
     def can_manage_payment(self, member):
         return is_manager(member, self.model.shift) and member.has_perm(


### PR DESCRIPTION
Closes #2398 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Bug fixed that allowed underaged users to still pay for age restricted items.
Made a property in payable that states if the payment is allowed
overwritten the property in the orderpayable to return false if payment is age restricted and user is not an adult
added test for this property in services where the payment is created such that payment is not created if the user is underaged and order is age restricted
Added a test for this property to the tests in testservices of payments

### How to test
Steps to test the changes you made:
1. Make an age-restricted order
2. Claim the order (set payer or use the api endpoint)
3. Try to pay the order from the api
4. See that it is not possible
