### PR TITLE
Fix newsletter image urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Optional, but recommended: follow the tutorial! It can be found by going to the 
 
 Pillow dependencies are used for the thumbnail generation. The website will give lots of errors and work weirdly if you don't install these native dependencies.
 
-The Thabloid dependencies are less important. If you don't intall them, the only thing that doesn't work is creating Thabloid cover images.
-
 ### Pillow dependencies
 
 For Ubuntu, use:

--- a/website/activemembers/templates/activemembers/board_index.html
+++ b/website/activemembers/templates/activemembers/board_index.html
@@ -24,7 +24,7 @@
                 <a href="{{ current_board.get_absolute_url }}" class="current-board col-12 text-center">
                     {% if current_board.photo %}
                         <img alt="{{ current_board.name }}"
-                             src="{% thumbnail current_board.photo THUMBNAIL_SIZE_LARGE fit=False %}">
+                             src="{% thumbnail current_board.photo THUMBNAIL_SIZE_LARGE %}">
                     {% else %}
                         <img alt="{{ current_board.name }}"
                              src="/static/activemembers/images/placeholder.png">

--- a/website/activemembers/templates/activemembers/membergroup_detail.html
+++ b/website/activemembers/templates/activemembers/membergroup_detail.html
@@ -12,7 +12,7 @@
             <div class="row align-items-start">
                 {% if membergroup.photo %}
                     <img alt="{{ membergroup.name }}" class="col-12"
-                         src="{% thumbnail membergroup.photo THUMBNAIL_SIZE_LARGE fit=False %}">
+                         src="{% thumbnail membergroup.photo THUMBNAIL_SIZE_LARGE %}">
                 {% else %}
                     <img alt="{{ membergroup.name }}" class="col-12"
                          src="/static/activemembers/images/placeholder.png">

--- a/website/activemembers/templatetags/activemembers_cards.py
+++ b/website/activemembers/templatetags/activemembers_cards.py
@@ -14,7 +14,7 @@ register = template.Library()
 def membergroup_card(group):
     image_url = static("activemembers/images/placeholder_overview.png")
     if group.photo:
-        image_url = get_thumbnail_url(group.photo, settings.THUMBNAIL_SIZES["medium"])
+        image_url = get_thumbnail_url(group.photo, "medium")
 
     return grid_item(
         title=group.name,

--- a/website/activemembers/templatetags/activemembers_cards.py
+++ b/website/activemembers/templatetags/activemembers_cards.py
@@ -1,5 +1,4 @@
 from django import template
-from django.conf import settings
 from django.templatetags.static import static
 from django.utils.translation import gettext_lazy as _
 

--- a/website/announcements/api/v1/serializers.py
+++ b/website/announcements/api/v1/serializers.py
@@ -27,5 +27,5 @@ class SlideSerializer(CleanedModelSerializer):
 
     def _file(self, obj):
         return self.context["request"].build_absolute_uri(
-            get_thumbnail_url(obj.content, settings.THUMBNAIL_SIZES["slide"])
+            get_thumbnail_url(obj.content, "slide")
         )

--- a/website/announcements/api/v1/serializers.py
+++ b/website/announcements/api/v1/serializers.py
@@ -1,6 +1,4 @@
 """DRF serializers defined by the announcements package."""
-from django.conf import settings
-
 from rest_framework import serializers
 
 from announcements.models import Slide
@@ -26,6 +24,4 @@ class SlideSerializer(CleanedModelSerializer):
     content = serializers.SerializerMethodField("_file")
 
     def _file(self, obj):
-        return self.context["request"].build_absolute_uri(
-            get_thumbnail_url(obj.content, "slide")
-        )
+        return get_thumbnail_url(obj.content, "slide", absolute_url=True)

--- a/website/announcements/api/v2/serializers.py
+++ b/website/announcements/api/v2/serializers.py
@@ -1,6 +1,4 @@
 """DRF serializers defined by the announcements package."""
-from django.conf import settings
-
 from rest_framework import serializers
 
 from announcements.models import Slide

--- a/website/announcements/api/v2/serializers.py
+++ b/website/announcements/api/v2/serializers.py
@@ -26,9 +26,9 @@ class SlideSerializer(CleanedModelSerializer):
         )
 
     content = ThumbnailSerializer(
-        size_large=settings.THUMBNAIL_SIZES["slide"],
-        size_medium=settings.THUMBNAIL_SIZES["slide_medium"],
-        size_small=settings.THUMBNAIL_SIZES["slide_small"],
+        size_large="slide",
+        size_medium="slide_medium",
+        size_small="slide_small",
     )
 
 

