### PR TITLE
Add createcachetable make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,11 @@ website/db.sqlite3: .make/deps $(MIGRATIONS)
 .PHONY: migrate
 migrate: ## Run all database migrations
 	poetry run website/manage.py migrate
+	poetry run website/manage.py createcachetable
+
+.PHONY: cachetable
+cachetable: ## Create the cache table
+	poetry run website/manage.py createcachetable
 
 .PHONY: migrations
 migrations: ## Automatically create migration scripts


### PR DESCRIPTION
Closes #3019

### Summary
Adds a `make cachetable` command to the make file, running it at migrate too

### How to test
Steps to test the changes you made:
1. `make run`
2. `make migrate`
3. `make cachetable`

They should all work