### PR TITLE
API event slug support

### DIFF
--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.reverse import reverse
 
 from activemembers.api.v2.serializers.member_group import MemberGroupSerializer
 from documents.api.v2.serializers.document import DocumentSerializer
@@ -21,6 +22,7 @@ class EventSerializer(CleanedModelSerializer):
         fields = (
             "pk",
             "slug",
+            "url",
             "title",
             "description",
             "caption",
@@ -58,6 +60,7 @@ class EventSerializer(CleanedModelSerializer):
     fine = PaymentAmountSerializer()
     documents = DocumentSerializer(many=True)
     user_permissions = serializers.SerializerMethodField("_user_permissions")
+    url = serializers.SerializerMethodField("_url")
 
     def _user_registration(self, instance: Event):
         if self.context["request"].member and len(instance.member_registration) > 0:
@@ -101,6 +104,19 @@ class EventSerializer(CleanedModelSerializer):
     def _user_permissions(self, instance):
         member = self.context["request"].member
         return services.event_permissions(member, instance, registration_prefetch=True)
+
+    def _url(self, instance: Event):
+        if instance.slug is None:
+            return reverse(
+                "events:event",
+                kwargs={"pk": instance.pk},
+                request=self.context["request"],
+            )
+        return reverse(
+            "events:event",
+            kwargs={"slug": instance.slug},
+            request=self.context["request"],
+        )
 
     def _maps_url(self, instance):
         return create_google_maps_url(instance.map_location, zoom=13, size="450x250")

--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -20,6 +20,7 @@ class EventSerializer(CleanedModelSerializer):
         model = Event
         fields = (
             "pk",
+            "slug",
             "title",
             "description",
             "caption",

--- a/website/events/api/v2/urls.py
+++ b/website/events/api/v2/urls.py
@@ -22,6 +22,11 @@ urlpatterns = [
         name="event-detail",
     ),
     path(
+        "events/<slug:slug>/",
+        EventDetailView.as_view(lookup_field="slug"),
+        name="event-detail",
+    ),
+    path(
         "events/<int:pk>/registrations/",
         EventRegistrationsView.as_view(),
         name="event-registrations",


### PR DESCRIPTION
Closes #2929

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The API now has basic support for event slugs, which is important for the app to support deeplinks.

### How to test
Steps to test the changes you made:
1. Go to /api/v2/events/<slug> for an event with a slug
2. See that you get the correct event
3. Observe that the URL is now also provided
