### PR TITLE
Add /.well-known/assetlinks.json (verified Android app links)

### DIFF
--- a/concrexit-server.nix
+++ b/concrexit-server.nix
@@ -297,6 +297,10 @@ in
             alias = ./infra/resources/apple-app-site-association.json;
             extraConfig = "default_type application/json;";
           };
+          locations."= /.well-known/assetlinks.json" = {
+            alias = ./infra/resources/assetlinks.json;
+            extraConfig = "default_type application/json;";
+          };
           locations."/.well-known/change-password" = {
             # Implementing https://github.com/WICG/change-password-url
             return = "301 https://$host/user/password_change/";

--- a/infra/resources/assetlinks.json
+++ b/infra/resources/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.thaliapp",
+      "sha256_cert_fingerprints": [
+        "25:F7:06:CA:04:36:32:62:87:10:7C:59:84:5E:A0:E7:68:A4:DD:80:E1:CF:EB:30:96:3C:B1:CC:CF:E4:32:16"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Closes #2679 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I added the file as described by Dirk in the issue.

### How to test
Steps to test the changes you made:
- deploy on staging
- ???
- profit

This is because I am not sure how deployment works, and it seems this part of the nginx config is still going through NixOS on both staging and production, seeing as running the website via `docker-compose up` does not pass through these files. This should probably be fixed independently.