### PR TITLE
Change production envvars to match release branch

### DIFF
--- a/infra/docker/production/concrexit-production-public.env
+++ b/infra/docker/production/concrexit-production-public.env
@@ -1,6 +1,8 @@
 # secret environment variables are located in /infra/secrets/concrexit-production.env.age
 SITE_DOMAIN=thalia.nu
-SENDFILE_ROOT=/var/lib/concrexit/media
+SENDFILE_ROOT=/media
+STATIC_ROOT=/static
+MEDIA_ROOT=/media
 POSTGRES_HOST=postgres
 POSTGRES_USER=concrexit
 POSTGRES_PASSWORD=concrexit


### PR DESCRIPTION
I found that on the release branch these were modified, but not on master. It seems that these should be updated on master as well, so that the next version will not have incorrect values for these.
