### PR TITLE
fix missing organiser email

### DIFF
--- a/website/events/emails.py
+++ b/website/events/emails.py
@@ -25,13 +25,19 @@ def notify_first_waiting(event):
         subject = _("[THALIA] Notification about your registration for '{}'").format(
             event.title
         )
+
+        organiser_emails = [
+            organiser.contact_address
+            for organiser in event.organisers.all()
+            if organiser.contact_address is not None
+        ]
         text_message = text_template.render(
             {
                 "event": event,
                 "registration": first_waiting,
                 "name": first_waiting.name or first_waiting.member.first_name,
                 "base_url": settings.BASE_URL,
-                "organisers": event.organisers.values_list("contact_email", flat=True),
+                "organisers": organiser_emails,
             }
         )
 

--- a/website/events/emails.py
+++ b/website/events/emails.py
@@ -31,6 +31,7 @@ def notify_first_waiting(event):
                 "registration": first_waiting,
                 "name": first_waiting.name or first_waiting.member.first_name,
                 "base_url": settings.BASE_URL,
+                "organisers": event.organisers.values_list("contact_email", flat=True),
             }
         )
 

--- a/website/events/templates/events/member_email.txt
+++ b/website/events/templates/events/member_email.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with event_title=event.title baseurl=base_url event_url=event.get_absolute_url registration_date=registration.date|date:"SHORT_DATETIME_FORMAT" cancel_deadline=event.cancel_deadline|date:"SHORT_DATETIME_FORMAT" organiser_name=event.organiser.name organiser_mail=event.organiser.contact_address %}Hi {{ name }},
+{% load i18n %}{% blocktrans with organiser_emails=organisers|join:", " event_title=event.title baseurl=base_url event_url=event.get_absolute_url registration_date=registration.date|date:"SHORT_DATETIME_FORMAT" cancel_deadline=event.cancel_deadline|date:"SHORT_DATETIME_FORMAT" %}Hi {{ name }},
 
 You registered for the event '{{ event_title }}' on {{ registration_date }} and unfortunately you were placed on the waiting list.
 However someone just unregistered and we would like to let you know that you'll be able to attend now!
@@ -6,7 +6,7 @@ However someone just unregistered and we would like to let you know that you'll 
 You can find more information about the event on the website: {{ baseurl }}{{ event_url }}
 
 We're assuming that you'll be there, but you're still able to unregister until {{ cancel_deadline }}.
-If this date has already passed you can contact the {{ organiser_name }} via {{ organiser_mail }}.
+If this date has already passed you can contact the organisers via {{ organiser_emails }}.
 
 Best regards,
 Study Association Thalia{% endblocktrans %}


### PR DESCRIPTION
Closes #2802

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Remove the no longer existing organiser_name and organiser_mail from the email template
create list of organiser emails and email lists filtering out organisers without an email-address
Add variable with comma seperate list for email template

### How to test
Create an event (with 1 open registration)
register 1 user and put another user in the queue
deregister original user
observer the email in terminal and see it no longer says "you can reach   at  .
