### PR TITLE
Make uncloseable announcements always appear

### DIFF
--- a/website/announcements/context_processors.py
+++ b/website/announcements/context_processors.py
@@ -15,7 +15,7 @@ def announcements(request):
     announcements_list = [
         a
         for a in Announcement.objects.all()
-        if a.is_visible and a.pk not in closed_announcements and not a.closeable
+        if a.is_visible and (not a.closeable or a.pk not in closed_announcements)
     ]
 
     # Announcements set by AnnouncementMiddleware.

--- a/website/announcements/context_processors.py
+++ b/website/announcements/context_processors.py
@@ -15,7 +15,7 @@ def announcements(request):
     announcements_list = [
         a
         for a in Announcement.objects.all()
-        if a.is_visible and a.pk not in closed_announcements
+        if a.is_visible and a.pk not in closed_announcements and not a.closeable
     ]
 
     # Announcements set by AnnouncementMiddleware.


### PR DESCRIPTION
Closes #3110 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Uncloseable announcements now always appear.

This replaces the old behaviour were you were only unable to close them.

Note that this was stored in the user session, and not a cookie. I do think POSTing to the right URL (e.g. via curl) would have closed an uncloseable announcement previously. (Doing that now still adds it to your session, but the announcement will still be shown regardless.)

### How to test
Steps to test the changes you made:

1. Have an announcement that is closable
2. Close it on your machine
3. Change the announcement to be non-closable
4. It now reappears