--- a/website/announcements/templatetags/slider.py
+++ b/website/announcements/templatetags/slider.py
@@ -1,5 +1,4 @@
 from django import template
-from django.conf import settings
 
 from announcements.models import Slide
 

--- a/website/announcements/templatetags/slider.py
+++ b/website/announcements/templatetags/slider.py
@@ -14,5 +14,5 @@ def render_slider(context):
             for s in Slide.objects.all().order_by("order")
             if s.is_visible and (not s.members_only or context["request"].member)
         ],
-        "slide_size": settings.THUMBNAIL_SIZES["slide"],
+        "slide_size": "slide",
     }

--- a/website/documents/views.py
+++ b/website/documents/views.py
@@ -78,4 +78,4 @@ class DocumentDownloadView(DetailView):
 
         ext = os.path.splitext(file.name)[1]
 
-        return redirect(get_media_url(file, slugify(document.name) + ext))
+        return redirect(get_media_url(file, attachment=slugify(document.name) + ext))

--- a/website/education/views.py
+++ b/website/education/views.py
@@ -126,7 +126,7 @@ class ExamDetailView(DetailView):
 
         ext = os.path.splitext(obj.file.name)[1]
         filename = f"{obj.course.name}-summary{obj.year}{ext}"
-        return redirect(get_media_url(obj.file, filename))
+        return redirect(get_media_url(obj.file, attachment=filename))
 
 
 @method_decorator(login_required, "dispatch")
@@ -144,7 +144,7 @@ class SummaryDetailView(DetailView):
 
         ext = os.path.splitext(obj.file.name)[1]
         filename = f"{obj.course.name}-summary{obj.year}{ext}"
-        return redirect(get_media_url(obj.file, filename))
+        return redirect(get_media_url(obj.file, attachment=filename))
 
 
 @method_decorator(login_required, "dispatch")

--- a/website/events/api/v1/serializers/event_registrations/list.py
+++ b/website/events/api/v1/serializers/event_registrations/list.py
@@ -42,7 +42,7 @@ class EventRegistrationListSerializer(CleanedModelSerializer):
         if instance.member and instance.member.profile.photo:
             file = instance.member.profile.photo
         return create_image_thumbnail_dict(
-            self.context["request"], file, placeholder=placeholder, size_large="800x800"
+            file, placeholder=placeholder, size_large="avatar_large"
         )
 
 
@@ -152,7 +152,7 @@ class EventRegistrationSerializer(serializers.ModelSerializer):
         if instance.member and instance.member.profile.photo:
             file = instance.member.profile.photo
         return create_image_thumbnail_dict(
-            self.context["request"], file, placeholder=placeholder, size_large="800x800"
+            file, placeholder=placeholder, size_large="avatar_large"
         )
 
     def __init__(self, instance=None, data=empty, **kwargs):

--- a/website/events/views.py
+++ b/website/events/views.py
@@ -81,7 +81,7 @@ class EventDetail(DetailView):
 
         context["date_now"] = timezone.now()
 
