### PR TITLE
Added change-event button for admins to events

### DIFF
--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -16,7 +16,20 @@
 {% block body %}
     <section class="page-section" id="events-detail">
         <div class="container">
-            <h1 class="section-title">{{ event.title }}</h1>
+
+            <h1 class="section-title">
+                {{ event.title }}
+                {% if permissions.manage_event %}
+                    <a href="{% url 'admin:events_event_change' event.pk %}"
+                        class="btn btn-primary first-right"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="first-right"
+                        title=""
+                        data-original-title="{% trans "Admin" %}">
+                        <i class="fas fa-cog"></i>
+                    </a>
+                {% endif %}
+            </h1>
 
             {% bootstrap_messages %}
 

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -20,7 +20,7 @@
             <h1 class="section-title">
                 {{ event.title }}
                 {% if permissions.manage_event %}
-                    <a href="{% url 'admin:events_event_change' event.pk %}"
+                    <a href="{% url 'admin:events_event_details' event.pk %}"
                         class="btn btn-primary first-right"
                         data-bs-toggle="tooltip"
                         data-bs-placement="first-right"


### PR DESCRIPTION
Closes #2848.

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This adds a button in the top-right corner for admins of an event, taking them to the event admin.

### How to test
Steps to test the changes you made:
1. Be organiser of an event, and see the button.
2. Be not an organiser (nor superuser) and don't see the button.
