### PR TITLE
Try running migrations as appuser

### DIFF
--- a/infra/docker/docker-entrypoint.sh
+++ b/infra/docker/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
 
 chown -R appuser /media
-MANAGE_PY=1 /venv/bin/python manage.py migrate --no-input
+MANAGE_PY=1 runuser -u appuser -- /venv/bin/python manage.py migrate --no-input
 exec runuser -u appuser -- /venv/bin/gunicorn --bind 0.0.0.0:8000 --log-level info --workers 4 --threads 100 --capture-output thaliawebsite.wsgi:application

--- a/infra/modules/concrexit_cdn/main.tf
+++ b/infra/modules/concrexit_cdn/main.tf
@@ -4,7 +4,7 @@ data "aws_s3_bucket" "media_bucket" {
 
 module "cloudfront" {
   source  = "terraform-aws-modules/cloudfront/aws"
-  version = "3.0.3"
+  version = "3.1.0"
 
   aliases = [var.webdomain]
 


### PR DESCRIPTION
### Summary
This prevents accidentally setting the wrong permissions
