### PR TITLE
Remove X-Forwarded-Proto

### DIFF
--- a/concrexit-server.nix
+++ b/concrexit-server.nix
@@ -220,7 +220,6 @@ in
           'upstream_response_time=$upstream_response_time '
           'upstream_connect_time=$upstream_connect_time '
           'upstream_header_time=$upstream_header_time';
-      proxy_set_header X-Forwarded-Proto $scheme;
     '';
 
     virtualHosts =


### PR DESCRIPTION
### Summary
When adding this manually, it was added two times. Apparently nixos already adds the header in the recommended proxy settings.

### How to test
It's already running on staging, and CSRF works now