### PR TITLE
Handle a view not having an object_id

### DIFF
--- a/website/events/admin/event.py
+++ b/website/events/admin/event.py
@@ -251,7 +251,7 @@ class EventAdmin(DoNextModelAdmin):
         if pk == None:
             # I guess we are creating an event here; just call super() I think?
             return super().get_field_queryset(db, db_field, request)
-        
+
         if db_field.name == "organisers" and not request.user.has_perm(
             "events.override_organiser"
         ):

--- a/website/events/admin/event.py
+++ b/website/events/admin/event.py
@@ -246,8 +246,12 @@ class EventAdmin(DoNextModelAdmin):
         return custom_urls + urls
 
     def get_field_queryset(self, db, db_field, request):
-        """Members without the can view as organiser permission can only assign their own groups as organiser."""
-        pk = resolve(request.path_info).kwargs["object_id"]
+        """Members without the 'can view as organiser' permission can only assign their own groups as organiser."""
+        pk = resolve(request.path_info).kwargs.get("object_id")
+        if pk == None:
+            # I guess we are creating an event here; just call super() I think?
+            return super().get_field_queryset(db, db_field, request)
+        
         if db_field.name == "organisers" and not request.user.has_perm(
             "events.override_organiser"
         ):

--- a/website/events/admin/event.py
+++ b/website/events/admin/event.py
@@ -248,14 +248,13 @@ class EventAdmin(DoNextModelAdmin):
     def get_field_queryset(self, db, db_field, request):
         """Members without the 'can view as organiser' permission can only assign their own groups as organiser."""
         pk = resolve(request.path_info).kwargs.get("object_id")
-        if pk == None:
-            # I guess we are creating an event here; just call super() I think?
-            return super().get_field_queryset(db, db_field, request)
-
         if db_field.name == "organisers" and not request.user.has_perm(
             "events.override_organiser"
         ):
-            return request.member.get_member_groups().union(
-                MemberGroup.objects.filter(event_organiser__pk=pk)
-            )
+            if pk is None:
+                return request.member.get_member_groups()
+            else:
+                return request.member.get_member_groups().union(
+                    MemberGroup.objects.filter(event_organiser__pk=pk)
+                )
         return super().get_field_queryset(db, db_field, request)


### PR DESCRIPTION
Closes #2545

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Handle the case for opening the event form when the form does not exist yet; hence the View does not define an object_id.

I'm doing this by just calling into super, I think this should work?

### How to test
Steps to test the changes you made:
1. Try to create an event
2. See that this is not impossible anymore.
