### PR TITLE
Revert "Cache docker builds"

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -40,8 +40,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=user/app:buildcache
-          cache-to: type=registry,ref=user/app:buildcache,mode=max
   restart-container-on-staging:
     runs-on: ubuntu-latest
     needs: build-and-push-image


### PR DESCRIPTION
Reverts svthalia/concrexit#2581

Doesn't work: https://github.com/svthalia/concrexit/actions/runs/3242832491


buildx failed with: ERROR: cache export feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")


Not sure which option we need to use rn