### PR TITLE
Increase gunicorn timeout

### DIFF
--- a/infra/docker/docker-entrypoint.sh
+++ b/infra/docker/docker-entrypoint.sh
@@ -2,4 +2,4 @@
 
 chown -R appuser /media
 MANAGE_PY=1 runuser -u appuser -- /venv/bin/python manage.py migrate --no-input
-exec runuser -u appuser -- /venv/bin/gunicorn --bind 0.0.0.0:8000 --log-level info --workers 4 --threads 100 --capture-output thaliawebsite.wsgi:application
+exec runuser -u appuser -- /venv/bin/gunicorn --bind 0.0.0.0:8000 --log-level info --workers 4 --threads 20 --timeout 240 --capture-output thaliawebsite.wsgi:application


### PR DESCRIPTION

### Summary
Should fix SystemExit errors in sentry because those are due to gunicorn aborting our worker process
