### PR TITLE
2915 make model graph a make target instead of ci workflow

### DIFF
--- a/.github/workflows/generate_models_graph.yaml
+++ b/.github/workflows/generate_models_graph.yaml
@@ -37,18 +37,30 @@ jobs:
         run: sudo apt install graphviz
 
       - name: Generate full_models_graph.png
+        id: full_model_generation
         run: poetry run website/manage.py graph_models --pydot -a -g -o full_models_graph.png
 
+      - name: Handle flakiness
+        if: steps.full_model_generation.outcome != 'success'
+        run: echo "Failed to generate full models graph"
+
       - name: Save full_models_graph.png
+        if: steps.full_model_generation.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: full_models_graph.png
           path: ./full_models_graph.png
 
       - name: Generate partial_models_graph.png
+        id: partial_model_generation
         run:  poetry run website/manage.py graph_models --pydot -X LogEntry,ContentType,Permission,PermissionsMixin,AbstractUser,AbstractBaseUser,Group -o partial_models_graph.png
 
+      - name: Handle flakiness
+        if: steps.partial_model_generation.outcome != 'success'
+        run: echo "Failed to generate partial models graph"
+
       - name: Save partial_models_graph.png
+        if: steps.partial_models_graph.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: partial_models_graph.png

--- a/.github/workflows/generate_models_graph.yaml
+++ b/.github/workflows/generate_models_graph.yaml
@@ -60,7 +60,7 @@ jobs:
         run: echo "Failed to generate partial models graph"
 
       - name: Save partial_models_graph.png
-        if: steps.partial_models_graph.outcome == 'success'
+        if: steps.partial_model_generation.outcome == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: partial_models_graph.png

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,13 @@ docs: ## Generate docs HTML files
 apidocscheck: apidocs # Check whether new apidocs are generated
 	@git diff --name-only | grep 'docs/' >/dev/null && (echo "WARNING: you have uncommitted apidocs changes"; exit 1) || exit 0
 
+.PHONY: graphs
+graphs: ## Generate model graphs
+	@echo "Generating full models graph"
+	@poetry run website/manage.py graph_models --pydot -a -g -o full_models_graph.png
+	@echo "Generating partial models graph"
+	@poetry run website/manage.py graph_models --pydot -X LogEntry,ContentType,Permission,PermissionsMixin,AbstractUser,AbstractBaseUser,Group -o partial_models_graph.png
+
 .make/docker: .make
 	docker build $(DOCKER_FLAGS) --build-arg "source_commit=$$(git rev-parse HEAD)" --tag "thalia/concrexit:$$(git rev-parse HEAD)" .
 


### PR DESCRIPTION
Closes #2915

### Summary
Catch failure in workflow
Create `make graphs` command in Makefile

### How to test
Steps to test the changes you made:
1. Check action, when it would have failed (flaky) it should now log failure and continue.
2. Run make graphs, the two new images should appear in the root folder.
