### PR TITLE
Fix 500 on edit-information-fields admin

### DIFF
--- a/website/events/admin/views.py
+++ b/website/events/admin/views.py
@@ -66,7 +66,7 @@ class RegistrationAdminFields(FormView):
                 "change": True,
                 "has_view_permission": True,
                 "has_add_permission": False,
-                "has_change_permission": self.request.user.has_perms(
+                "has_change_permission": self.request.user.has_perm(
                     "events.change_eventregistration"
                 ),
                 "has_delete_permission": False,
@@ -143,7 +143,7 @@ class EventMessage(FormView):
                 "change": True,
                 "has_view_permission": True,
                 "has_add_permission": False,
-                "has_change_permission": self.request.user.has_perms(
+                "has_change_permission": self.request.user.has_perm(
                     "events.change_event"
                 ),
                 "has_delete_permission": False,


### PR DESCRIPTION
Closes #2861.

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
For some reason we only now found out about a typo `has_perms` instead of `has_perm` that completely breaks a view. 

### How to test
Steps to test the changes you made:
1. Try opening the view (http://127.0.0.1:8000/admin/events/eventregistration/1/fields/)
