### PR TITLE
Fix bugs related to multiple organisers

### DIFF
--- a/website/events/emails.py
+++ b/website/events/emails.py
@@ -72,12 +72,21 @@ def notify_waiting(event, registration):
     subject = _("[THALIA] Notification about your registration for '{}'").format(
         event.title
     )
+
+    organiser_emails = [
+        organiser.contact_address
+        for organiser in event.organisers.all()
+        if organiser.contact_address is not None
+    ]
+
     text_message = text_template.render(
         {
             "event": event,
             "registration": registration,
             "name": registration.name or registration.member.first_name,
             "base_url": settings.BASE_URL,
+            "organisers": organiser_emails,
         }
     )
+
     EmailMessage(subject, text_message, to=[registration.email]).send()

--- a/website/events/templates/events/admin/details.html
+++ b/website/events/templates/events/admin/details.html
@@ -74,8 +74,10 @@
             <dd>{{ event.title }}</dd>
             <dt>{% trans "date"|capfirst %}</dt>
             <dd>{{ event.start }} <br>— {{ event.end }}</dd>
-            <dt>{% trans "organiser"|capfirst %}</dt>
-            <dd>{{ event.organiser }}</dd>
+            <dt>{% trans "organised by"|capfirst %}</dt>
+            {% for organiser in event.organisers.all %}
+            <dd>{{ organiser }}</dd>
+            {% endfor %}
             {% if event.registration_start %}
             <dt>{% trans "registration period"|capfirst %}</dt>
             <dd>{{ event.registration_start }} <br>— {{ event.registration_end }}</dd>

--- a/website/events/templates/events/more_places_email.txt
+++ b/website/events/templates/events/more_places_email.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with event_title=event.title baseurl=base_url event_url=event.get_absolute_url registration_date=registration.date|date:"SHORT_DATETIME_FORMAT" cancel_deadline=event.cancel_deadline|date:"SHORT_DATETIME_FORMAT" organiser_name=event.organiser.name organiser_mail=event.organiser.contact_address %}Hi {{ name }},
+{% load i18n %}{% blocktrans with organiser_emails=organisers|join:", " event_title=event.title baseurl=base_url event_url=event.get_absolute_url registration_date=registration.date|date:"SHORT_DATETIME_FORMAT" cancel_deadline=event.cancel_deadline|date:"SHORT_DATETIME_FORMAT" %}Hi {{ name }},
 
 You registered for the event '{{ event_title }}' on {{ registration_date }} and unfortunately you were placed on the waiting list.
 However some more spots were added and we would like to let you know that you'll be able to attend now!
@@ -6,7 +6,7 @@ However some more spots were added and we would like to let you know that you'll
 You can find more information about the event on the website: {{ baseurl }}{{ event_url }}
 
 We're assuming that you'll be there, but you're still able to unregister until {{ cancel_deadline }}.
-If this date has already passed you can contact the {{ organiser_name }} via {{ organiser_mail }}.
+If this date has already passed you can contact the organisers via {{ organiser_emails }}.
 
 Best regards,
 Study Association Thalia{% endblocktrans %}


### PR DESCRIPTION
Closes #2814 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I fixed #2814 which was (still) related to multiple organisers. I also 'ported' #2808 to the more_places_email and I believe this was the last of the multiple organiser bugs :tada: (but don't quote me on this tbh)

### How to test
Steps to test the changes you made:
1. Go to an event overview in the admin
2. Observe that the organiser(s) are now actually displayed.
