### PR TITLE
Fix tinymce z-index

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -761,6 +761,14 @@ TINYMCE_DEFAULT_CONFIG = {
     "remove_script_host": False,
     "autoresize_bottom_margin": 50,
 }
+TINYMCE_EXTRA_MEDIA = {
+    "css": {
+        "all": [
+            "css/tinymce.css",
+        ],
+    },
+}
+
 
 BOOTSTRAP5 = {"required_css_class": "required-field"}
 

--- a/website/thaliawebsite/static/css/tinymce.css
+++ b/website/thaliawebsite/static/css/tinymce.css
@@ -1,0 +1,3 @@
+.form-row .tox .tox-editor-header {
+    z-index: 0;
+}


### PR DESCRIPTION
Closes #2491 

### Summary
When adding an event to the site the window, which pops up when you select a date or a time, appears underneath the text styling bar of the description. The z index of the description text styling bar should be lower then that of the time/date selection window.

### How to reproduce
Steps to reproduce the behaviour:
1. Go to 'thalia.nu/admin'
2. Click on 'events'
3. Click on add event
4. Go to details
5. Go to 'End time'
6. Click on the clock icon
7. See error
