### PR TITLE
Add MemberGroupShortSerializer and use in /api/v2/events

### DIFF
--- a/website/activemembers/api/v2/serializers/member_group.py
+++ b/website/activemembers/api/v2/serializers/member_group.py
@@ -72,3 +72,16 @@ class MemberGroupListSerializer(MemberGroupSerializer):
             "contact_address",
             "photo",
         )
+
+
+class MemberGroupShortSerializer(MemberGroupListSerializer):
+    class Meta:
+        model = MemberGroup
+        fields = (
+            "pk",
+            "name",
+            "type",
+            "since",
+            "until",
+            "contact_address",
+        )

--- a/website/events/api/v2/serializers/event.py
+++ b/website/events/api/v2/serializers/event.py
@@ -1,7 +1,10 @@
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-from activemembers.api.v2.serializers.member_group import MemberGroupSerializer
+from activemembers.api.v2.serializers.member_group import (
+    MemberGroupSerializer,
+    MemberGroupShortSerializer,
+)
 from documents.api.v2.serializers.document import DocumentSerializer
 from events import services
 from events.api.v2.serializers.event_registration import EventRegistrationSerializer
@@ -123,34 +126,4 @@ class EventSerializer(CleanedModelSerializer):
 
 
 class EventListSerializer(EventSerializer):
-    class Meta:
-        model = Event
-        fields = (
-            "pk",
-            "slug",
-            "url",
-            "title",
-            "description",
-            "caption",
-            "start",
-            "end",
-            "category",
-            "registration_start",
-            "registration_end",
-            "cancel_deadline",
-            "optional_registrations",
-            "location",
-            "price",
-            "fine",
-            "num_participants",
-            "max_participants",
-            "no_registration_message",
-            "registration_status",
-            "cancel_too_late_message",
-            "has_fields",
-            "food_event",
-            "maps_url",
-            "user_permissions",
-            "user_registration",
-            "documents",
-        )
+    organisers = MemberGroupShortSerializer(many=True)


### PR DESCRIPTION
This serializer only contains some essential data about a member group: no description, no image

Closes #3150 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
The lack of organiser info in the event list gave issues for Reaxit, so I readded it in a more basic form.

### How to test
Steps to test the changes you made:
1. Go to /api/v2/events
2. See that there is some organiser info now
3. Check that the detail endpoint /api/v2/events/<id> still has the full organiser info
