### PR TITLE
Prefetch likes and liked photo album

### DIFF
--- a/website/photos/api/v2/serializers/photo.py
+++ b/website/photos/api/v2/serializers/photo.py
@@ -41,7 +41,4 @@ class PhotoListSerializer(PhotoSerializer):
     liked = serializers.SerializerMethodField("_liked")
 
     def _liked(self, instance):
-        return (
-            self.context["request"].member
-            and instance.likes.filter(member=self.context["request"].member).exists()
-        )
+        return self.context["request"].member and instance.member_likes > 0

--- a/website/photos/models.py
+++ b/website/photos/models.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
+from queryable_properties.managers import QueryablePropertiesManager
 from queryable_properties.properties import AnnotationProperty
 
 from events.models import Event
@@ -35,6 +36,8 @@ def photo_uploadto(instance, filename):
 
 class Photo(models.Model):
     """Model for a Photo object."""
+
+    objects = QueryablePropertiesManager()
 
     album = models.ForeignKey(
         "Album", on_delete=models.CASCADE, verbose_name=_("album")

--- a/website/photos/views.py
+++ b/website/photos/views.py
@@ -63,7 +63,10 @@ def index(request):
 
 def _render_album_page(request, album):
     """Render album.html for a specified album."""
-    context = {"album": album, "photos": album.photo_set.filter(hidden=False)}
+    context = {
+        "album": album,
+        "photos": album.photo_set.filter(hidden=False).select_properties("num_likes"),
+    }
     return render(request, "photos/album.html", context)
 
 
@@ -120,6 +123,10 @@ def shared_download(request, slug, token, filename):
 
 @login_required
 def liked_photos(request):
-    photos = Photo.objects.filter(likes__member=request.member, album__hidden=False)
+    photos = (
+        Photo.objects.filter(likes__member=request.member, album__hidden=False)
+        .select_related("album")
+        .select_properties("num_likes")
+    )
     context = {"photos": photos}
     return render(request, "photos/liked-photos.html", context)


### PR DESCRIPTION
Closes #2641 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I added select_properties and select_related to make the photo views more efficient.

### How to test
Steps to test the changes you made:
1. Load an album or your list of liked photos
2. Observe that there are no more n+1 queries

Do note that there can be 2n+1 queries in the album overview if there is no explicit cover photo selected. I have not optimized for this case, although it probably is possible. I don't know the statistics for this on production; are cover photos always selected explicitly?
