### PR TITLE
Fix event cancellation and other mail improvements

### DIFF
--- a/website/activemembers/admin.py
+++ b/website/activemembers/admin.py
@@ -46,7 +46,7 @@ class MemberGroupAdmin(admin.ModelAdmin):
 
     inlines = (MemberGroupMembershipInline,)
     form = MemberGroupForm
-    list_display = ("name", "since", "until", "active", "email")
+    list_display = ("name", "since", "until", "active", "contact_address")
     list_filter = (
         "until",
         "active",
@@ -66,14 +66,6 @@ class MemberGroupAdmin(admin.ModelAdmin):
         "active",
         "display_members",
     )
-
-    @staticmethod
-    def email(instance):
-        if instance.contact_email:
-            return instance.contact_email
-        if instance.contact_mailinglist:
-            return instance.contact_mailinglist.name + "@thalia.nu"
-        return None
 
 
 @admin.register(models.Committee)

--- a/website/activemembers/models.py
+++ b/website/activemembers/models.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 
 from django.conf import settings
+from django.contrib.admin import display as admin_display
 from django.contrib.auth.models import Permission
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.core.validators import MinValueValidator
@@ -95,6 +96,7 @@ class MemberGroup(models.Model):
     )
 
     @property
+    @admin_display(description=_("email"))
     def contact_address(self):
         if self.contact_mailinglist:
             return f"{self.contact_mailinglist.name}@{settings.SITE_DOMAIN}"

--- a/website/events/admin/forms.py
+++ b/website/events/admin/forms.py
@@ -53,29 +53,6 @@ class RegistrationInformationFieldForm(forms.ModelForm):
 
 
 class EventAdminForm(forms.ModelForm):
-    def is_valid(self):
-        valid = super().is_valid()
-        if not valid:
-            return valid
-
-        if (
-            self.cleaned_data.get("organisers")
-            and not any(
-                organiser.contact_address is not None
-                for organiser in self.cleaned_data["organisers"]
-            )
-            and self.cleaned_data["send_cancel_email"]
-        ):
-            self.add_error(
-                "organisers",
-                _(
-                    "One of the organisers does not have a contact mail address so sending a cancellation email is impossible."
-                ),
-            )
-            return False
-
-        return True
-
     def clean(self):
         super().clean()
         self.instance.clean_changes(self.changed_data)

--- a/website/events/admin/forms.py
+++ b/website/events/admin/forms.py
@@ -61,7 +61,7 @@ class EventAdminForm(forms.ModelForm):
         if (
             self.cleaned_data.get("organisers")
             and not any(
-                organiser.contact_mailinglist is not None
+                organiser.contact_address is not None
                 for organiser in self.cleaned_data["organisers"]
             )
             and self.cleaned_data["send_cancel_email"]
@@ -69,7 +69,7 @@ class EventAdminForm(forms.ModelForm):
             self.add_error(
                 "organisers",
                 _(
-                    "One of the organisers does not have a contact mailinglist so sending a cancellation email is impossible."
+                    "One of the organisers does not have a contact mail address so sending a cancellation email is impossible."
                 ),
             )
             return False

--- a/website/events/emails.py
+++ b/website/events/emails.py
@@ -51,7 +51,7 @@ def notify_organiser(event, registration):
 
     send_email(
         to=[
-            organiser.contact_address + "@" + settings.SITE_DOMAIN
+            organiser.contact_address
             for organiser in event.organisers.all()
             if organiser.contact_address is not None
         ],

--- a/website/events/emails.py
+++ b/website/events/emails.py
@@ -51,8 +51,9 @@ def notify_organiser(event, registration):
 
     send_email(
         to=[
-            organiser.contact_mailinglist.name + "@" + settings.SITE_DOMAIN
+            organiser.contact_address + "@" + settings.SITE_DOMAIN
             for organiser in event.organisers.all()
+            if organiser.contact_address is not None
         ],
         subject=f"Registration for {event.title} cancelled by member",
         txt_template="events/email/organiser_email.txt",

--- a/website/events/emails.py
+++ b/website/events/emails.py
@@ -20,9 +20,7 @@ def notify_first_waiting(event):
         ).order_by("date")[event.max_participants]
 
         organiser_emails = [
-            organiser.contact_address
-            for organiser in event.organisers.all()
-            if organiser.contact_address is not None
+            organiser.contact_address for organiser in event.organisers.all()
         ]
 
         send_email(
@@ -50,11 +48,7 @@ def notify_organiser(event, registration):
         return
 
     send_email(
-        to=[
-            organiser.contact_address
-            for organiser in event.organisers.all()
-            if organiser.contact_address is not None
-        ],
+        to=[organiser.contact_address for organiser in event.organisers.all()],
         subject=f"Registration for {event.title} cancelled by member",
         txt_template="events/email/organiser_email.txt",
         html_template="events/email/organiser_email.html",
@@ -64,9 +58,7 @@ def notify_organiser(event, registration):
 
 def notify_waiting(event, registration):
     organiser_emails = [
-        organiser.contact_address
-        for organiser in event.organisers.all()
-        if organiser.contact_address is not None
+        organiser.contact_address for organiser in event.organisers.all()
     ]
 
     send_email(

--- a/website/mailinglists/services.py
+++ b/website/mailinglists/services.py
@@ -164,10 +164,8 @@ def get_automatic_lists():
             "description": "Automatic moderated mailinglist that is a "
             "collection of all committee lists",
             "addresses": [
-                f"{c.contact_mailinglist.name}@{settings.GSUITE_DOMAIN}"
-                for c in Committee.objects.exclude(
-                    contact_mailinglist=None
-                ).select_related("contact_mailinglist")
+                c.contact_address
+                for c in Committee.objects.all().select_related("contact_mailinglist")
             ],
             "moderated": True,
         },
@@ -176,10 +174,8 @@ def get_automatic_lists():
             "description": "Automatic moderated mailinglist that is a "
             "collection of all society lists",
             "addresses": [
-                f"{c.contact_mailinglist.name}@{settings.GSUITE_DOMAIN}"
-                for c in Society.objects.exclude(
-                    contact_mailinglist=None
-                ).select_related("contact_mailinglist")
+                c.contact_address
+                for c in Society.objects.all().select_related("contact_mailinglist")
             ],
             "moderated": True,
         },


### PR DESCRIPTION
Closes #2964 and does some code cleanup

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
- Event emails (about late event cancellation etc) now uses contact_address instead of contact_mailinglist so that all member groups can now be reached. This also means no None checking is necessary because this field is always true: we verify in `clean()` that there is either a mailinglist or an address.
- Remove check for organisers without contact mailing list because we can now also mail the contact address.
- Remove some duplicate code in the admin, which does change shown email addresses on staging and localhost
- The `committees` and `societies` mailinglists now include membergroups with contact_email rather than contact_mailinglist set.

### How to test
Steps to test the changes you made:
1. Create an event with some organisers that do not have a mailing list associated with them, and cancellation notifications enabled.
2. Observe that you can now cancel from this event, unlike before.
3. Also observe that committees and societies still have correct email addresses in the admin list display. (Note that thalia.nu may be replaced by thalia.localhost, this is because it uses the SITE_DOMAIN.)
4. Somehow check that the mailinglist integration still reports the correct email addresses. I am not sure how to do this (@JobDoesburg do you maybe know this?)