### PR TITLE
Use correct url for the website of Study Association via

### DIFF
--- a/website/singlepages/templates/singlepages/sibling_associations.html
+++ b/website/singlepages/templates/singlepages/sibling_associations.html
@@ -39,7 +39,7 @@
                         <li><a href="https://nsaweb.nl/">NSA ({% trans "University of Amsterdam" %})</a></li>
                         <li><a href="https://www.stickyutrecht.nl/">Sticky ({% trans "Utrecht University" %})</a></li>
                         <li><a href="https://www.storm.vu/">STORM ({% trans "VU University Amsterdam" %})</a></li>
-                        <li><a href="https://www.svia.nl/">via ({% trans "University of Amsterdam" %})</a></li>
+                        <li><a href="https://svia.nl/">via ({% trans "University of Amsterdam" %})</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
### Summary
`www.svia.nl` seems to have been removed from the certificate of the website of via, invalidating the URL `https://www.svia.nl/`. This PR replaces it with `https://svia.nl/`, which does work.

### How to test
Steps to test the changes you made:
1. Go to the "Sibling Associations" page and click on "via (University of Amsterdam)".
