### PR TITLE
Remove storage url timing span

### DIFF
--- a/website/utils/media/views.py
+++ b/website/utils/media/views.py
@@ -10,7 +10,6 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.utils import timezone
 
-import sentry_sdk
 from django_sendfile import sendfile
 
 
@@ -57,11 +56,7 @@ def private_media(request, request_path):
 
     # Serve the file, or redirect to a signed bucket url in the case of S3
     if hasattr(storage, "bucket"):
-        with sentry_sdk.start_span(
-            op="generate_private_media_url",
-            description="Generate the presigned s3 url for a media file",
-        ) as span:
-            serve_url = storage.url(sig_info["serve_path"])
+        serve_url = storage.url(sig_info["serve_path"])
         return redirect(
             f"{serve_url}",
             permanent=False,


### PR DESCRIPTION
S3 is fast now, no longer need to investigate its performance with sentry.
