### PR TITLE
Don't show pulsing background on partner page

### DIFF
--- a/website/partners/templatetags/partner_cards.py
+++ b/website/partners/templatetags/partner_cards.py
@@ -27,6 +27,7 @@ def partner_card(partner):
         url=partner.get_absolute_url,
         image_url=image_url,
         class_name="partner-card contain-logo",
+        show_loading_animation=False,
     )
 
 

--- a/website/thaliawebsite/templates/includes/grid_item.html
+++ b/website/thaliawebsite/templates/includes/grid_item.html
@@ -3,7 +3,7 @@
     {% if url %}
         <a class="d-flex" href="{{ url }}" {{ anchor_attrs|safe }}>
     {% endif %}
-    <div class="image pulsing-background">
+    <div class="image{% if show_loading_animation %} pulsing-background{% endif %}">
         <img alt="{{ title }}" src="{{ image_url }}" loading="lazy" />
     </div>
     <div class="name">

--- a/website/thaliawebsite/templatetags/grid_item.py
+++ b/website/thaliawebsite/templatetags/grid_item.py
@@ -12,6 +12,7 @@ def grid_item(
     ribbon=None,
     class_name="",
     anchor_attrs="",
+    show_loading_animation=True,
 ):
     return {
         "title": title,
@@ -21,4 +22,5 @@ def grid_item(
         "ribbon": ribbon,
         "class_name": class_name,
         "anchor_attrs": anchor_attrs,
+        "show_loading_animation": show_loading_animation,
     }


### PR DESCRIPTION
Closes #2487 

### Summary
Hides the pulsing background on partner page

### How to test
1. go to the partner page
2. No pulsing background