### PR TITLE
Pregenerate thumbnails for photo albums

### DIFF
--- a/website/photos/models.py
+++ b/website/photos/models.py
@@ -44,7 +44,9 @@ class Photo(models.Model):
         "Album", on_delete=models.CASCADE, verbose_name=_("album")
     )
 
-    file = ImageField(_("file"), upload_to=photo_uploadto)
+    file = ImageField(
+        _("file"), upload_to=photo_uploadto, pregenerated_sizes=["medium"]
+    )
 
     rotation = models.IntegerField(
         verbose_name=_("rotation"),


### PR DESCRIPTION
### Summary
Pregenerate thumbnails for photo albums

### How to test
1. Upload a new album with a lot of photos.
2. Saving the album should be slower now, but loading the album for the first time should be fast