### PR TITLE
Prefetch thumbnail metadata from database

### DIFF
--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -120,3 +120,37 @@ class EventSerializer(CleanedModelSerializer):
 
     def _maps_url(self, instance):
         return create_google_maps_url(instance.map_location, zoom=13, size="450x250")
+
+
+class EventListSerializer(EventSerializer):
+    class Meta:
+        model = Event
+        fields = (
+            "pk",
+            "slug",
+            "url",
+            "title",
+            "description",
+            "caption",
+            "start",
+            "end",
+            "category",
+            "registration_start",
+            "registration_end",
+            "cancel_deadline",
+            "optional_registrations",
+            "location",
+            "price",
+            "fine",
+            "num_participants",
+            "max_participants",
+            "no_registration_message",
+            "registration_status",
+            "cancel_too_late_message",
+            "has_fields",
+            "food_event",
+            "maps_url",
+            "user_permissions",
+            "user_registration",
+            "documents",
+        )

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -25,6 +25,7 @@ from events.models.external_event import ExternalEvent
 from events.services import is_user_registered
 from thaliawebsite.api.v2.permissions import IsAuthenticatedOrTokenHasScopeForMethod
 from thaliawebsite.api.v2.serializers import EmptySerializer
+from utils.media.services import fetch_thumbnails_db
 
 
 class EventListView(ListAPIView):
@@ -123,6 +124,11 @@ class EventRegistrationsView(ListAPIView):
                 event=self.event, date_cancelled=None
             ).select_related("member__profile")[: self.event.max_participants]
         return EventRegistration.objects.none()
+
+    def get_serializer(self, registrations=None, *args, **kwargs):
+        if registrations:
+            fetch_thumbnails_db([r.member.profile.photo for r in registrations])
+        return super().get_serializer(registrations, *args, **kwargs)
 
     def initial(self, request, *args, **kwargs):
         """Run anything that needs to occur prior to calling the method handler."""

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -125,10 +125,11 @@ class EventRegistrationsView(ListAPIView):
             ).select_related("member__profile")[: self.event.max_participants]
         return EventRegistration.objects.none()
 
-    def get_serializer(self, registrations=None, *args, **kwargs):
-        if registrations:
+    def get_serializer(self, *args, **kwargs):
+        if len(args) > 0:
+            registrations = args[0]
             fetch_thumbnails_db([r.member.profile.photo for r in registrations])
-        return super().get_serializer(registrations, *args, **kwargs)
+        return super().get_serializer(*args, **kwargs)
 
     def initial(self, request, *args, **kwargs):
         """Run anything that needs to occur prior to calling the method handler."""

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -16,7 +16,7 @@ from rest_framework.views import APIView
 
 from events import services
 from events.api.v2 import filters
-from events.api.v2.serializers.event import EventSerializer
+from events.api.v2.serializers.event import EventListSerializer, EventSerializer
 from events.api.v2.serializers.event_registration import EventRegistrationSerializer
 from events.api.v2.serializers.external_event import ExternalEventSerializer
 from events.exceptions import RegistrationError
@@ -30,7 +30,7 @@ from thaliawebsite.api.v2.serializers import EmptySerializer
 class EventListView(ListAPIView):
     """Returns an overview of all upcoming events."""
 
