### PR TITLE
Add X-Forwarded-Proto header

### DIFF
--- a/concrexit-server.nix
+++ b/concrexit-server.nix
@@ -220,6 +220,7 @@ in
           'upstream_response_time=$upstream_response_time '
           'upstream_connect_time=$upstream_connect_time '
           'upstream_header_time=$upstream_header_time';
+      proxy_set_header X-Forwarded-Proto $scheme;
     '';
 
     virtualHosts =

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -260,6 +260,9 @@ SESSION_COOKIE_SECURE = setting(development=False, production=True)
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-secure
 CSRF_COOKIE_SECURE = setting(development=False, production=True)
 
+# https://docs.djangoproject.com/en/dev/ref/settings/#std-setting-SECURE_PROXY_SSL_HEADER
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 


### PR DESCRIPTION
### Summary
This is needed to make Django believe where on https, and thus to check CSRF succesfully

### How to test
Deploy to staging