### PR TITLE
Add some basic integration tests for events

### DIFF
--- a/website/events/tests/test_api.py
+++ b/website/events/tests/test_api.py
@@ -15,6 +15,7 @@ from events.models import (
     RegistrationInformationField,
     TextRegistrationInformation,
 )
+from events.models.external_event import ExternalEvent
 from members.models import Member
 
 
@@ -428,3 +429,79 @@ class RegistrationApiTest(TestCase):
 
         self.assertContains(response, "This event has already ended.", status_code=403)
         self.assertFalse(registration.present)
+
+@override_settings(SUSPEND_SIGNALS=True)
+class CalendarjsTest(TestCase):
+    """Tests for CalendarJS/Fullcalendar view."""
+
+    fixtures = ["members.json", "member_groups.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.event = Event.objects.create(
+            pk=1,
+            title="testevent",
+            description="desc",
+            published=True,
+            start=timezone.make_aware(datetime.datetime(2010, 1, 1, 20, 0, 0)),
+            end=timezone.make_aware(datetime.datetime(2010, 1, 1, 22, 0, 0)),
+            location="test location",
+            map_location="test map location",
+            price=13.37,
+            fine=5.00,
+        )
+        cls.unpubEvent = Event.objects.create(
+            pk=2,
+            title="secretevent",
+            description="desc",
+            published=False,
+            start=timezone.make_aware(datetime.datetime(2010, 1, 1, 20, 0, 0)),
+            end=timezone.make_aware(datetime.datetime(2010, 1, 1, 22, 0, 0)),
+            location="fake location",
+            map_location="fake map location",
+            price=6.66,
+            fine=5.00,
+        )
+        cls.extEvent = ExternalEvent.objects.create(
+            pk=3,
+            organiser="Technicie",
+            title="extevent",
+            description="desc",
+            published=True,
+            start=timezone.make_aware(datetime.datetime(2010, 1, 1, 20, 0, 0)),
+            end=timezone.make_aware(datetime.datetime(2010, 1, 1, 22, 0, 0)),
+            location="partner location",
+        )
+        cls.event.organisers.add(Committee.objects.get(pk=1))
+        cls.member = Member.objects.filter(last_name="Wiggers").first()
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_login(self.member)
+
+    def test_event_list(self):
+        response = self.client.get(
+            "/api/calendarjs/events/?start=2010-01-01T00%3A00%3A00%2B01%3A00&end=2011-01-01T00%3A00%3A00%2B01%3A00",
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "testevent")
+
+    def test_unpub_event_list(self):
+        response = self.client.get(
+            "/api/calendarjs/events/unpublished/?start=2010-01-01T00%3A00%3A00%2B01%3A00&end=2011-01-01T00%3A00%3A00%2B01%3A00",
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "secretevent")
+
+    def test_external_event_list(self):
+        response = self.client.get(
+            "/api/calendarjs/external/?start=2010-01-01T00%3A00%3A00%2B01%3A00&end=2011-01-01T00%3A00%3A00%2B01%3A00",
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], "extevent (Technicie)")

--- a/website/events/tests/test_api.py
+++ b/website/events/tests/test_api.py
@@ -430,6 +430,7 @@ class RegistrationApiTest(TestCase):
         self.assertContains(response, "This event has already ended.", status_code=403)
         self.assertFalse(registration.present)
 
+
 @override_settings(SUSPEND_SIGNALS=True)
 class CalendarjsTest(TestCase):
     """Tests for CalendarJS/Fullcalendar view."""
@@ -505,3 +506,44 @@ class CalendarjsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["title"], "extevent (Technicie)")
+
+
+@override_settings(SUSPEND_SIGNALS=True)
+class EventApiV2Test(TestCase):
+    """Tests for registration view."""
+
+    fixtures = ["members.json", "member_groups.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.event = Event.objects.create(
+            pk=1,
+            title="testevent",
+            description="desc",
+            published=True,
+            start=(timezone.now() + datetime.timedelta(hours=1)),
+            end=(timezone.now() + datetime.timedelta(hours=2)),
+            location="test location",
+            map_location="test map location",
+            price=13.37,
+            fine=5.00,
+        )
+        cls.event.organisers.add(Committee.objects.get(pk=1))
+        cls.member = Member.objects.filter(last_name="Wiggers").first()
+
+        cls.mark_present_api_url = reverse(
+            "api:v2:events:mark-present",
+            kwargs={
+                "pk": cls.event.pk,
+                "token": cls.event.mark_present_url_token,
+            },
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_login(self.member)
+
+    def test_event_list(self):
+        response = self.client.get("/api/v2/events/", format="json")
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["title"], "testevent")

--- a/website/events/tests/test_views.py
+++ b/website/events/tests/test_views.py
@@ -591,8 +591,8 @@ class EventPageTest(TestCase):
         self.client.force_login(self.member)
 
     def test_list_page(self):
-        # TODO: we should probably test the calendar itself too
-        #       but that requires setting up browser automation
+        # note: this does not test the calendar itself!
+        # but we test the API so it should work
         response = self.client.get("/events/")
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Closes #2123 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Added some integration tests for events

### How to test
1. Run `make test`
2. Observe that all tests pass
3. Break something
4. Observe that test starts failing
5. Try to think of some more endpoints to test :)
