### PR TITLE
Fix tests on python 3.11

### DIFF
--- a/website/payments/tests/api/v1/test_viewsets_payments.py
+++ b/website/payments/tests/api/v1/test_viewsets_payments.py
@@ -106,7 +106,7 @@ class PaymentProcessViewTest(TestCase):
         )
 
     @mock.patch("payments.services.create_payment")
-    @mock.patch("payments.payables.get_payable")
+    @mock.patch("payments.payables.payables.get_payable")
     def test_creates_payment(self, get_payable, create_payment):
         def set_payments_side_effect(*args, **kwargs):
             self.payable.model.payment = Payment.objects.create(amount=8)

--- a/website/payments/tests/test_admin_views.py
+++ b/website/payments/tests/test_admin_views.py
@@ -69,7 +69,7 @@ class PaymentAdminViewTest(TestCase):
     @mock.patch("django.contrib.messages.success")
     @mock.patch("django.shortcuts.resolve_url")
     @mock.patch("payments.services.create_payment")
-    @mock.patch("payments.payables.get_payable")
+    @mock.patch("payments.payables.payables.get_payable")
     def test_post(
         self, get_payable, create_payment, resolve_url, messages_success, messages_error
     ):


### PR DESCRIPTION
Closes #2689

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Tests failed on Python 3.11. It seemed the website itself still worked fine on 3.11. This seems related to subtly changed rules re: aliasing imports (`payments` contains a submodule `payables`, but there is also a line that imports `payables.payables`, which is an instance of `Payables`). I changed the test to work with Python 3.11.

I verified that `payables` still worked, by testing the presence of the "Pay with Thalia Pay" button.

### How to test
1. Install Python 3.11
2. Instruct Poetry to use Python 3.11
3. `make test` -> OK
4. Find code that uses `payments.payables.get_payable` and verify that it still works correctly. (eg `payment_button`)