### PR TITLE
Add nowrap to event admin table header

### DIFF
--- a/website/events/static/events/css/admin.scss
+++ b/website/events/static/events/css/admin.scss
@@ -67,6 +67,7 @@
 
 th.sortable {
     outline: none;
+    white-space: nowrap;
 
     &:hover {
         background-color: var(--selected-bg);


### PR DESCRIPTION
Closes #2967 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Add `white-space: nowrap` to `th` in `admin.scss` in events.

### How to test
Steps to test the changes you made:
1. Go to event detail page
2. It doesn't look scuffed:
![image](https://user-images.githubusercontent.com/7569492/231549534-d97ba616-457c-419c-9bef-2db85548cd74.png)

