### PR TITLE
remove double call to bootstrap_messages

### DIFF
--- a/website/members/templates/members/user/edit_profile.html
+++ b/website/members/templates/members/user/edit_profile.html
@@ -8,7 +8,6 @@
 {% block page_title %}{% trans "edit profile"|capfirst %}{% endblock %}
 
 {% block page_content %}
-    {% bootstrap_messages %}
     {% if form.errors %}
         {% trans "Please check your profile for errors." as error_text %}
         {% alert 'danger' error_text dismissible=True %}


### PR DESCRIPTION
Closes #ISSUE

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Both the simple_page.html and edit_profile.html (which extends simple_page) had a call to bootstrap_messages, causing it to display the success message twice. I removed the call in the edit_profile.html file

### How to test
Steps to test the changes you made:
1. Go to edit profile
2. Click on 'save'
3. Observe a singular success message
