### PR TITLE
Dont call distinct on order queryset

### DIFF
--- a/website/sales/admin/order_admin.py
+++ b/website/sales/admin/order_admin.py
@@ -253,7 +253,7 @@ class OrderAdmin(admin.ModelAdmin):
         elif not request.member.has_perm("sales.override_manager"):
             queryset = queryset.filter(
                 shift__managers__in=request.member.get_member_groups()
-            ).distinct()
+            )
 
         queryset = queryset.select_properties(
             "total_amount", "subtotal", "num_items", "age_restricted"
@@ -335,7 +335,7 @@ class OrderAdmin(admin.ModelAdmin):
             elif not request.member.has_perm("sales.override_manager"):
                 field.queryset = field.queryset.filter(
                     managers__in=request.member.get_member_groups()
-                )
+                ).distinct()
         return field
 
     def changelist_view(self, request, extra_context=None):


### PR DESCRIPTION
Closes #2478

### Summary
Removes  the query set.distinct call for the admin's get_queryset method because we don't need it there, but re-adds the call on the shift field query set 

### How to test
1. Have a shift with 2 managers that you're both part of
2. Create an order from the admin (this won't crash)
3. Try to delete the orders via the changelist admin action