### PR TITLE
Fix event clean

### DIFF
--- a/website/events/admin/event.py
+++ b/website/events/admin/event.py
@@ -119,13 +119,6 @@ class EventAdmin(DoNextModelAdmin):
 
     def get_form(self, request, obj=None, change=False, **kwargs):
         form = super().get_form(request, obj, change, **kwargs)
-        default_clean = form.clean
-
-        def clean(form):
-            default_clean(form)
-            form.instance.clean_changes(form.changed_data)
-
-        form.clean = clean
         form.request = request
         return form
 

--- a/website/events/admin/event.py
+++ b/website/events/admin/event.py
@@ -119,7 +119,13 @@ class EventAdmin(DoNextModelAdmin):
 
     def get_form(self, request, obj=None, change=False, **kwargs):
         form = super().get_form(request, obj, change, **kwargs)
-        form.clean = lambda form: form.instance.clean_changes(form.changed_data)
+        default_clean = form.clean
+
+        def clean(form):
+            default_clean(form)
+            form.instance.clean_changes(form.changed_data)
+
+        form.clean = clean
         form.request = request
         return form
 

--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -363,8 +363,6 @@ class Event(models.Model):
         # pylint: disable=too-many-branches
         super().clean()
         errors = {}
-        if Event.objects.exclude(id=self.id).filter(slug=self.slug).exists():
-            errors.update({"slug": _("Slug must be unique")})
         if self.start is None:
             errors.update({"start": _("Start cannot have an empty date or time field")})
         if self.end is None:


### PR DESCRIPTION
Closes #3122 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I removed the manual check for duplicate slugs and instead made sure to call the original clean() function.

### How to test
Steps to test the changes you made:
- Same as #3129 except that the error message is now different (`Event with this Slug already exists.`)
