### PR TITLE
Fix request.member evaluated too early in API calls

### DIFF
--- a/website/announcements/context_processors.py
+++ b/website/announcements/context_processors.py
@@ -17,6 +17,8 @@ def announcements(request):
         for a in Announcement.objects.all()
         if a.is_visible and a.pk not in closed_announcements
     ]
+
+    # Announcements set by AnnouncementMiddleware.
     persistent_announcements = getattr(request, "_announcements", [])
     return {
         "announcements": announcements_list,

--- a/website/announcements/middleware.py
+++ b/website/announcements/middleware.py
@@ -2,6 +2,13 @@ from django.apps import apps
 
 
 class AnnouncementMiddleware:
+    """Adds the _announcements attribute to requests.
+
+    This middleware lets apps add announcements to a request, by providing an
+    AppConfig.announcements method that takes the request as argument, and returns
+    a list of announcements to add.
+    """
+
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/website/members/apps.py
+++ b/website/members/apps.py
@@ -35,7 +35,13 @@ class MembersConfig(AppConfig):
             ],
         }
 
-    def announcements(self, request):
+    def announcements(self, request) -> list[dict]:
+        # Skip announcements for anonymous users to prevent evaluating
+        # request.member too early for API requests, because DRF only sets
+        # the correct request.user after evaluating the middlewares.
+        if request.user.is_anonymous:
+            return []
+
         announcements = []
         if request.member and request.member.current_membership is None:
             announcements.append(


### PR DESCRIPTION
### Summary
Fixes a problem (introduced in #2734) where the API calls cannot access `request.member` when authenticated with oauth only. See e.g. https://thalia.sentry.io/issues/3952946075/?project=1463433&query=is%3Aunresolved&referrer=issue-stream where this leads to a 500. In other cases, APIs currently would simply return wrong results.

### How to test
Steps to test the changes you made:
1. Make an API call that would use request.member, but without session authentication (i.e. not from the swagger client, unless you remove the sessionid after authenticating it with oauth).
For example `http 127.0.0.1:8000/api/v2/payments/ authorization:"Bearer <insert a token here>" -h`
