### PR TITLE
Limit price changes if participants exist

### DIFF
--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -335,7 +335,7 @@ class Event(models.Model):
         can be retrieved from self.changed_data
         """
         errors = {}
-        if self.published:
+        if self.published or self.participant_count > 0:
             for field in ("price", "registration_start"):
                 if (
                     field in changed_data


### PR DESCRIPTION
Closes #2700

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
In #2700 we complain about an 'exploit' where an event can be unpublished and then have its price changed. This PR limits it to also block when there are registrations.

### How to test
Steps to test the changes you made:
1. Create an event
2. Register for it
3. Unpublish it
4. Observe that you cannot change the price anymore

Side-note: an earlier version crashed when I tried creating an event, but that went okay with this version. Might be a good idea to test that, too
