### PR TITLE
Fix photo ordering lost after select_properties

### DIFF
--- a/website/photos/api/v2/views.py
+++ b/website/photos/api/v2/views.py
@@ -50,6 +50,10 @@ class AlbumDetailView(RetrieveAPIView):
             photos = photos.annotate(
                 member_likes=Count("likes", filter=Q(likes__member=self.request.member))
             )
+
+        # Fix select_properties dropping the default ordering.
+        photos = photos.order_by("pk")
+
         return Album.objects.filter(hidden=False).prefetch_related(
             Prefetch("photo_set", queryset=photos)
         )

--- a/website/photos/urls.py
+++ b/website/photos/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
                     "<slug>/",
                     include(
                         [
-                            path("", views.detail, name="album"),
+                            path("", views.AlbumDetailView.as_view(), name="album"),
                             path(
                                 "download/",
                                 include(
@@ -40,7 +40,11 @@ urlpatterns = [
                                     ]
                                 ),
                             ),
-                            path("<token>/", views.shared_album, name="shared-album"),
+                            path(
+                                "<token>/",
+                                views.SharedAlbumView.as_view(),
+                                name="shared-album",
+                            ),
                         ]
                     ),
                 ),


### PR DESCRIPTION
Closes #2903.

I hope and expect it also works for #2878.

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This explicitly adds order_by after `select_properties`. And it refactors the album view to use class-based views.

### How to test
Steps to test the changes you made:
1. Open some albums in the views and the API.
2. Check that they're order by pk/filename, even if there are many likes on some photos.