### PR TITLE
Reintroduce organiser inline in EventAdmin

### DIFF
--- a/website/events/admin/event.py
+++ b/website/events/admin/event.py
@@ -40,6 +40,7 @@ class EventAdmin(DoNextModelAdmin):
         "event_date",
         "registration_date",
         "num_participants",
+        "get_organisers",
         "category",
         "published",
         "edit_link",
@@ -108,7 +109,12 @@ class EventAdmin(DoNextModelAdmin):
     )
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_properties("participant_count")
+        return (
+            super()
+            .get_queryset(request)
+            .select_properties("participant_count")
+            .prefetch_related("organisers")
+        )
 
     def get_form(self, request, obj=None, change=False, **kwargs):
         form = super().get_form(request, obj, change, **kwargs)
@@ -160,6 +166,11 @@ class EventAdmin(DoNextModelAdmin):
         return f"{num}/{obj.max_participants}"
 
     num_participants.short_description = _("Number of participants")
+
+    def get_organisers(self, obj):
+        return ", ".join(str(o) for o in obj.organisers.all())
+
+    get_organisers.short_description = _("Organisers")
 
     def make_published(self, request, queryset):
         """Change the status of the event to published."""


### PR DESCRIPTION
Closes #2889 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The events list in the admin now shows a list of organisers, similar to before there were multiple organisers and it showed one organiser.

I also prefetch the organiser to prevent large amounts of queries.

### How to test
Steps to test the changes you made:
1. Go to `/admin/events/event/`
2. Observe that there is now a comma-separated list of organisers for each event
3. Check that there's not an excessive amount of queries (15 is the right amount)
