### PR TITLE
Prevent boards with no start or stop date

### DIFF
--- a/website/activemembers/models.py
+++ b/website/activemembers/models.py
@@ -201,6 +201,23 @@ class Board(MemberGroup):
         self.active = True
         super().save(**kwargs)
 
+    def clean(self):
+        if self.since is None:
+            raise ValidationError(
+                {
+                    "since": _("Please insert a starting year for the new board."),
+                }
+            )
+
+        if self.until is None:
+            raise ValidationError(
+                {
+                    "until": _(
+                        "Please insert the year until when the board is active."
+                    ),
+                }
+            )
+
     def get_absolute_url(self):
         return reverse(
             "activemembers:board", args=[str(self.since.year), str(self.until.year)]

--- a/website/activemembers/tests.py
+++ b/website/activemembers/tests.py
@@ -251,8 +251,5 @@ class BoardTest(TestCase):
         b.since = b.since.replace(year=1991, month=9, day=2)
         b.full_clean()
 
-        b.until = None
-        b.full_clean()
-
     def test_get_absolute_url(self):
         self.testboard.get_absolute_url()


### PR DESCRIPTION
Closes #2991

bug

### Summary
Added a clean function inside Board in website/activemembers/models.py which checks for the "since" and "until" date of a newly created board. Message is put on screen when (either one of) these fields are empty.

### How to test
Steps to test the changes you made:
1. Go to 'Active Members' and then 'Boards'
2. Click on 'add'
3. Fill the form in until 'Founded in' and 'Existed until'.
4. Try to leave 'Founded in' and 'Existed until' empty.
5. You should now see a message saying that these fields cannot be empty.
