### PR TITLE
Cache docker builds

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -39,6 +39,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=user/app:buildcache
+          cache-to: type=registry,ref=user/app:buildcache,mode=max
   restart-container-on-staging:
     runs-on: ubuntu-latest
     needs: build-and-push-image


### PR DESCRIPTION
Use info from https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#registry-cache to cache builds