### PR TITLE
Relax rate limits API

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -640,8 +640,8 @@ REST_FRAMEWORK = {
         "thaliawebsite.api.throttling.UserRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": setting(
-        production={"anon": "100/day", "user": "20/min"},
-        staging={"anon": "100/day", "user": "20/min"},
+        production={"anon": "30/min", "user": "30/min"},
+        staging={"anon": "30/min", "user": "30/min"},
         development={"anon": None, "user": None},
     ),
 }


### PR DESCRIPTION
### Summary

The rate limits are currently so low that a Discord bot cannot sync all users each hour. Looked up what other APIs use and we have very low limits. This should be more in line with what can be used.

