### PR TITLE
Add Career Central link to base.html

### DIFF
--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -255,6 +255,9 @@
             <a target="_blank" rel="noopener" href="https://github.com/svthalia/" title="GitHub page for Thalia">
                 <i aria-hidden="true" class="fab fa-github"></i>
             </a>
+            <a target="_blank" rel="noopener" href="https://ru.nxus.nl/student/group/0b242b79-01a4-4502-a582-8a0327676a2b" title="Career Central page for Thalia">
+                <i aria-hidden="true" class="fas fa-graduation-cap"></i>
+            </a>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Closes #2921

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I added a link to Career Central in base.html. I used the `graduationcap` icon from [FontAwesome](https://fontawesome.com/icons)
![image](https://user-images.githubusercontent.com/7569492/228645844-c8b4889a-cacb-4dbf-8da4-a457101be2ba.png)

I'm not sure if this is the best icon, for example `briefcase` might also be suitable. @timkersten655 what do you say? (You can find the available icons at the link, do be careful that we can only use free icons.)

### How to test
Steps to test the changes you made:
1. Go to any page
2. Scroll down
3. Click the link
