### PR TITLE
Hide admin menu

### DIFF
--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -181,12 +181,14 @@
                                 </a>
                             </li>
                             <li><hr class="dropdown-divider"></li>
-                            <li>
-                                <a class="dropdown-item"
-                                   href="{% url 'admin:index' %}">
-                                    {% trans "Site administration" %}
-                                </a>
-                            </li>
+                            {% if user.is_staff %}
+                                <li>
+                                    <a class="dropdown-item"
+                                       href="{% url 'admin:index' %}">
+                                        {% trans "Site administration" %}
+                                    </a>
+                                </li>
+                            {% endif %}
                             <li>
                                 <a class="dropdown-item"
                                    href="{% url 'logout' %}">

--- a/website/thaliawebsite/urls.py
+++ b/website/thaliawebsite/urls.py
@@ -31,7 +31,6 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.urls import path, re_path
-from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 
 import debug_toolbar
@@ -58,6 +57,7 @@ from thaliawebsite.views import (
     RateLimitedLoginView,
     RateLimitedPasswordResetView,
     TestCrashView,
+    admin_unauthorized_view,
 )
 from utils.media.views import private_media
 
@@ -80,7 +80,7 @@ THALIA_SITEMAP.update(singlepages_sitemap)
 urlpatterns = [
     path(
         "admin/login/",
-        RedirectView.as_view(url="/user/login", query_string=True),
+        admin_unauthorized_view,
         name="login-redirect",
     ),
     path("admin/", admin.site.urls),


### PR DESCRIPTION
Closes #3159 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
- The link to the admin is hidden for non-staff
- Trying to open now can result in 3 different scenarios:
  - Not logged in -> opens login page
  - Logged in but not staff -> 403 page (on a wrong URL)
  - Logged in and staff -> opens admin page

### How to test
Steps to test the changes you made:
1. See that for a logged in user the admin link is only there if they are staff.
2. Test the 3 scenarios listed in the summary when going to `/admin`.