-        context["slide_size"] = settings.THUMBNAIL_SIZES["slide"]
+        context["slide_size"] = "slide"
 
         context["participants"] = event.participants.select_related(
             "member", "member__profile"

--- a/website/events/views.py
+++ b/website/events/views.py
@@ -1,6 +1,5 @@
 """Views provided by the events package."""
 
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect

--- a/website/members/api/v1/serializers.py
+++ b/website/members/api/v1/serializers.py
@@ -63,7 +63,7 @@ class ProfileRetrieveSerializer(CleanedModelSerializer):
         if instance.photo:
             file = instance.photo
         return create_image_thumbnail_dict(
-            self.context["request"], file, placeholder=placeholder, size_large="800x800"
+            file, placeholder=placeholder, size_large="avatar_large"
         )
 
 
@@ -93,7 +93,7 @@ class MemberListSerializer(serializers.ModelSerializer):
         if instance.profile.photo:
             file = instance.profile.photo
         return create_image_thumbnail_dict(
-            self.context["request"], file, placeholder=placeholder, size_large="800x800"
+            file, placeholder=placeholder, size_large="avatar_large"
         )
 
     def _membership_type(self, instance):
@@ -183,5 +183,5 @@ class ProfileEditSerializer(CleanedModelSerializer):
         if instance.photo:
             file = instance.photo
         return create_image_thumbnail_dict(
-            self.context["request"], file, placeholder=placeholder, size_large="800x800"
+            file, placeholder=placeholder, size_large="avatar_large"
         )

--- a/website/members/api/v2/serializers/profile.py
+++ b/website/members/api/v2/serializers/profile.py
@@ -34,9 +34,9 @@ class ProfileSerializer(CleanedModelSerializer):
     birthday = serializers.SerializerMethodField("_birthday")
 
     photo = ThumbnailSerializer(
-        size_small=settings.THUMBNAIL_SIZES["small"],
-        size_medium=settings.THUMBNAIL_SIZES["medium"],
-        size_large=settings.THUMBNAIL_SIZES["avatar_large"],
+        size_small="small",
+        size_medium="medium",
+        size_large="avatar_large",
         placeholder="members/images/default-avatar.jpg",
     )
 

--- a/website/members/api/v2/serializers/profile.py
+++ b/website/members/api/v2/serializers/profile.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 from rest_framework import serializers
 
 from members.models import Profile

--- a/website/merchandise/templates/merchandise/index.html
+++ b/website/merchandise/templates/merchandise/index.html
@@ -12,7 +12,7 @@
         <hr />
         <div class="row">
             <div class="col-12 col-md-3">
-                <img src="{% thumbnail item.image THUMBNAIL_SIZE_MEDIUM fit=False %}" id="image" alt="{{ item.name }}" />
+                <img src="{% thumbnail item.image THUMBNAIL_SIZE_MEDIUM %}" id="image" alt="{{ item.name }}" />
             </div>
             <div class="col-12 col-md-9 pt-4 pt-md-0">
                 <h2>{{ item.name }}</h2>

--- a/website/newsletters/templates/newsletters/email.html
+++ b/website/newsletters/templates/newsletters/email.html
@@ -207,7 +207,7 @@
                 <td align="center" style="color: black; font-size: 12px;">
                     <p style="margin: 10px; font-family: 'Gill Sans', 'Trebuchet MS', sans-serif;">
                         <a href="{{ main_partner.link }}">
-                            <img src="{% baseurl %}{% thumbnail main_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}" height="95" style="height: 95px;" alt="{{ main_partner.name }}"/>
+                            <img src="{% thumbnail main_partner.logo THUMBNAIL_SIZE_MEDIUM absolute_url=True %}" height="95" style="height: 95px;" alt="{{ main_partner.name }}"/>
                         </a><br>
                         {% trans "our main partner"|upper %}
                     </p>
@@ -233,7 +233,7 @@
                             <td align="center" style="color: black; font-size: 12px;">
                                 <p style="margin: 10px; font-family: 'Gill Sans', 'Trebuchet MS', sans-serif;">
                                     <a href="{{ local_partner.link }}">
-                                        <img src="{% baseurl %}{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}" height="70" style="height: 70px; margin-bottom: 25px" alt="{{ local_partner.name }}"/>
+                                        <img src="{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM absolute_url=True %}" height="70" style="height: 70px; margin-bottom: 25px" alt="{{ local_partner.name }}"/>
                                     </a><br>
                                     {% trans "our local partner"|upper %}
                                 </p>

--- a/website/partners/templates/partners/banners.html
+++ b/website/partners/templates/partners/banners.html
@@ -7,7 +7,7 @@
                     <a href="{% url "partners:partner" partner.slug %}">
                         <img class="image text-hide"
                              alt="Logo {{ partner.name }}"
-                             src="{% if partner.alternate_logo %}{% thumbnail partner.alternate_logo thumb_size fit=False %}{% else %}{% thumbnail partner.logo thumb_size fit=False %}{% endif %}"
+                             src="{% if partner.alternate_logo %}{% thumbnail partner.alternate_logo thumb_size %}{% else %}{% thumbnail partner.logo thumb_size %}{% endif %}"
                         />
                     </a>
                 </div>

--- a/website/partners/templates/partners/index.html
+++ b/website/partners/templates/partners/index.html
@@ -20,7 +20,7 @@
     </p>
     <div class="row mt-4 justify-content-center">
         <div class="col-12 col-md-6 mt-auto">
-                <img src="{% thumbnail main_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}"/>
+                <img src="{% thumbnail main_partner.logo THUMBNAIL_SIZE_MEDIUM %}"/>
 
             <div class="mt-3">
                 <h2>{% trans "our main partner"|capfirst %}</h2>
@@ -33,7 +33,7 @@
     <div class="row mt-4 justify-content-center">
         {% for local_partner in local_partners %}
             <div class="col-12 col-md-6 mt-4">
-                <img src="{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}"/>
+                <img src="{% thumbnail local_partner.logo THUMBNAIL_SIZE_MEDIUM %}"/>
 
                 <div class="mt-3">
                     <h2>{% trans "our local partner"|capfirst %}</h2>

--- a/website/partners/templates/partners/partner.html
+++ b/website/partners/templates/partners/partner.html
@@ -20,7 +20,7 @@
 
             <div class="row">
                 <div class="col-12 col-md-4">
-                    <img src="{% thumbnail partner.logo THUMBNAIL_SIZE_MEDIUM fit=False %}" alt="Logo {{ partner.name }}"/>
+                    <img src="{% thumbnail partner.logo THUMBNAIL_SIZE_MEDIUM %}" alt="Logo {{ partner.name }}"/>
 
                     <h4 class="mt-4">{% trans "Address" %}</h4>
                     <p>

--- a/website/partners/templatetags/partner_banners.py
+++ b/website/partners/templatetags/partner_banners.py
@@ -31,5 +31,5 @@ def render_partner_banners(context):
 
     return {
         "partners": [p for p in all_partners if p.id in chosen],
-        "thumb_size": settings.THUMBNAIL_SIZES["medium"],
+        "thumb_size": "medium",
     }

--- a/website/partners/templatetags/partner_banners.py
+++ b/website/partners/templatetags/partner_banners.py
@@ -1,7 +1,6 @@
 from random import sample
 
 from django import template
-from django.conf import settings
 
 from partners.models import Partner
 

--- a/website/partners/templatetags/partner_cards.py
+++ b/website/partners/templatetags/partner_cards.py
@@ -1,5 +1,4 @@
 from django import template
-from django.conf import settings
 from django.template.defaultfilters import striptags, truncatechars
 
 from thaliawebsite.templatetags.bleach_tags import bleach

--- a/website/partners/templatetags/partner_cards.py
+++ b/website/partners/templatetags/partner_cards.py
@@ -14,9 +14,7 @@ def partner_card(partner):
     """Return grid item showing partner."""
     image_url = ""
     if partner.logo:
-        image_url = get_thumbnail_url(
-            partner.logo, settings.THUMBNAIL_SIZES["medium"], fit=False
-        )
+        image_url = get_thumbnail_url(partner.logo, "medium")
 
     meta_text = truncatechars(bleach(striptags(partner.company_profile)), 80)
 
@@ -34,11 +32,11 @@ def partner_card(partner):
 def partner_image_card(image):
     """Return grid item showing partner image."""
     class_name = "partner-image-card"
-    image_url = get_thumbnail_url(image, settings.THUMBNAIL_SIZES["medium"])
+    image_url = get_thumbnail_url(image, "medium")
 
     return grid_item(
         title="",
-        url=get_thumbnail_url(image, settings.THUMBNAIL_SIZES["large"], fit=False),
+        url=get_thumbnail_url(image, "large"),
         image_url=image_url,
         class_name=class_name,
         anchor_attrs='data-fancybox="gallery"',
@@ -50,9 +48,7 @@ def vacancy_card(vacancy):
     """Return grid item showing vacancy."""
     image_url = None
     if vacancy.get_company_logo():
-        image_url = get_thumbnail_url(
-            vacancy.get_company_logo(), settings.THUMBNAIL_SIZES["medium"], fit=False
-        )
+        image_url = get_thumbnail_url(vacancy.get_company_logo(), "medium")
 
     description = truncatechars(bleach(striptags(vacancy.description)), 300)
     extra_class = "external-vacancy"

--- a/website/photos/api/v1/serializers.py
+++ b/website/photos/api/v1/serializers.py
@@ -15,9 +15,7 @@ class PhotoRetrieveSerializer(CleanedModelSerializer):
         file = None
         if obj:
             file = obj.file
-        return create_image_thumbnail_dict(
-            self.context["request"], file, fit_large=False
-        )
+        return create_image_thumbnail_dict(self.context["request"], file)
 
     class Meta:
         """Meta class for PhotoRetrieveSerializer."""

--- a/website/photos/api/v1/serializers.py
+++ b/website/photos/api/v1/serializers.py
@@ -15,7 +15,7 @@ class PhotoRetrieveSerializer(CleanedModelSerializer):
         file = None
         if obj:
             file = obj.file
-        return create_image_thumbnail_dict(self.context["request"], file)
+        return create_image_thumbnail_dict(file)
 
     class Meta:
         """Meta class for PhotoRetrieveSerializer."""

--- a/website/photos/views.py
+++ b/website/photos/views.py
@@ -108,7 +108,7 @@ def _download(request, obj, filename):
     """
     photopath = _photo_path(obj, filename)
     photo = get_object_or_404(Photo.objects.filter(album=obj, file=photopath))
-    return redirect(get_media_url(photo.file, f"{obj.slug}-{filename}"))
+    return redirect(get_media_url(photo.file, attachment=f"{obj.slug}-{filename}"))
 
 
 @login_required

--- a/website/thabloid/templatetags/thabloid_cards.py
+++ b/website/thabloid/templatetags/thabloid_cards.py
@@ -2,7 +2,7 @@ from django import template
 
 from thabloid.models import Thabloid
 from thaliawebsite.templatetags.grid_item import grid_item
-from utils.media.services import get_media_url, get_thumbnail_url
+from utils.media.services import get_media_url
 
 register = template.Library()
 
@@ -10,9 +10,13 @@ register = template.Library()
 @register.inclusion_tag("includes/grid_item.html")
 def thabloid_card(thabloid: Thabloid):
     """Create a card for a thabloid to show on an overview of thabloids."""
+    download_url = get_media_url(
+        thabloid.file, attachment=f"thabloid-{thabloid.file.name}"
+    )
+
     buttons = f"""
         <div class="text-center mt-2">
-            <a href="{get_media_url(thabloid.file, attachment=True)}" download
+            <a href="{download_url}" download
                class="btn btn-secondary d-inline-flex download ms-1">
                 <i class="fas fa-download"></i>
             </a>
@@ -23,6 +27,6 @@ def thabloid_card(thabloid: Thabloid):
         title=f"{thabloid.year}-{thabloid.year+1}, #{thabloid.issue}",
         meta_text=buttons,
         url=None,
-        image_url=get_thumbnail_url(thabloid.cover, "255x360"),
+        image_url=get_media_url(thabloid.cover),
         class_name="thabloid-card",
     )

--- a/website/thaliawebsite/api/services.py
+++ b/website/thaliawebsite/api/services.py
@@ -7,25 +7,16 @@ def create_image_thumbnail_dict(
     request,
     file,
     placeholder="",
-    size_small=settings.THUMBNAIL_SIZES["small"],
-    size_medium=settings.THUMBNAIL_SIZES["medium"],
-    size_large=settings.THUMBNAIL_SIZES["large"],
-    fit_small=True,
-    fit_medium=True,
-    fit_large=True,
+    size_small="small",
+    size_medium="medium",
+    size_large="large",
 ):
     if file:
         return {
             "full": request.build_absolute_uri(get_media_url(file)),
-            "small": request.build_absolute_uri(
-                get_thumbnail_url(file, size_small, fit=fit_small)
-            ),
-            "medium": request.build_absolute_uri(
-                get_thumbnail_url(file, size_medium, fit=fit_medium)
-            ),
-            "large": request.build_absolute_uri(
-                get_thumbnail_url(file, size_large, fit=fit_large)
-            ),
+            "small": request.build_absolute_uri(get_thumbnail_url(file, size_small)),
+            "medium": request.build_absolute_uri(get_thumbnail_url(file, size_medium)),
+            "large": request.build_absolute_uri(get_thumbnail_url(file, size_large)),
         }
     return {
         "full": placeholder,

--- a/website/thaliawebsite/api/services.py
+++ b/website/thaliawebsite/api/services.py
@@ -1,10 +1,7 @@
-from django.conf import settings
-
 from utils.media.services import get_media_url, get_thumbnail_url
 
 
 def create_image_thumbnail_dict(
-    request,
     file,
     placeholder="",
     size_small="small",
@@ -13,10 +10,10 @@ def create_image_thumbnail_dict(
 ):
     if file:
         return {
-            "full": request.build_absolute_uri(get_media_url(file)),
-            "small": request.build_absolute_uri(get_thumbnail_url(file, size_small)),
-            "medium": request.build_absolute_uri(get_thumbnail_url(file, size_medium)),
-            "large": request.build_absolute_uri(get_thumbnail_url(file, size_large)),
+            "full": get_media_url(file, absolute_url=True),
+            "small": get_thumbnail_url(file, size_small, absolute_url=True),
+            "medium": get_thumbnail_url(file, size_medium, absolute_url=True),
+            "large": get_thumbnail_url(file, size_large, absolute_url=True),
         }
     return {
         "full": placeholder,

--- a/website/thaliawebsite/api/v2/serializers/thumbnail.py
+++ b/website/thaliawebsite/api/v2/serializers/thumbnail.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.templatetags.static import static
 
 from rest_framework.fields import FileField
@@ -35,9 +34,7 @@ class ThumbnailSerializer(FileField):
                 static(self.placeholder)
             )
 
-        return create_image_thumbnail_dict(
-            self.context["request"], value, placeholder, **self.options
-        )
+        return create_image_thumbnail_dict(value, placeholder, **self.options)
 
     def to_internal_value(self, data):
         if data == "":

--- a/website/thaliawebsite/api/v2/serializers/thumbnail.py
+++ b/website/thaliawebsite/api/v2/serializers/thumbnail.py
@@ -14,12 +14,9 @@ class ThumbnailSerializer(FileField):
         instance=None,
         data=None,
         placeholder=None,
-        size_small=settings.THUMBNAIL_SIZES["small"],
-        size_medium=settings.THUMBNAIL_SIZES["medium"],
-        size_large=settings.THUMBNAIL_SIZES["large"],
-        fit_small=True,
-        fit_medium=True,
-        fit_large=True,
+        size_small="small",
+        size_medium="medium",
+        size_large="large",
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -29,9 +26,6 @@ class ThumbnailSerializer(FileField):
             "size_small": size_small,
             "size_medium": size_medium,
             "size_large": size_large,
-            "fit_small": fit_small,
-            "fit_medium": fit_medium,
-            "fit_large": fit_large,
         }
 
     def to_representation(self, value):

--- a/website/thaliawebsite/context_processors.py
+++ b/website/thaliawebsite/context_processors.py
@@ -11,9 +11,9 @@ def source_commit(_):
 def thumbnail_sizes(_):
     """Get the defined sizes for thumbnails."""
     return {
-        "THUMBNAIL_SIZE_SMALL": settings.THUMBNAIL_SIZES["small"],
-        "THUMBNAIL_SIZE_MEDIUM": settings.THUMBNAIL_SIZES["medium"],
-        "THUMBNAIL_SIZE_LARGE": settings.THUMBNAIL_SIZES["large"],
+        "THUMBNAIL_SIZE_SMALL": "small",
+        "THUMBNAIL_SIZE_MEDIUM": "medium",
+        "THUMBNAIL_SIZE_LARGE": "large",
     }
 
 

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -871,15 +871,7 @@ THUMBNAILS = {
     },
 }
 
-THUMBNAIL_SIZES = {
-    "small": "small",
-    "medium": "medium",
-    "large": "large",
-    "avatar_large": "avatar_large",
-    "slide_small": "slide_small",
-    "slide_medium": "slide_medium",
-    "slide": "slide",
-}
+THUMBNAIL_SIZES = set(THUMBNAILS["SIZES"].keys())
 
 
 # Photos settings

--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -26,7 +26,7 @@ def save_image(storage, image, path, format):
     return storage.save(path, file)
 
 
-def get_media_url(file, attachment: bool | str = False, absolute_url: bool = False):
+def get_media_url(file, attachment=False, absolute_url: bool = False):
     """Get the url of the provided media file to serve in a browser.
 
     If the file is private a signature will be added.

--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -52,11 +52,8 @@ def get_media_url(file, attachment: bool | str = False, absolute_url: bool = Fal
 
 
 def get_thumbnail_url(file, size: str, absolute_url: bool = False):
-    storage = DefaultStorage()
     name = file
-
     if isinstance(file, (ImageFieldFile, FieldFile)):
-        storage = file.storage
         name = file.name
 
     if isinstance(file, ThumbnailedImageFile):

--- a/website/utils/templatetags/thumbnail.py
+++ b/website/utils/templatetags/thumbnail.py
@@ -8,16 +8,16 @@ register = template.Library()
 
 
 @register.simple_tag
-def thumbnail(path, size, fit=True):
+def thumbnail(path, size, absolute_url=False):
     """Generate a thumbnail for a path.
 
     This templatetag provides us with a way of getting a thumbnail
     directly inside templates. See the documentation
     of :func:`get_thumbnail_url` for a more information.
-    :param path: the path or ImageField we want an thumbnail from,
-    this field MUST NEVER be a user input
-    :param size: the size formatted like `widthxheight`
-    :param fit: True if we want the image to fit
-    :return: the thumbnail url
+    :param path: The path or ImageField we want an thumbnail from,
+    this field MUST NEVER be a user input.
+    :param size: The size we want from settings.THUMBNAIL_SIZES.
+    :param absolute_url: True if we want the full url including the scheme and domain.
+    :return: The thumbnail url.
     """
-    return get_thumbnail_url(path, size, fit)
+    return get_thumbnail_url(path, size, absolute_url)


### PR DESCRIPTION
Closes #3009.

This simplifies some stuff related to thumbnails, and adds an `absolute_url` argument to solve the problem of S3 urls already being url, and filesystem urls still needing the baseurl prefix.

### How to test
Try out that images work properly everywhere, and send a newsletter.
Of course most interesting is to see this work with S3, so it's probably easiest to just merge and ensure that it works on staging after.
