### PR TITLE
Pk value check to fix 2698

### DIFF
--- a/website/sales/models/shift.py
+++ b/website/sales/models/shift.py
@@ -66,7 +66,7 @@ class Shift(models.Model):
         super().clean()
         errors = {}
 
-        if self.pk and self.orders.filter(created_at__lt=self.start):
+        if self.pk is not None and self.orders.filter(created_at__lt=self.start):
             errors.update(
                 {
                     "start": _(

--- a/website/sales/models/shift.py
+++ b/website/sales/models/shift.py
@@ -66,7 +66,7 @@ class Shift(models.Model):
         super().clean()
         errors = {}
 
-        if self.orders.filter(created_at__lt=self.start):
+        if self.pk and self.orders.filter(created_at__lt=self.start):
             errors.update(
                 {
                     "start": _(


### PR DESCRIPTION
Closes #2698 

### Summary
Fixes food ordering shift bug that was caused by not checking if a primary key exists before trying to use this pk in the database. This caused a problem when creating a new food ordering shift, as there is no pk at that point. Bug is fixed by checking if the pk is None. 

### How to test
1. Create a shift 
2. See there is no crash when creating the shift
