### PR TITLE
Fix get_serializer overrides to deal with 0 parameters

### DIFF
--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -28,9 +28,11 @@ class MemberListView(ListAPIView):
         .prefetch_related("membership_set")
     )
 
-    def get_serializer(self, members, *args, **kwargs):
-        fetch_thumbnails_db([member.profile.photo for member in members])
-        return super().get_serializer(members, *args, **kwargs)
+    def get_serializer(self, *args, **kwargs):
+        if len(args) > 0:
+            members = args[0]
+            fetch_thumbnails_db([member.profile.photo for member in members])
+        return super().get_serializer(*args, **kwargs)
 
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,

--- a/website/partners/api/v2/views.py
+++ b/website/partners/api/v2/views.py
@@ -20,9 +20,11 @@ class PartnerListView(ListAPIView):
         framework_filters.SearchFilter,
     )
 
-    def get_serializer(self, partners, *args, **kwargs):
-        fetch_thumbnails_db([partner.logo for partner in partners])
-        return super().get_serializer(partners, *args, **kwargs)
+    def get_serializer(self, *args, **kwargs):
+        if len(args) > 0:
+            partners = args[0]
+            fetch_thumbnails_db([partner.logo for partner in partners])
+        return super().get_serializer(*args, **kwargs)
 
     ordering_fields = ("name", "pk")
     search_fields = ("name",)

--- a/website/photos/api/v2/views.py
+++ b/website/photos/api/v2/views.py
@@ -22,9 +22,11 @@ class AlbumListView(ListAPIView):
 
     serializer_class = AlbumListSerializer
 
-    def get_serializer(self, albums, *args, **kwargs):
-        fetch_thumbnails_db([album.cover.file for album in albums if album.cover])
-        return super().get_serializer(albums, *args, **kwargs)
+    def get_serializer(self, *args, **kwargs):
+        if len(args) > 0:
+            albums = args[0]
+            fetch_thumbnails_db([album.cover.file for album in albums if album.cover])
+        return super().get_serializer(*args, **kwargs)
 
     queryset = Album.objects.filter(hidden=False).select_related("_cover")
 
@@ -90,9 +92,11 @@ class LikedPhotosListView(ListAPIView):
             )
         return self.list(request, *args, **kwargs)
 
-    def get_serializer(self, photos, *args, **kwargs):
-        fetch_thumbnails_db([photo.file for photo in photos])
-        return super().get_serializer(photos, *args, **kwargs)
+    def get_serializer(self, *args, **kwargs):
+        if len(args) > 0:
+            photos = args[0]
+            fetch_thumbnails_db([photo.file for photo in photos])
+        return super().get_serializer(*args, **kwargs)
 
     def get_queryset(self):
         return (


### PR DESCRIPTION
Closes #3130 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
In #2998 I overrode get_serializer in some places, but get_serializer can get called without a dataset. Some implementations were not ready for that, but they are now

### How to test
Steps to test the changes you made:
1. Check that `/api/docs` loads again
2. Check that the thumbnails are still prefetched correctly for the urls that match with these views.
