### PR TITLE
Document API serializer returns signed cdn URL 2: Electric Boogaloo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: "23.1.0"
+  rev: "23.3.0"
   hooks:
   - id: black
     exclude: .*/migrations/.*
 - repo: https://github.com/python-poetry/poetry
-  rev: "1.3.0"
+  rev: "1.4.0"
   hooks:
     - id: poetry-check

--- a/website/documents/api/v2/serializers/document.py
+++ b/website/documents/api/v2/serializers/document.py
@@ -16,9 +16,11 @@ class DocumentSerializer(CleanedModelSerializer):
 
     def _url(self, instance):
         if instance.members_only and (
-            not self.request.user.is_authenticated
-            or not self.request.member.has_active_membership()
+            not self.context["request"].user.is_authenticated
+            or not self.context["request"].member.has_active_membership()
         ):
-            return self.request.build_absolute_uri(instance.get_absolute_url())
+            return self.context["request"].build_absolute_uri(
+                instance.get_absolute_url()
+            )
 
         return get_media_url(instance.file, absolute_url=True)

--- a/website/documents/api/v2/serializers/document.py
+++ b/website/documents/api/v2/serializers/document.py
@@ -1,10 +1,10 @@
 from rest_framework.fields import SerializerMethodField
-from rest_framework.reverse import reverse
 
 from documents.models import Document
 from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
     CleanedModelSerializer,
 )
+from utils.media.services import get_media_url
 
 
 class DocumentSerializer(CleanedModelSerializer):
@@ -15,6 +15,10 @@ class DocumentSerializer(CleanedModelSerializer):
     url = SerializerMethodField("_url")
 
     def _url(self, instance):
-        return self.context["request"].build_absolute_uri(
-            reverse("documents:document", kwargs={"pk": instance.pk})
-        )
+        if instance.members_only and (
+            not self.request.user.is_authenticated
+            or not self.request.member.has_active_membership()
+        ):
+            return self.request.build_absolute_uri(instance.get_absolute_url())
+        else:
+            return get_media_url(instance.file, absolute_url=True)

--- a/website/documents/api/v2/serializers/document.py
+++ b/website/documents/api/v2/serializers/document.py
@@ -20,5 +20,5 @@ class DocumentSerializer(CleanedModelSerializer):
             or not self.request.member.has_active_membership()
         ):
             return self.request.build_absolute_uri(instance.get_absolute_url())
-        else:
-            return get_media_url(instance.file, absolute_url=True)
+
+        return get_media_url(instance.file, absolute_url=True)


### PR DESCRIPTION
Closes #3050

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Changed the document API serializer to return a signed cdn URL if the file is public or the user is authenticated and authorized.

### How to test
Steps to test the changes you made:
1. Go to the API page of an event with an attached document (you must be logged in for this)
2. See the URL is now the actual cdn URL of the file
