### PR TITLE
Use latest docker tag

### DIFF
--- a/concrexit-server.nix
+++ b/concrexit-server.nix
@@ -12,7 +12,7 @@ let
   stagingSecrets = ./infra/secrets/concrexit-staging.env.age;
   secretsFile = if production then productionSecrets else stagingSecrets;
 
-  dockerImage = "ghcr.io/svthalia/concrexit:${if production then "release-43" else "master"}";
+  dockerImage = "ghcr.io/svthalia/concrexit:${if production then "latest" else "master"}";
 
   staticdir = "/var/lib/concrexit/static/";
   mediadir = "/var/lib/concrexit/media/";


### PR DESCRIPTION
### Summary

Last time we couldn't use the latest tag because I tagged from github instead of pushing the new tag. For release v44 I did push the tag, so the docker latest tag was correctly updated for the v44 tag build 
