### PR TITLE
Fix concrexit timer

### DIFF
--- a/concrexit-server.nix
+++ b/concrexit-server.nix
@@ -147,7 +147,7 @@ in
 
   concrexit-timers = {
     docker-command = ''
-      docker run --network concrexit --name concrexit -p 127.0.0.1:8000:8000 \
+      docker run --network concrexit --rm -p 127.0.0.1:8000:8000 \
         -v /var/lib/concrexit/static:/static \
         -v /var/lib/concrexit/media:/media \
         --env-file ${envFile} \


### PR DESCRIPTION
### Summary
The previous command never worked... You cannot start a container named `concrexit` when one is already running.

This builds on #2571