### PR TITLE
Former member api

### DIFF
--- a/website/members/api/v2/filters.py
+++ b/website/members/api/v2/filters.py
@@ -1,4 +1,9 @@
-from rest_framework import filters
+from datetime import datetime
+
+from django.db.models import Q
+from django.utils import timezone
+
+from rest_framework import filters, serializers
 
 from members.models import Membership
 
@@ -23,6 +28,62 @@ class StartingYearFilter(filters.BaseFilterBackend):
                 "description": "Filter by starting year",
                 "schema": {
                     "type": "number",
+                },
+            }
+        ]
+
+
+class FormerMemberFilter(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        former = request.query_params.get("former", "false")
+
+        if former == "false":
+            # Filter out former members
+            return (
+                queryset.exclude(membership=None)
+                .filter(
+                    Q(membership__until__isnull=True)
+                    | Q(membership__until__gt=timezone.now().date())
+                )
+                .distinct()
+            )
+        elif former == "true":
+            # Filter out current members
+
+            memberships_query = Q(until__gt=datetime.now()) | Q(until=None)
+            members_query = ~Q(id=None)
+
+            # Filter out all current active memberships
+            memberships_query &= Q(type=Membership.MEMBER) | Q(type=Membership.HONORARY)
+            memberships = Membership.objects.filter(memberships_query)
+            members_query &= ~Q(pk__in=memberships.values("user__pk"))
+
+            memberships_query = Q(type=Membership.MEMBER) | Q(type=Membership.HONORARY)
+            memberships = Membership.objects.filter(memberships_query)
+            all_memberships = Membership.objects.all()
+            # Only keep members that were once members, or are legacy users
+            # that do not have any memberships at all
+            members_query &= Q(pk__in=memberships.values("user__pk")) | ~Q(
+                pk__in=all_memberships.values("user__pk")
+            )
+
+            return queryset.filter(members_query)
+        elif former == "any":
+            # Include both former and current members
+            return queryset
+        else:
+            raise serializers.ValidationError("invalid former parameter")
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                "name": "former",
+                "required": False,
+                "in": "query",
+                "description": "Include former members or only former members",
+                "schema": {
+                    "type": "string",
+                    "enum": ["true", "false", "any"],
                 },
             }
         ]

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -58,7 +58,7 @@ class MemberDetailView(RetrieveAPIView):
     """Returns details of a member."""
 
     serializer_class = MemberSerializer
-    queryset = Member.current_members.all()
+    queryset = Member.objects.all()
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
     ]

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -23,7 +23,7 @@ class MemberListView(ListAPIView):
 
     serializer_class = MemberListSerializer
     queryset = (
-        Member.current_members.all()
+        Member.objects.all()
         .select_related("profile")
         .prefetch_related("membership_set")
     )
@@ -43,6 +43,7 @@ class MemberListView(ListAPIView):
         framework_filters.SearchFilter,
         filters.MembershipTypeFilter,
         filters.StartingYearFilter,
+        filters.FormerMemberFilter,
     )
     ordering_fields = ("first_name", "last_name", "username")
     search_fields = (


### PR DESCRIPTION
Closes #3067 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
- Allow MemberDetailView to display former members
- Add a FormerMemberFilter to the MemberListView

### How to test
Steps to test the changes you made:
1. Go to `/api/v2/members/<id>`  for a former member
2. Observe that the page loads
3. Go to `/api/v2/members/?former={any|true|false}`
4. See that there are {also/only/none} former members in the list