### PR TITLE
Include query string in partnerevents API redirect

### DIFF
--- a/website/partners/api/v2/urls.py
+++ b/website/partners/api/v2/urls.py
@@ -16,14 +16,18 @@ urlpatterns = [
     path(
         "partners/events/",
         RedirectView.as_view(
-            pattern_name="api:v2:events:external-events-list", permanent=False
+            pattern_name="api:v2:events:external-events-list",
+            permanent=False,
+            query_string=True,
         ),
         name="partner-events-list",
     ),
     path(
         "partners/events/<int:pk>/",
         RedirectView.as_view(
-            pattern_name="api:v2:events:external-event-detail", permanent=False
+            pattern_name="api:v2:events:external-event-detail",
+            permanent=False,
+            query_string=True,
         ),
         name="partner-events-detail",
     ),


### PR DESCRIPTION
Closes #2847 as I think this was the only API endpoint with this issue

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The redirected endpoint now passes through the query string, so that it filters correctly for example

### How to test
Steps to test the changes you made:
1. Go to an endpoint like localhost:8000/api/v2/partners/events/?search=beest&ordering=start&start=2023-02-01T00%3A00%3A00.000
2. Observe that the redirected URL now still includes the search term and start date
