### PR TITLE
Event admin: Move the cancellation mail/mailing list test to yet another place

### DIFF
--- a/website/events/admin/forms.py
+++ b/website/events/admin/forms.py
@@ -66,9 +66,12 @@ class EventAdminForm(forms.ModelForm):
             )
             and self.cleaned_data["send_cancel_email"]
         ):
-            self.add_error("organisers", _(
+            self.add_error(
+                "organisers",
+                _(
                     "One of the organisers does not have a contact mailinglist so sending a cancellation email is impossible."
-                ))
+                ),
+            )
             return False
 
         return True


### PR DESCRIPTION
Also why does clean not get called?????? So now I do the validation in `is_valid` instead.

Closes (no issue made again)

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
See the previous pr about this: #2547

### How to test
Steps to test the changes you made:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