-    serializer_class = EventSerializer
+    serializer_class = EventListSerializer
     filter_backends = (
         framework_filters.OrderingFilter,
         framework_filters.SearchFilter,

--- a/website/events/views.py
+++ b/website/events/views.py
@@ -14,6 +14,7 @@ from events.exceptions import RegistrationError
 from events.models import categories
 from events.services import is_user_registered
 from payments.models import Payment
+from utils.media.services import fetch_thumbnails_db
 
 from .forms import FieldsForm
 from .models import Event, EventRegistration
@@ -41,7 +42,7 @@ class EventDetail(DetailView):
     """Render a single event detail page."""
 
     model = Event
-    queryset = Event.objects.filter(published=True)
+    queryset = Event.objects.filter(published=True).prefetch_related("organisers")
     template_name = "events/event.html"
     context_object_name = "event"
 
@@ -85,6 +86,8 @@ class EventDetail(DetailView):
         context["participants"] = event.participants.select_related(
             "member", "member__profile"
         )
+
+        fetch_thumbnails_db([p.member.profile.photo for p in context["participants"]])
 
         return context
 

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -22,15 +22,15 @@ class MemberListView(ListAPIView):
     """Returns an overview of all members."""
 
     serializer_class = MemberListSerializer
+    queryset = (
+        Member.current_members.all()
+        .select_related("profile")
+        .prefetch_related("membership_set")
+    )
 
-    def get_queryset(self):
-        members = (
-            Member.current_members.all()
-            .select_related("profile")
-            .prefetch_related("membership_set")
-        )
+    def get_serializer(self, members, *args, **kwargs):
         fetch_thumbnails_db([member.profile.photo for member in members])
-        return members
+        return super().get_serializer(members, *args, **kwargs)
 
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -15,13 +15,23 @@ from members.api.v2.serializers.member import (
 from members.models import Member
 from thaliawebsite.api.openapi import OAuthAutoSchema
 from thaliawebsite.api.v2.permissions import IsAuthenticatedOrTokenHasScopeForMethod
+from utils.media.services import fetch_thumbnails_db
 
 
 class MemberListView(ListAPIView):
     """Returns an overview of all members."""
 
     serializer_class = MemberListSerializer
-    queryset = Member.current_members.all().select_related("profile")
+
+    def get_queryset(self):
+        members = (
+            Member.current_members.all()
+            .select_related("profile")
+            .prefetch_related("membership_set")
+        )
+        fetch_thumbnails_db([member.profile.photo for member in members])
+        return members
+
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
     ]

--- a/website/members/views.py
+++ b/website/members/views.py
@@ -25,6 +25,7 @@ from members import emails, services
 from members.decorators import membership_required
 from members.models import EmailChange, Member, Membership, Profile
 from thaliawebsite.views import PagedView
+from utils.media.services import fetch_thumbnails_db
 from utils.snippets import datetime_to_lectureyear
 
 from . import models
@@ -123,11 +124,13 @@ class MembersIndex(PagedView):
         else:
             memberships = Membership.objects.filter(memberships_query)
             members_query &= Q(pk__in=memberships.values("user__pk"))
-        return (
+        members = (
             Member.objects.filter(members_query)
             .order_by("first_name")
             .select_related("profile")
         )
+        fetch_thumbnails_db([member.profile.photo for member in members])
+        return members
 
     def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)

--- a/website/partners/api/v2/views.py
+++ b/website/partners/api/v2/views.py
@@ -7,6 +7,7 @@ from partners.api.v2.serializers import VacancyCategorySerializer
 from partners.api.v2.serializers.partner import PartnerSerializer
 from partners.api.v2.serializers.vacancy import VacancySerializer
 from partners.models import Partner, Vacancy, VacancyCategory
+from utils.media.services import fetch_thumbnails_db
 
 
 class PartnerListView(ListAPIView):
@@ -18,6 +19,11 @@ class PartnerListView(ListAPIView):
         framework_filters.OrderingFilter,
         framework_filters.SearchFilter,
     )
+
+    def get_serializer(self, partners, *args, **kwargs):
+        fetch_thumbnails_db([partner.logo for partner in partners])
+        return super().get_serializer(partners, *args, **kwargs)
+
     ordering_fields = ("name", "pk")
     search_fields = ("name",)
     permission_classes = [IsAuthenticatedOrTokenHasScope]

--- a/website/partners/templatetags/frontpage_vacancies.py
+++ b/website/partners/templatetags/frontpage_vacancies.py
@@ -10,7 +10,7 @@ register = template.Library()
 def render_frontpage_vacancies():
     vacancies = []
 
-    for vacancy in Vacancy.objects.order_by("?")[:6]:
+    for vacancy in Vacancy.objects.order_by("?")[:6].select_related("partner"):
         url = f"{reverse('partners:vacancies')}#vacancy-{vacancy.id}"
         if vacancy.partner and vacancy.partner.is_active:
             url = f"{vacancy.partner.get_absolute_url()}#vacancy-{vacancy.id}"

