### PR TITLE
Do not throw away bank accounts that may not be deleted during member data minimisation

### DIFF
--- a/website/members/services.py
+++ b/website/members/services.py
@@ -236,7 +236,6 @@ def execute_data_minimisation(dry_run=False, members=None) -> List[Member]:
             profile.birthday = datetime(1900, 1, 1)
             profile.emergency_contact_phone_number = None
             profile.emergency_contact = None
-            member.bank_accounts.all().delete()
             if not dry_run:
                 profile.save()
 


### PR DESCRIPTION
Closes #2539 

### Summary
Moves bank account minimization to the payments app. This will keep bank accounts 13 months after last usage for collecting a Thalia Pay batch, as is required.


### How to test
1. Do data minimisation
2. Bank accounts will only be removed 13 months after last usage