### PR TITLE
Fix missing ordering on liked photos API

### DIFF
--- a/website/photos/api/v2/views.py
+++ b/website/photos/api/v2/views.py
@@ -105,6 +105,8 @@ class LikedPhotosListView(ListAPIView):
                 member_likes=Count("likes", filter=Q(likes__member=self.request.member))
             )
             .select_properties("num_likes")
+            # Fix select_properties dropping the default ordering.
+            .order_by("pk")
         )
 
 


### PR DESCRIPTION
Closes #2878 

I guess I missed one case a while back.