--- a/website/partners/templatetags/partner_banners.py
+++ b/website/partners/templatetags/partner_banners.py
@@ -3,6 +3,7 @@ from random import sample
 from django import template
 
 from partners.models import Partner
+from utils.media.services import fetch_thumbnails_db
 
 register = template.Library()
 
@@ -28,7 +29,13 @@ def render_partner_banners(context):
     chosen, rest = sequence[:4], sequence[4:]
     request.session["partner_sequence"] = rest + chosen
 
+    partners = [p for p in all_partners if p.id in chosen]
+    fetch_thumbnails_db(
+        [p.alternate_logo or p.logo for p in partners],
+        settings.THUMBNAIL_SIZES["medium"],
+    )
+
     return {
-        "partners": [p for p in all_partners if p.id in chosen],
+        "partners": partners,
         "thumb_size": "medium",
     }

--- a/website/partners/templatetags/partner_banners.py
+++ b/website/partners/templatetags/partner_banners.py
@@ -32,7 +32,7 @@ def render_partner_banners(context):
     partners = [p for p in all_partners if p.id in chosen]
     fetch_thumbnails_db(
         [p.alternate_logo or p.logo for p in partners],
-        settings.THUMBNAIL_SIZES["medium"],
+        "medium",
     )
 
     return {

--- a/website/partners/views.py
+++ b/website/partners/views.py
@@ -3,6 +3,7 @@ from random import random
 from django.shortcuts import get_object_or_404, render
 
 from partners.models import Partner, Vacancy, VacancyCategory
+from utils.media.services import fetch_thumbnails_db
 
 
 def index(request):
@@ -12,6 +13,8 @@ def index(request):
     )
     main_partner = Partner.objects.filter(is_main_partner=True).first()
     local_partners = Partner.objects.filter(is_local_partner=True)
