### PR TITLE
People from the future can no longer register

### DIFF
--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -415,6 +415,9 @@ class Registration(Entry):
         if self.programme is None and self.membership_type != Membership.BENEFACTOR:
             errors.update({"programme": _("This field is required.")})
 
+        if self.birthday and self.birthday > timezone.now().date():
+            errors.update({"birthday": _("A birthday cannot be in the future.")})
+
         if self.direct_debit:
             if not self.iban:
                 errors.update(

--- a/website/registrations/tests/test_models.py
+++ b/website/registrations/tests/test_models.py
@@ -207,6 +207,17 @@ class RegistrationTest(TestCase):
         with self.assertRaises(ValidationError):
             self.registration.clean()
 
+    def test_require_past_birthday(self):
+        registration = Registration.objects.create(
+            length=Entry.MEMBERSHIP_YEAR,
+            first_name="John",
+            last_name="Doe",
+            birthday=timezone.now().date() + timezone.timedelta(weeks=52),
+        )
+
+        with self.assertRaises(ValidationError):
+            registration.clean()
+
     def test_unique_student_number_user(self):
         self.registration.student_number = "s1234567"
         self.registration.clean()


### PR DESCRIPTION
Closes #2856.

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Fixed bug that allows people to register with a birthday which was in the future

### How to test
Steps to test the changes you made:
1. Go to the become a member page
2. Try to make yourself a member with a birthday in the future
3. Try again but make the birthday possible
