### PR TITLE
Prune docker before deploying

### DIFF
--- a/concrexit-server.nix
+++ b/concrexit-server.nix
@@ -170,6 +170,7 @@ in
 
     path = with pkgs; [ docker ];
     script = ''
+      docker system prune -f || true
       docker rm concrexit || true
       out=$(docker pull ${dockerImage} | tee >(cat >&2))
 


### PR DESCRIPTION
### Summary
Makes sure the disk doesn't fill up