+
+    fetch_thumbnails_db([p.logo for p in partners])
 
     context = {
         "main_partner": main_partner,
@@ -33,12 +36,14 @@ def partner(request, slug):
 
 def vacancies(request):
     """View to show vacancies."""
+    vacancies = list(
+        Vacancy.objects.order_by("?")
+        .select_related("partner")
+        .prefetch_related("categories")
+    )
+    fetch_thumbnails_db(v.get_company_logo() for v in vacancies)
     context = {
-        "vacancies": list(
-            Vacancy.objects.order_by("?")
-            .select_related("partner")
-            .prefetch_related("categories")
-        ),
+        "vacancies": vacancies,
         "categories": list(VacancyCategory.objects.all()),
     }
 

--- a/website/photos/api/v2/views.py
+++ b/website/photos/api/v2/views.py
@@ -22,10 +22,11 @@ class AlbumListView(ListAPIView):
 
     serializer_class = AlbumListSerializer
 
-    def get_queryset(self):
-        albums = Album.objects.filter(hidden=False)
+    def get_serializer(self, albums, *args, **kwargs):
         fetch_thumbnails_db([album.cover.file for album in albums if album.cover])
-        return albums
+        return super().get_serializer(albums, *args, **kwargs)
+
+    queryset = Album.objects.filter(hidden=False).select_related("_cover")
 
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,

--- a/website/photos/views.py
+++ b/website/photos/views.py
@@ -35,7 +35,7 @@ class IndexView(LoginRequiredMixin, PagedView):
             albums = albums.filter(**{"title__icontains": key})
         albums = get_annotated_accessible_albums(self.request, albums)
         albums = albums.order_by("-date")
-        fetch_thumbnails_db([x.cover.file for x in albums])
+        fetch_thumbnails_db([x.cover.file for x in albums if x.cover])
 
         return albums
 

--- a/website/photos/views.py
+++ b/website/photos/views.py
@@ -13,7 +13,7 @@ from photos.services import (
     is_album_accessible,
 )
 from thaliawebsite.views import PagedView
-from utils.media.services import get_media_url
+from utils.media.services import fetch_thumbnails_db, get_media_url
 
 COVER_FILENAME = "cover.jpg"
 
@@ -35,6 +35,8 @@ class IndexView(LoginRequiredMixin, PagedView):
             albums = albums.filter(**{"title__icontains": key})
         albums = get_annotated_accessible_albums(self.request, albums)
         albums = albums.order_by("-date")
+        fetch_thumbnails_db([x.cover.file for x in albums])
+
         return albums
 
     def get_context_data(self, **kwargs):
@@ -59,6 +61,9 @@ class _BaseAlbumView(TemplateView):
 
         # Fix select_properties dropping the default ordering.
         photos = photos.order_by("pk")
+
+        # Prefetch thumbnails for efficiency
+        fetch_thumbnails_db([p.file for p in photos])
 
         context["photos"] = photos
         return context
@@ -132,9 +137,11 @@ class LikedPhotoView(LoginRequiredMixin, PagedView):
     context_object_name = "photos"
 
     def get_queryset(self):
-        return (
+        photos = (
             Photo.objects.filter(likes__member=self.request.member, album__hidden=False)
             .select_related("album")
             .select_properties("num_likes")
             .order_by("-album__date")
         )
+        fetch_thumbnails_db([p.file for p in photos])
+        return photos

--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -85,7 +85,8 @@ def fetch_thumbnails_db(images, sizes=None):
 
     :param images: A list of images to prefetch thumbnails for.
     :param sizes: A list of sizes to prefetch. If None, all sizes will be prefetched.
-    :return: None"""
+    :return: None
+    """
     if not images:
         return
 

--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -81,6 +81,11 @@ def get_thumbnail_url(
 
 
 def fetch_thumbnails_db(images, sizes=None):
+    """Prefetches thumbnails from the database in one query.
+
+    :param images: A list of images to prefetch thumbnails for.
+    :param sizes: A list of sizes to prefetch. If None, all sizes will be prefetched.
+    :return: None"""
     if not images:
         return
 

--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -6,8 +6,10 @@ from django.core.files.storage import DefaultStorage
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db.models.fields.files import FieldFile, ImageFieldFile
 
+from thumbnails.backends.metadata import ImageMeta
 from thumbnails.files import ThumbnailedImageFile
 from thumbnails.images import Thumbnail
+from thumbnails.models import ThumbnailMeta
 
 
 def save_image(storage, image, path, format):
@@ -76,3 +78,26 @@ def get_thumbnail_url(
                 )
 
     return get_media_url(file, absolute_url=absolute_url)
+
+
+def fetch_thumbnails_db(images, sizes=None):
+    if not images:
+        return
+
+    image_dict = {image.thumbnails.source_image.name: image for image in images}
+    thumbnails = ThumbnailMeta.objects.select_related("source").filter(
+        source__name__in=image_dict.keys()
+    )
+    if sizes:
+        thumbnails.filter(size__in=sizes)
+
+    for thumb in thumbnails:
+        source_name = thumb.source.name
+
+        thumbnails = image_dict[source_name].thumbnails
+        if not thumbnails._thumbnails:
+            thumbnails._thumbnails = {}
+        image_meta = ImageMeta(source_name, thumb.name, thumb.size)
+        thumbnails._thumbnails[thumb.size] = Thumbnail(
+            image_meta, storage=thumbnails.storage
+        )


### PR DESCRIPTION
Closes #2986 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I created a function that prefetches thumbnail metadata from the database for a list of images.

### TODO
This function still needs to be used in more places, and the relevant size limit also needs to be added when calling the function like in members/views.py

### How to test
Steps to test the changes you made:
1. Go to `/members/directory/`
2. Open the query list in the debug toolbar
3. See one big query instead of many small ones for fetching thumbnail info:
![image](https://user-images.githubusercontent.com/7569492/231566990-72876c21-b0ba-43c0-a180-fdfbb30bc856.png)

(Note: it would be better if we could fetch these in-line, but that's probably not going to happen and this single big query is still a massive improvement.)
