### PR TITLE
Add mark-present api

### DIFF
--- a/website/events/api/v2/admin/serializers/event.py
+++ b/website/events/api/v2/admin/serializers/event.py
@@ -24,6 +24,7 @@ class EventAdminSerializer(CleanedModelSerializer):
     description = CleanedHTMLSerializer()
     price = PaymentAmountSerializer()
     fine = PaymentAmountSerializer()
+    mark_present_url = serializers.ReadOnlyField()
 
     def to_internal_value(self, data):
         self.fields["organisers"] = serializers.PrimaryKeyRelatedField(

--- a/website/events/api/v2/urls.py
+++ b/website/events/api/v2/urls.py
@@ -9,6 +9,7 @@ from events.api.v2.views import (
     EventRegistrationsView,
     ExternalEventDetailView,
     ExternalEventListView,
+    MarkPresentAPIView,
 )
 
 app_name = "events"
@@ -34,6 +35,11 @@ urlpatterns = [
         "events/<int:event_id>/registrations/<int:registration_id>/fields/",
         EventRegistrationFieldsView.as_view(),
         name="event-registration-fields",
+    ),
+    path(
+        "events/<int:pk>/mark-present/<uuid:token>/",
+        MarkPresentAPIView.as_view(),
+        name="mark-present",
     ),
     path(
         "events/external/", ExternalEventListView.as_view(), name="external-events-list"

--- a/website/sales/api/v2/views.py
+++ b/website/sales/api/v2/views.py
@@ -128,7 +128,9 @@ class OrderClaimView(GenericAPIView):
 
     def patch(self, request, *args, **kwargs):
         if request.member is None:
-            raise PermissionDenied("You need to be a member to pay for an order.")
+            raise PermissionDenied(
+                detail="You need to be a member to pay for an order."
+            )
 
         order = self.get_object()
         if order.payment:


### PR DESCRIPTION

Closes #2520.

### Summary
Adds an api view basically identical to that at the mark-present-url, but using PATCH. And adds the mark_present_url to the event admin serializer.


### How to test
Steps to test the changes you made:
1. Try to mark yourself as present with the api.
