### PR TITLE
Fix loading animation properly

### DIFF
--- a/website/thaliawebsite/static/js/loading-animation.js
+++ b/website/thaliawebsite/static/js/loading-animation.js
@@ -1,0 +1,9 @@
+const items = document.querySelectorAll(".pulsing-background");
+items.forEach(
+    (item) => {
+        item.querySelector("img").addEventListener(
+            "load", event => {event.target.parentNode.classList.remove("pulsing-background")}
+        )
+    }
+)
+

--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -284,6 +284,8 @@
             src="{% static "js/js.cookie.min.js" %}"></script>
     <script type="text/javascript"
             src="{% static "announcements/js/announcements.js" %}"></script>
+    <script type="text/javascript"
+            src="{% static "js/loading-animation.js" %}"></script>
 {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Closes #2543

### Summary
Adds event listener to delete the pulsing-background class when images load

### How to test
1. Have a transparent image, like a society logo
2. The background will pulse during loading
3. The background will not pulse after loading anymore