### PR TITLE
Fix frontpage vacancy URL for inactive partners

### DIFF
--- a/website/partners/templatetags/frontpage_vacancies.py
+++ b/website/partners/templatetags/frontpage_vacancies.py
@@ -12,7 +12,7 @@ def render_frontpage_vacancies():
 
     for vacancy in Vacancy.objects.order_by("?")[:6]:
         url = "{}#vacancy-{}".format(reverse("partners:vacancies"), vacancy.id)
-        if vacancy.partner:
+        if vacancy.partner and vacancy.partner.is_active:
             url = "{}#vacancy-{}".format(vacancy.partner.get_absolute_url(), vacancy.id)
 
         vacancies.append(


### PR DESCRIPTION
Closes #2524 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Make inactive partners refer to the "generic"/partnerless URL to prevent 404 errors.

### How to test
Steps to test the changes you made:
1. Reproduce the bug
3. Merge this change
4. Observe that you get sent to the vacancy page instead of a 404
