### PR TITLE
Fix summary and exam download

### DIFF
--- a/website/education/views.py
+++ b/website/education/views.py
@@ -129,8 +129,7 @@ class ExamDetailView(DetailView):
         exam.save()
 
         ext = os.path.splitext(exam.file.name)[1]
-        filename = f"{exam.course.name}-exam{exam.year}{ext}"
-        return redirect(get_media_url(exam.file, filename))
+        return redirect(get_media_url(exam.file, True))
 
 
 @method_decorator(login_required, "dispatch")
@@ -147,8 +146,7 @@ class SummaryDetailView(DetailView):
         obj.save()
 
         ext = os.path.splitext(obj.file.name)[1]
-        filename = f"{obj.course.name}-summary{obj.year}{ext}"
-        return redirect(get_media_url(obj.file, filename))
+        return redirect(get_media_url(obj.file, True))
 
 
 @method_decorator(login_required, "dispatch")

--- a/website/education/views.py
+++ b/website/education/views.py
@@ -124,12 +124,13 @@ class ExamDetailView(DetailView):
 
     def get(self, request, *args, **kwargs) -> HttpResponse:
         response = super().get(request, *args, **kwargs)
-        exam = response.context_data["object"]
-        exam.download_count += 1
-        exam.save()
+        obj = response.context_data["object"]
+        obj.download_count += 1
+        obj.save()
 
-        ext = os.path.splitext(exam.file.name)[1]
-        return redirect(get_media_url(exam.file, True))
+        ext = os.path.splitext(obj.file.name)[1]
+        filename = f"{obj.course.name}-summary{obj.year}{ext}"
+        return redirect(get_media_url(obj.file, filename))
 
 
 @method_decorator(login_required, "dispatch")
@@ -146,7 +147,8 @@ class SummaryDetailView(DetailView):
         obj.save()
 
         ext = os.path.splitext(obj.file.name)[1]
-        return redirect(get_media_url(obj.file, True))
+        filename = f"{obj.course.name}-summary{obj.year}{ext}"
+        return redirect(get_media_url(obj.file, filename))
 
 
 @method_decorator(login_required, "dispatch")

--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -32,7 +32,7 @@ def get_media_url(file, attachment=False):
     If the file is private a signature will be added.
     Do NOT use this with user input
     :param file: the file field
-    :param attachment: True if the file is a forced download
+    :param attachment: filename to use for the attachment or False to not download as attachment
     :return: the url of the media
     """
     storage = DefaultStorage()


### PR DESCRIPTION
Closes #2625 

### Summary
We used to use `send_file`, but refactored and broke it in #2355


### How to test
