### PR TITLE
Replace django compressor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,12 @@
 website/media
 website/static
+website/filepond-temp-uploads
+website/filepond-uploaded
+website/static
 website/db.sqlite3
 
 **/Dockerfile
-README.md
+**/README.md
 docs
 
 .git
@@ -15,7 +18,7 @@ docs
 
 infra/terraform
 infra/env.*
-.env
+**/.env
 
 
 .codeclimate.yml
@@ -25,6 +28,6 @@ infra/env.*
 .mailmap
 renovate.json
 
-.DS_Store
-__pycache__
+**/.DS_Store
+**/__pycache__
 *.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,30 @@
 website/media
 website/static
 website/db.sqlite3
-infra/modules
-scripts
 
 **/Dockerfile
 README.md
 docs
 
-# These files would not be copied, but increase the size of the build context
 .git
 .github
 .make
+.venv
+.vscode
+.ruff_cache
+
+infra/terraform
+infra/env.*
+.env
+
+
 .codeclimate.yml
 .coverage
 .gitattributes
 .gitignore
 .mailmap
 renovate.json
+
+.DS_Store
+__pycache__
+*.pyc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches: ['master']
     tags: ['v*']
-  workflow_dispatch:
 
 jobs:
   build-concrexit:
@@ -97,9 +96,7 @@ jobs:
 
   deploy-staging:
     name: Deploy to staging
-    if: | # Deploy to staging on push to master or workflow_dispatch
-      github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: github.ref == 'refs/heads/master'
     environment:
       name: staging
       url: https://staging.thalia.nu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-poetry-
 
       - name: Install any new dependencies
-        run: poetry install --extras "postgres"
+        run: poetry install --with postgres
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run tests
@@ -132,7 +132,7 @@ jobs:
             ${{ runner.os }}-poetry-
 
       - name: Install any new dependencies
-        run: poetry install --extras "postgres"
+        run: poetry install --with postgres
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run create fixtures

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ PORT ?= 8000
 ifdef CI
 # These add to any existing POETRY_FLAGS variable, it doesn't replace existing
 # flags.
-	POETRY_FLAGS := $(POETRY_FLAGS) --no-interaction --extras postgres
+	POETRY_FLAGS := $(POETRY_FLAGS) --no-interaction --with postgres
 	BLACK_FLAGS := $(BLACK_FLAGS) --quiet
 	DOCKER_FLAGS := $(DOCKER_FLAGS) --quiet
 endif
@@ -259,7 +259,7 @@ covhtml: .coverage ## Generate an HTML coverage report
 	poetry run coverage html --directory=covhtml --no-skip-covered --title="Coverage Report"
 
 .make/docsdeps: .make .make/deps
-	poetry install $(POETRY_FLAGS) --extras "docs"
+	poetry install $(POETRY_FLAGS) --with docs
 	@touch .make/docsdeps
 
 .PHONY: apidocs

--- a/infra/concrexit/Dockerfile
+++ b/infra/concrexit/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 
-FROM base as build-final
+FROM base as build-venv
 # This stage installs the dependencies that need to be installed in the final image.
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -29,7 +29,7 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry install --only main --only postgres
 
 
-FROM build-final as build-scss
+FROM build-venv as build-scss
 # This stage builds the SASS, using dependencies that are not needed in the final image.
 
 RUN poetry install --only main --only postgres --only scss
@@ -63,7 +63,7 @@ RUN crontab /cronjobs && rm /cronjobs
 COPY infra/concrexit/docker-entrypoint.sh /app/docker-entrypoint.sh
 CMD [ "/app/docker-entrypoint.sh" ]
 
-COPY --from=build-final /venv /venv
+COPY --from=build-venv /venv /venv
 COPY --from=build-scss /app/website /app/website
 WORKDIR /app/website
 

--- a/infra/concrexit/Dockerfile
+++ b/infra/concrexit/Dockerfile
@@ -6,52 +6,67 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-FROM base as builder
+
+FROM base as build-final
+# This stage installs the dependencies that need to be installed in the final image.
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
 
-RUN pip install "poetry==1.3.1"
+RUN pip install "poetry==1.3.1" && pip install --upgrade setuptools
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential libpq-dev libjpeg-dev zlib1g-dev libwebp-dev libmagic1
 
-RUN python -m venv /venv
+RUN  python -m venv /venv
 ENV PATH=/venv/bin:$PATH \
     VIRTUAL_ENV=/venv
+
 COPY pyproject.toml poetry.lock ./
 
-RUN pip install --upgrade setuptools
-RUN poetry install --only main --extras "postgres"
+RUN poetry install --only main --only postgres
+
+
+FROM build-final as build-scss
+# This stage builds the SASS, using dependencies that are not needed in the final image.
+
+RUN poetry install --only main --only postgres --only scss
+
+COPY website /app/website
+
+RUN MANAGE_PY=1 /venv/bin/python /app/website/manage.py compilescss
+
 
 FROM base as final
+# The final image, with only the dependencies needed in production, and compiled SASS.
 
 EXPOSE 8000
 
 VOLUME [ "/volumes/media", "/volumes/static" ]
 
-ENV MEDIA_ROOT="/volumes/media" \
+ENV PATH=/venv/bin:$PATH \
+    MEDIA_ROOT="/volumes/media" \
     STATIC_ROOT="/volumes/static" \
     SENDFILE_ROOT="/volumes/media"
 
+# Install runtime dependencies.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         cron postgresql-client libjpeg-dev zlib1g-dev libwebp-dev libmagic1 && \
-        rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 COPY infra/concrexit/cronjobs /cronjobs
 RUN crontab /cronjobs && rm /cronjobs
 
-COPY --from=builder /venv /venv
 COPY infra/concrexit/docker-entrypoint.sh /app/docker-entrypoint.sh
-COPY website /app/website
+CMD [ "/app/docker-entrypoint.sh" ]
 
+COPY --from=build-final /venv /venv
+COPY --from=build-scss /app/website /app/website
 WORKDIR /app/website
 
-RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
-
-CMD [ "/app/docker-entrypoint.sh" ]
+RUN adduser --system --uid 5678 appuser
 
 # Persist the SOURCE_COMMIT build argument as
 # environment variable in the resulting image.

--- a/infra/concrexit/Dockerfile
+++ b/infra/concrexit/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.11-slim-bullseye AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    DJANGO_ENV=production
+    DJANGO_ENV=production \
+    TZ=Europe/Amsterdam
 
 WORKDIR /app
 

--- a/infra/concrexit/docker-entrypoint.sh
+++ b/infra/concrexit/docker-entrypoint.sh
@@ -3,11 +3,9 @@
 chown -R appuser /volumes/static
 chown -R appuser /volumes/media
 
-MANAGE_PY=1 runuser -u appuser -- /venv/bin/python manage.py collectstatic --no-input
-MANAGE_PY=1 runuser -u appuser -- /venv/bin/python manage.py compress
-
-MANAGE_PY=1 runuser -u appuser -- /venv/bin/python manage.py migrate --no-input
-MANAGE_PY=1 runuser -u appuser -- /venv/bin/python manage.py createcachetable
+MANAGE_PY=1 runuser -u appuser -- ./manage.py collectstatic --no-input
+MANAGE_PY=1 runuser -u appuser -- ./manage.py migrate --no-input
+MANAGE_PY=1 runuser -u appuser -- ./manage.py createcachetable
 
 # Store all environment variables in /etc/environment for cron to use.
 printenv > /etc/environment

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,8 +4,8 @@
 name = "alabaster"
 version = "0.7.13"
 description = "A configurable sidebar-enabled Sphinx theme"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "alabaster-0.7.13-py3-none-any.whl", hash = "sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3"},
@@ -92,8 +92,8 @@ tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 name = "babel"
 version = "2.12.1"
 description = "Internationalization utilities"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Babel-2.12.1-py3-none-any.whl", hash = "sha256:b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610"},
@@ -266,14 +266,14 @@ crt = ["awscrt (==0.16.9)"]
 
 [[package]]
 name = "cachecontrol"
-version = "0.13.0"
+version = "0.13.1"
 description = "httplib2 caching for requests"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "CacheControl-0.13.0-py3-none-any.whl", hash = "sha256:4544a012a25cf0a73c53cd986f68b4f9c9f6b1df01d741c2923c3d56c66c7bda"},
-    {file = "CacheControl-0.13.0.tar.gz", hash = "sha256:fd3fd2cb0ca66b9a6c1d56cc9709e7e49c63dbd19b1b1bcbd8d3f94cedfe8ce5"},
+    {file = "cachecontrol-0.13.1-py3-none-any.whl", hash = "sha256:95dedbec849f46dda3137866dc28b9d133fc9af55f5b805ab1291833e4457aa4"},
+    {file = "cachecontrol-0.13.1.tar.gz", hash = "sha256:f012366b79d2243a6118309ce73151bf52a38d4a5dac8ea57f09bd29087e506b"},
 ]
 
 [package.dependencies]
@@ -281,6 +281,7 @@ msgpack = ">=0.5.2"
 requests = ">=2.16.0"
 
 [package.extras]
+dev = ["CacheControl[filecache,redis]", "black", "build", "cherrypy", "mypy", "pytest", "pytest-cov", "sphinx", "tox", "types-redis", "types-requests"]
 filecache = ["filelock (>=3.8.0)"]
 redis = ["redis (>=2.10.5)"]
 
@@ -513,8 +514,8 @@ files = [
 name = "commonmark"
 version = "0.9.1"
 description = "Python parser for the CommonMark Markdown spec"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 files = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
@@ -724,7 +725,7 @@ django = ">=2.0"
 name = "django-appconf"
 version = "1.0.5"
 description = "A helper class for handling configuration defaults of packaged apps gracefully."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -754,7 +755,7 @@ Django = ">=3.2"
 name = "django-compressor"
 version = "4.3.1"
 description = "('Compresses linked and inline JavaScript or CSS into single cached files.',)"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 files = [
@@ -869,7 +870,7 @@ icalendar = ">=4.0.3"
 name = "django-libsass"
 version = "0.8"
 description = "A django-compressor filter to compile SASS files using libsass"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 files = [
@@ -958,6 +959,21 @@ files = [
 [package.dependencies]
 django = ">=2.2"
 python-dateutil = "*"
+
+[[package]]
+name = "django-sass-processor"
+version = "1.2.2"
+description = "SASS processor to compile SCSS files into *.css, while rendering, or offline."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-sass-processor-1.2.2.tar.gz", hash = "sha256:f6098c181cc95a21593df6bb502791e32015615222803de216fdcc8bb42c0f77"},
+    {file = "django_sass_processor-1.2.2-py3-none-any.whl", hash = "sha256:d5e2970228ec9648da83d083a2b468fa682bef80357d0bab8e3f6c6df301681e"},
+]
+
+[package.extras]
+management-command = ["django-compressor (>=2.4)"]
 
 [[package]]
 name = "django-sendfile2"
@@ -1068,8 +1084,8 @@ pytz = "*"
 name = "docutils"
 version = "0.19"
 description = "Docutils -- Python Documentation Utilities"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
@@ -1112,19 +1128,19 @@ python-dateutil = ">=2.4"
 
 [[package]]
 name = "filelock"
-version = "3.12.0"
+version = "3.12.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.12.0-py3-none-any.whl", hash = "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9"},
-    {file = "filelock-3.12.0.tar.gz", hash = "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"},
+    {file = "filelock-3.12.2-py3-none-any.whl", hash = "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"},
+    {file = "filelock-3.12.2.tar.gz", hash = "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "firebase-admin"
@@ -1163,34 +1179,34 @@ python-dateutil = ">=2.7"
 
 [[package]]
 name = "google-api-core"
-version = "2.11.0"
+version = "2.11.1"
 description = "Google API client core library"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-core-2.11.0.tar.gz", hash = "sha256:4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22"},
-    {file = "google_api_core-2.11.0-py3-none-any.whl", hash = "sha256:ce222e27b0de0d7bc63eb043b956996d6dccab14cc3b690aaea91c9cc99dc16e"},
+    {file = "google-api-core-2.11.1.tar.gz", hash = "sha256:25d29e05a0058ed5f19c61c0a78b1b53adea4d9364b464d014fbda941f6d1c9a"},
+    {file = "google_api_core-2.11.1-py3-none-any.whl", hash = "sha256:d92a5a92dc36dd4f4b9ee4e55528a90e432b059f93aee6ad857f9de8cc7ae94a"},
 ]
 
 [package.dependencies]
-google-auth = ">=2.14.1,<3.0dev"
-googleapis-common-protos = ">=1.56.2,<2.0dev"
+google-auth = ">=2.14.1,<3.0.dev0"
+googleapis-common-protos = ">=1.56.2,<2.0.dev0"
 grpcio = [
     {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""},
     {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
-    {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""},
-    {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0.dev0", optional = true, markers = "extra == \"grpc\""},
+    {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
-protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
-requests = ">=2.18.0,<3.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
+requests = ">=2.18.0,<3.0.0.dev0"
 
 [package.extras]
-grpc = ["grpcio (>=1.33.2,<2.0dev)", "grpcio (>=1.49.1,<2.0dev)", "grpcio-status (>=1.33.2,<2.0dev)", "grpcio-status (>=1.49.1,<2.0dev)"]
-grpcgcp = ["grpcio-gcp (>=0.2.2,<1.0dev)"]
-grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0dev)"]
+grpc = ["grpcio (>=1.33.2,<2.0dev)", "grpcio (>=1.49.1,<2.0dev)", "grpcio-status (>=1.33.2,<2.0.dev0)", "grpcio-status (>=1.49.1,<2.0.dev0)"]
+grpcgcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
+grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-api-python-client"
@@ -1213,14 +1229,14 @@ uritemplate = ">=3.0.1,<5"
 
 [[package]]
 name = "google-auth"
-version = "2.19.1"
+version = "2.20.0"
 description = "Google Authentication Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "google-auth-2.19.1.tar.gz", hash = "sha256:a9cfa88b3e16196845e64a3658eb953992129d13ac7337b064c6546f77c17183"},
-    {file = "google_auth-2.19.1-py2.py3-none-any.whl", hash = "sha256:ea165e014c7cbd496558796b627c271aa8c18b4cba79dc1cc962b24c5efdfb85"},
+    {file = "google-auth-2.20.0.tar.gz", hash = "sha256:030af34138909ccde0fbce611afc178f1d65d32fbff281f25738b1fe1c6f3eaa"},
+    {file = "google_auth-2.20.0-py2.py3-none-any.whl", hash = "sha256:23b7b0950fcda519bfb6692bf0d5289d2ea49fc143717cc7188458ec620e63fa"},
 ]
 
 [package.dependencies]
@@ -1231,11 +1247,11 @@ six = ">=1.9.0"
 urllib3 = "<2.0"
 
 [package.extras]
-aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "requests (>=2.20.0,<3.0.0dev)"]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0.dev0)", "requests (>=2.20.0,<3.0.0.dev0)"]
 enterprise-cert = ["cryptography (==36.0.2)", "pyopenssl (==22.0.0)"]
 pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
-requests = ["requests (>=2.20.0,<3.0.0dev)"]
+requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
 
 [[package]]
 name = "google-auth-httplib2"
@@ -1418,95 +1434,95 @@ requests = ["requests (>=2.18.0,<3.0.0dev)"]
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.59.0"
+version = "1.59.1"
 description = "Common protobufs used in Google APIs"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "googleapis-common-protos-1.59.0.tar.gz", hash = "sha256:4168fcb568a826a52f23510412da405abd93f4d23ba544bb68d943b14ba3cb44"},
-    {file = "googleapis_common_protos-1.59.0-py2.py3-none-any.whl", hash = "sha256:b287dc48449d1d41af0c69f4ea26242b5ae4c3d7249a38b0984c86a4caffff1f"},
+    {file = "googleapis-common-protos-1.59.1.tar.gz", hash = "sha256:b35d530fe825fb4227857bc47ad84c33c809ac96f312e13182bdeaa2abe1178a"},
+    {file = "googleapis_common_protos-1.59.1-py2.py3-none-any.whl", hash = "sha256:0cbedb6fb68f1c07e18eb4c48256320777707e7d0c55063ae56c15db3224a61e"},
 ]
 
 [package.dependencies]
-protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
 
 [package.extras]
-grpc = ["grpcio (>=1.44.0,<2.0.0dev)"]
+grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
 name = "grpcio"
-version = "1.54.2"
+version = "1.56.0"
 description = "HTTP/2-based RPC framework"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "grpcio-1.54.2-cp310-cp310-linux_armv7l.whl", hash = "sha256:40e1cbf69d6741b40f750f3cccc64326f927ac6145a9914d33879e586002350c"},
-    {file = "grpcio-1.54.2-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:2288d76e4d4aa7ef3fe7a73c1c470b66ea68e7969930e746a8cd8eca6ef2a2ea"},
-    {file = "grpcio-1.54.2-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:c0e3155fc5335ec7b3b70f15230234e529ca3607b20a562b6c75fb1b1218874c"},
-    {file = "grpcio-1.54.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bf88004fe086c786dc56ef8dd6cb49c026833fdd6f42cb853008bce3f907148"},
-    {file = "grpcio-1.54.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2be88c081e33f20630ac3343d8ad9f1125f32987968e9c8c75c051c9800896e8"},
-    {file = "grpcio-1.54.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:33d40954199bddbb6a78f8f6f2b2082660f381cd2583ec860a6c2fa7c8400c08"},
-    {file = "grpcio-1.54.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b52d00d1793d290c81ad6a27058f5224a7d5f527867e5b580742e1bd211afeee"},
-    {file = "grpcio-1.54.2-cp310-cp310-win32.whl", hash = "sha256:881d058c5ccbea7cc2c92085a11947b572498a27ef37d3eef4887f499054dca8"},
-    {file = "grpcio-1.54.2-cp310-cp310-win_amd64.whl", hash = "sha256:0212e2f7fdf7592e4b9d365087da30cb4d71e16a6f213120c89b4f8fb35a3ab3"},
-    {file = "grpcio-1.54.2-cp311-cp311-linux_armv7l.whl", hash = "sha256:1e623e0cf99a0ac114f091b3083a1848dbc64b0b99e181473b5a4a68d4f6f821"},
-    {file = "grpcio-1.54.2-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:66233ccd2a9371158d96e05d082043d47dadb18cbb294dc5accfdafc2e6b02a7"},
-    {file = "grpcio-1.54.2-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:4cb283f630624ebb16c834e5ac3d7880831b07cbe76cb08ab7a271eeaeb8943e"},
-    {file = "grpcio-1.54.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a1e601ee31ef30a9e2c601d0867e236ac54c922d32ed9f727b70dd5d82600d5"},
-    {file = "grpcio-1.54.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8da84bbc61a4e92af54dc96344f328e5822d574f767e9b08e1602bb5ddc254a"},
-    {file = "grpcio-1.54.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:5008964885e8d23313c8e5ea0d44433be9bfd7e24482574e8cc43c02c02fc796"},
-    {file = "grpcio-1.54.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a2f5a1f1080ccdc7cbaf1171b2cf384d852496fe81ddedeb882d42b85727f610"},
-    {file = "grpcio-1.54.2-cp311-cp311-win32.whl", hash = "sha256:b74ae837368cfffeb3f6b498688a123e6b960951be4dec0e869de77e7fa0439e"},
-    {file = "grpcio-1.54.2-cp311-cp311-win_amd64.whl", hash = "sha256:8cdbcbd687e576d48f7886157c95052825ca9948c0ed2afdc0134305067be88b"},
-    {file = "grpcio-1.54.2-cp37-cp37m-linux_armv7l.whl", hash = "sha256:782f4f8662a2157c4190d0f99eaaebc602899e84fb1e562a944e5025929e351c"},
-    {file = "grpcio-1.54.2-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:714242ad0afa63a2e6dabd522ae22e1d76e07060b5af2ddda5474ba4f14c2c94"},
-    {file = "grpcio-1.54.2-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:f900ed4ad7a0f1f05d35f955e0943944d5a75f607a836958c6b8ab2a81730ef2"},
-    {file = "grpcio-1.54.2-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96a41817d2c763b1d0b32675abeb9179aa2371c72aefdf74b2d2b99a1b92417b"},
-    {file = "grpcio-1.54.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70fcac7b94f4c904152809a050164650ac81c08e62c27aa9f156ac518029ebbe"},
-    {file = "grpcio-1.54.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:fd6c6c29717724acf9fc1847c4515d57e4dc12762452457b9cb37461f30a81bb"},
-    {file = "grpcio-1.54.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c2392f5b5d84b71d853918687d806c1aa4308109e5ca158a16e16a6be71041eb"},
-    {file = "grpcio-1.54.2-cp37-cp37m-win_amd64.whl", hash = "sha256:51630c92591d6d3fe488a7c706bd30a61594d144bac7dee20c8e1ce78294f474"},
-    {file = "grpcio-1.54.2-cp38-cp38-linux_armv7l.whl", hash = "sha256:b04202453941a63b36876a7172b45366dc0cde10d5fd7855c0f4a4e673c0357a"},
-    {file = "grpcio-1.54.2-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:89dde0ac72a858a44a2feb8e43dc68c0c66f7857a23f806e81e1b7cc7044c9cf"},
-    {file = "grpcio-1.54.2-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:09d4bfd84686cd36fd11fd45a0732c7628308d094b14d28ea74a81db0bce2ed3"},
-    {file = "grpcio-1.54.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7fc2b4edb938c8faa4b3c3ea90ca0dd89b7565a049e8e4e11b77e60e4ed2cc05"},
-    {file = "grpcio-1.54.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61f7203e2767800edee7a1e1040aaaf124a35ce0c7fe0883965c6b762defe598"},
-    {file = "grpcio-1.54.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e416c8baf925b5a1aff31f7f5aecc0060b25d50cce3a5a7255dc5cf2f1d4e5eb"},
-    {file = "grpcio-1.54.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:dc80c9c6b608bf98066a038e0172013a49cfa9a08d53335aefefda2c64fc68f4"},
-    {file = "grpcio-1.54.2-cp38-cp38-win32.whl", hash = "sha256:8d6192c37a30a115f4663592861f50e130caed33efc4eec24d92ec881c92d771"},
-    {file = "grpcio-1.54.2-cp38-cp38-win_amd64.whl", hash = "sha256:46a057329938b08e5f0e12ea3d7aed3ecb20a0c34c4a324ef34e00cecdb88a12"},
-    {file = "grpcio-1.54.2-cp39-cp39-linux_armv7l.whl", hash = "sha256:2296356b5c9605b73ed6a52660b538787094dae13786ba53080595d52df13a98"},
-    {file = "grpcio-1.54.2-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:c72956972e4b508dd39fdc7646637a791a9665b478e768ffa5f4fe42123d5de1"},
-    {file = "grpcio-1.54.2-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:9bdbb7624d65dc0ed2ed8e954e79ab1724526f09b1efa88dcd9a1815bf28be5f"},
-    {file = "grpcio-1.54.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c44e1a765b31e175c391f22e8fc73b2a2ece0e5e6ff042743d8109b5d2eff9f"},
-    {file = "grpcio-1.54.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cc928cfe6c360c1df636cf7991ab96f059666ac7b40b75a769410cc6217df9c"},
-    {file = "grpcio-1.54.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a08920fa1a97d4b8ee5db2f31195de4a9def1a91bc003544eb3c9e6b8977960a"},
-    {file = "grpcio-1.54.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4864f99aac207e3e45c5e26c6cbb0ad82917869abc2f156283be86c05286485c"},
-    {file = "grpcio-1.54.2-cp39-cp39-win32.whl", hash = "sha256:b38b3de8cff5bc70f8f9c615f51b48eff7313fc9aca354f09f81b73036e7ddfa"},
-    {file = "grpcio-1.54.2-cp39-cp39-win_amd64.whl", hash = "sha256:be48496b0e00460717225e7680de57c38be1d8629dc09dadcd1b3389d70d942b"},
-    {file = "grpcio-1.54.2.tar.gz", hash = "sha256:50a9f075eeda5097aa9a182bb3877fe1272875e45370368ac0ee16ab9e22d019"},
+    {file = "grpcio-1.56.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:fb34ace11419f1ae321c36ccaa18d81cd3f20728cd191250be42949d6845bb2d"},
+    {file = "grpcio-1.56.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:008767c0aed4899e657b50f2e0beacbabccab51359eba547f860e7c55f2be6ba"},
+    {file = "grpcio-1.56.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:17f47aeb9be0da5337f9ff33ebb8795899021e6c0741ee68bd69774a7804ca86"},
+    {file = "grpcio-1.56.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43c50d810cc26349b093bf2cfe86756ab3e9aba3e7e681d360930c1268e1399a"},
+    {file = "grpcio-1.56.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187b8f71bad7d41eea15e0c9812aaa2b87adfb343895fffb704fb040ca731863"},
+    {file = "grpcio-1.56.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:881575f240eb5db72ddca4dc5602898c29bc082e0d94599bf20588fb7d1ee6a0"},
+    {file = "grpcio-1.56.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c243b158dd7585021d16c50498c4b2ec0a64a6119967440c5ff2d8c89e72330e"},
+    {file = "grpcio-1.56.0-cp310-cp310-win32.whl", hash = "sha256:8b3b2c7b5feef90bc9a5fa1c7f97637e55ec3e76460c6d16c3013952ee479cd9"},
+    {file = "grpcio-1.56.0-cp310-cp310-win_amd64.whl", hash = "sha256:03a80451530fd3b8b155e0c4480434f6be669daf7ecba56f73ef98f94222ee01"},
+    {file = "grpcio-1.56.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:64bd3abcf9fb4a9fa4ede8d0d34686314a7075f62a1502217b227991d9ca4245"},
+    {file = "grpcio-1.56.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:fdc3a895791af4addbb826808d4c9c35917c59bb5c430d729f44224e51c92d61"},
+    {file = "grpcio-1.56.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:4f84a6fd4482e5fe73b297d4874b62a535bc75dc6aec8e9fe0dc88106cd40397"},
+    {file = "grpcio-1.56.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14e70b4dda3183abea94c72d41d5930c333b21f8561c1904a372d80370592ef3"},
+    {file = "grpcio-1.56.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b5ce42a5ebe3e04796246ba50357f1813c44a6efe17a37f8dc7a5c470377312"},
+    {file = "grpcio-1.56.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:8219f17baf069fe8e42bd8ca0b312b875595e43a70cabf397be4fda488e2f27d"},
+    {file = "grpcio-1.56.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:defdd14b518e6e468466f799aaa69db0355bca8d3a5ea75fb912d28ba6f8af31"},
+    {file = "grpcio-1.56.0-cp311-cp311-win32.whl", hash = "sha256:50f4daa698835accbbcc60e61e0bc29636c0156ddcafb3891c987e533a0031ba"},
+    {file = "grpcio-1.56.0-cp311-cp311-win_amd64.whl", hash = "sha256:59c4e606993a47146fbeaf304b9e78c447f5b9ee5641cae013028c4cca784617"},
+    {file = "grpcio-1.56.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:b1f4b6f25a87d80b28dd6d02e87d63fe1577fe6d04a60a17454e3f8077a38279"},
+    {file = "grpcio-1.56.0-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:c2148170e01d464d41011a878088444c13413264418b557f0bdcd1bf1b674a0e"},
+    {file = "grpcio-1.56.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:0409de787ebbf08c9d2bca2bcc7762c1efe72eada164af78b50567a8dfc7253c"},
+    {file = "grpcio-1.56.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66f0369d27f4c105cd21059d635860bb2ea81bd593061c45fb64875103f40e4a"},
+    {file = "grpcio-1.56.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38fdf5bd0a1c754ce6bf9311a3c2c7ebe56e88b8763593316b69e0e9a56af1de"},
+    {file = "grpcio-1.56.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:79d4c5911d12a7aa671e5eb40cbb50a830396525014d2d6f254ea2ba180ce637"},
+    {file = "grpcio-1.56.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5d2fc471668a7222e213f86ef76933b18cdda6a51ea1322034478df8c6519959"},
+    {file = "grpcio-1.56.0-cp37-cp37m-win_amd64.whl", hash = "sha256:991224fd485e088d3cb5e34366053691a4848a6b7112b8f5625a411305c26691"},
+    {file = "grpcio-1.56.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:c6f36621aabecbaff3e70c4d1d924c76c8e6a7ffec60c331893640a4af0a8037"},
+    {file = "grpcio-1.56.0-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:1eadd6de258901929223f422ffed7f8b310c0323324caf59227f9899ea1b1674"},
+    {file = "grpcio-1.56.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:72836b5a1d4f508ffbcfe35033d027859cc737972f9dddbe33fb75d687421e2e"},
+    {file = "grpcio-1.56.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f92a99ab0c7772fb6859bf2e4f44ad30088d18f7c67b83205297bfb229e0d2cf"},
+    {file = "grpcio-1.56.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa08affbf672d051cd3da62303901aeb7042a2c188c03b2c2a2d346fc5e81c14"},
+    {file = "grpcio-1.56.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2db108b4c8e29c145e95b0226973a66d73ae3e3e7fae00329294af4e27f1c42"},
+    {file = "grpcio-1.56.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8674fdbd28266d8efbcddacf4ec3643f76fe6376f73283fd63a8374c14b0ef7c"},
+    {file = "grpcio-1.56.0-cp38-cp38-win32.whl", hash = "sha256:bd55f743e654fb050c665968d7ec2c33f03578a4bbb163cfce38024775ff54cc"},
+    {file = "grpcio-1.56.0-cp38-cp38-win_amd64.whl", hash = "sha256:c63bc5ac6c7e646c296fed9139097ae0f0e63f36f0864d7ce431cce61fe0118a"},
+    {file = "grpcio-1.56.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:c0bc9dda550785d23f4f025be614b7faa8d0293e10811f0f8536cf50435b7a30"},
+    {file = "grpcio-1.56.0-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:d596408bab632ec7b947761e83ce6b3e7632e26b76d64c239ba66b554b7ee286"},
+    {file = "grpcio-1.56.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:76b6e6e1ee9bda32e6e933efd61c512e9a9f377d7c580977f090d1a9c78cca44"},
+    {file = "grpcio-1.56.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7beb84ebd0a3f732625124b73969d12b7350c5d9d64ddf81ae739bbc63d5b1ed"},
+    {file = "grpcio-1.56.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83ec714bbbe9b9502177c842417fde39f7a267031e01fa3cd83f1ca49688f537"},
+    {file = "grpcio-1.56.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4feee75565d1b5ab09cb3a5da672b84ca7f6dd80ee07a50f5537207a9af543a4"},
+    {file = "grpcio-1.56.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b4638a796778329cc8e142e4f57c705adb286b3ba64e00b0fa91eeb919611be8"},
+    {file = "grpcio-1.56.0-cp39-cp39-win32.whl", hash = "sha256:437af5a7673bca89c4bc0a993382200592d104dd7bf55eddcd141cef91f40bab"},
+    {file = "grpcio-1.56.0-cp39-cp39-win_amd64.whl", hash = "sha256:4241a1c2c76e748023c834995cd916570e7180ee478969c2d79a60ce007bc837"},
+    {file = "grpcio-1.56.0.tar.gz", hash = "sha256:4c08ee21b3d10315b8dc26f6c13917b20ed574cdbed2d2d80c53d5508fdcc0f2"},
 ]
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.54.2)"]
+protobuf = ["grpcio-tools (>=1.56.0)"]
 
 [[package]]
 name = "grpcio-status"
-version = "1.54.2"
+version = "1.56.0"
 description = "Status proto mapping for gRPC"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "grpcio-status-1.54.2.tar.gz", hash = "sha256:3255cbec5b7c706caa3d4dd584606c080e6415e15631bb2f6215e2b70055836d"},
-    {file = "grpcio_status-1.54.2-py3-none-any.whl", hash = "sha256:2a7cb4838225f1b53bd0448a3008c5b5837941e1f3a0b13fa38768f08a7b68c2"},
+    {file = "grpcio-status-1.56.0.tar.gz", hash = "sha256:9eca0b2dcda0782d3702df225918efd6d820f75f93cd5c51c7fb6a4ffbfea12c"},
+    {file = "grpcio_status-1.56.0-py3-none-any.whl", hash = "sha256:e5f101c96686e9d4e94a114567960fdb00052aa3c818b029745e3db37dc9c613"},
 ]
 
 [package.dependencies]
 googleapis-common-protos = ">=1.5.5"
-grpcio = ">=1.54.2"
+grpcio = ">=1.56.0"
 protobuf = ">=4.21.6"
 
 [[package]]
@@ -1592,8 +1608,8 @@ files = [
 name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
@@ -1602,14 +1618,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.6.0"
+version = "6.7.0"
 description = "Read metadata from Python packages"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-6.6.0-py3-none-any.whl", hash = "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed"},
-    {file = "importlib_metadata-6.6.0.tar.gz", hash = "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"},
+    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
+    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
 ]
 
 [package.dependencies]
@@ -1618,7 +1634,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "isort"
@@ -1642,8 +1658,8 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
@@ -1687,7 +1703,7 @@ deprecated = "*"
 name = "libsass"
 version = "0.22.0"
 description = "Sass for Python: A straightforward binding of libsass for Python."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1702,8 +1718,8 @@ files = [
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
@@ -1879,7 +1895,7 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1981,19 +1997,19 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "platformdirs"
-version = "3.5.1"
+version = "3.8.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
-    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
+    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
+    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pre-commit"
@@ -2016,14 +2032,14 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "proto-plus"
-version = "1.22.2"
+version = "1.22.3"
 description = "Beautiful, Pythonic protocol buffers."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "proto-plus-1.22.2.tar.gz", hash = "sha256:0e8cda3d5a634d9895b75c573c9352c16486cb75deb0e078b5fda34db4243165"},
-    {file = "proto_plus-1.22.2-py3-none-any.whl", hash = "sha256:de34e52d6c9c6fcd704192f09767cb561bb4ee64e70eede20b0834d841f0be4d"},
+    {file = "proto-plus-1.22.3.tar.gz", hash = "sha256:fdcd09713cbd42480740d2fe29c990f7fbd885a67efc328aa8be6ee3e9f76a6b"},
+    {file = "proto_plus-1.22.3-py3-none-any.whl", hash = "sha256:a49cd903bc0b6ab41f76bf65510439d56ca76f868adf0274e738bfdd096894df"},
 ]
 
 [package.dependencies]
@@ -2034,33 +2050,33 @@ testing = ["google-api-core[grpc] (>=1.31.5)"]
 
 [[package]]
 name = "protobuf"
-version = "4.23.2"
+version = "4.23.3"
 description = ""
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "protobuf-4.23.2-cp310-abi3-win32.whl", hash = "sha256:384dd44cb4c43f2ccddd3645389a23ae61aeb8cfa15ca3a0f60e7c3ea09b28b3"},
-    {file = "protobuf-4.23.2-cp310-abi3-win_amd64.whl", hash = "sha256:09310bce43353b46d73ba7e3bca78273b9bc50349509b9698e64d288c6372c2a"},
-    {file = "protobuf-4.23.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:b2cfab63a230b39ae603834718db74ac11e52bccaaf19bf20f5cce1a84cf76df"},
-    {file = "protobuf-4.23.2-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:c52cfcbfba8eb791255edd675c1fe6056f723bf832fa67f0442218f8817c076e"},
-    {file = "protobuf-4.23.2-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:86df87016d290143c7ce3be3ad52d055714ebaebb57cc659c387e76cfacd81aa"},
-    {file = "protobuf-4.23.2-cp37-cp37m-win32.whl", hash = "sha256:281342ea5eb631c86697e1e048cb7e73b8a4e85f3299a128c116f05f5c668f8f"},
-    {file = "protobuf-4.23.2-cp37-cp37m-win_amd64.whl", hash = "sha256:ce744938406de1e64b91410f473736e815f28c3b71201302612a68bf01517fea"},
-    {file = "protobuf-4.23.2-cp38-cp38-win32.whl", hash = "sha256:6c081863c379bb1741be8f8193e893511312b1d7329b4a75445d1ea9955be69e"},
-    {file = "protobuf-4.23.2-cp38-cp38-win_amd64.whl", hash = "sha256:25e3370eda26469b58b602e29dff069cfaae8eaa0ef4550039cc5ef8dc004511"},
-    {file = "protobuf-4.23.2-cp39-cp39-win32.whl", hash = "sha256:efabbbbac1ab519a514579ba9ec52f006c28ae19d97915951f69fa70da2c9e91"},
-    {file = "protobuf-4.23.2-cp39-cp39-win_amd64.whl", hash = "sha256:54a533b971288af3b9926e53850c7eb186886c0c84e61daa8444385a4720297f"},
-    {file = "protobuf-4.23.2-py3-none-any.whl", hash = "sha256:8da6070310d634c99c0db7df48f10da495cc283fd9e9234877f0cd182d43ab7f"},
-    {file = "protobuf-4.23.2.tar.gz", hash = "sha256:20874e7ca4436f683b64ebdbee2129a5a2c301579a67d1a7dda2cdf62fb7f5f7"},
+    {file = "protobuf-4.23.3-cp310-abi3-win32.whl", hash = "sha256:514b6bbd54a41ca50c86dd5ad6488afe9505901b3557c5e0f7823a0cf67106fb"},
+    {file = "protobuf-4.23.3-cp310-abi3-win_amd64.whl", hash = "sha256:cc14358a8742c4e06b1bfe4be1afbdf5c9f6bd094dff3e14edb78a1513893ff5"},
+    {file = "protobuf-4.23.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:2991f5e7690dab569f8f81702e6700e7364cc3b5e572725098215d3da5ccc6ac"},
+    {file = "protobuf-4.23.3-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:08fe19d267608d438aa37019236db02b306e33f6b9902c3163838b8e75970223"},
+    {file = "protobuf-4.23.3-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:3b01a5274ac920feb75d0b372d901524f7e3ad39c63b1a2d55043f3887afe0c1"},
+    {file = "protobuf-4.23.3-cp37-cp37m-win32.whl", hash = "sha256:aca6e86a08c5c5962f55eac9b5bd6fce6ed98645d77e8bfc2b952ecd4a8e4f6a"},
+    {file = "protobuf-4.23.3-cp37-cp37m-win_amd64.whl", hash = "sha256:0149053336a466e3e0b040e54d0b615fc71de86da66791c592cc3c8d18150bf8"},
+    {file = "protobuf-4.23.3-cp38-cp38-win32.whl", hash = "sha256:84ea0bd90c2fdd70ddd9f3d3fc0197cc24ecec1345856c2b5ba70e4d99815359"},
+    {file = "protobuf-4.23.3-cp38-cp38-win_amd64.whl", hash = "sha256:3bcbeb2bf4bb61fe960dd6e005801a23a43578200ea8ceb726d1f6bd0e562ba1"},
+    {file = "protobuf-4.23.3-cp39-cp39-win32.whl", hash = "sha256:5cb9e41188737f321f4fce9a4337bf40a5414b8d03227e1d9fbc59bc3a216e35"},
+    {file = "protobuf-4.23.3-cp39-cp39-win_amd64.whl", hash = "sha256:29660574cd769f2324a57fb78127cda59327eb6664381ecfe1c69731b83e8288"},
+    {file = "protobuf-4.23.3-py3-none-any.whl", hash = "sha256:447b9786ac8e50ae72cae7a2eec5c5df6a9dbf9aa6f908f1b8bda6032644ea62"},
+    {file = "protobuf-4.23.3.tar.gz", hash = "sha256:7a92beb30600332a52cdadbedb40d33fd7c8a0d7f549c440347bc606fb3fe34b"},
 ]
 
 [[package]]
 name = "psycopg2"
 version = "2.9.6"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "psycopg2-2.9.6-cp310-cp310-win32.whl", hash = "sha256:f7a7a5ee78ba7dc74265ba69e010ae89dae635eea0e97b055fb641a01a31d2b1"},
@@ -2150,8 +2166,8 @@ pyparsing = ">=2.1.4"
 name = "pygments"
 version = "2.15.1"
 description = "Pygments is a syntax highlighting package written in Python."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
@@ -2269,7 +2285,7 @@ files = [
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -2344,7 +2360,7 @@ test = ["coverage", "pytest"]
 name = "rcssmin"
 version = "1.1.1"
 description = "CSS Minifier"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 files = [
@@ -2377,8 +2393,8 @@ files = [
 name = "recommonmark"
 version = "0.7.1"
 description = "A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 files = [
     {file = "recommonmark-0.7.1-py2.py3-none-any.whl", hash = "sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f"},
@@ -2416,7 +2432,7 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "rjsmin"
 version = "1.2.1"
 description = "Javascript Minifier"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 files = [
@@ -2550,14 +2566,14 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "setuptools"
-version = "67.8.0"
+version = "68.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
-    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 
 [package.extras]
@@ -2593,8 +2609,8 @@ files = [
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
@@ -2617,8 +2633,8 @@ files = [
 name = "sphinx"
 version = "6.2.1"
 description = "Python documentation generator"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "Sphinx-6.2.1.tar.gz", hash = "sha256:6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b"},
@@ -2653,8 +2669,8 @@ test = ["cython", "filelock", "html5lib", "pytest (>=4.6)"]
 name = "sphinxcontrib-applehelp"
 version = "1.0.4"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
@@ -2669,8 +2685,8 @@ test = ["pytest"]
 name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
@@ -2685,8 +2701,8 @@ test = ["pytest"]
 name = "sphinxcontrib-htmlhelp"
 version = "2.0.1"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"},
@@ -2701,8 +2717,8 @@ test = ["html5lib", "pytest"]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -2716,8 +2732,8 @@ test = ["flake8", "mypy", "pytest"]
 name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
@@ -2732,8 +2748,8 @@ test = ["pytest"]
 name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
@@ -2847,24 +2863,24 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.23.0"
+version = "20.23.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.23.0-py3-none-any.whl", hash = "sha256:6abec7670e5802a528357fdc75b26b9f57d5d92f29c5462ba0fbe45feacc685e"},
-    {file = "virtualenv-20.23.0.tar.gz", hash = "sha256:a85caa554ced0c0afbd0d638e7e2d7b5f92d23478d05d17a76daeac8f279f924"},
+    {file = "virtualenv-20.23.1-py3-none-any.whl", hash = "sha256:34da10f14fea9be20e0fd7f04aba9732f84e593dac291b757ce42e3368a39419"},
+    {file = "virtualenv-20.23.1.tar.gz", hash = "sha256:8ff19a38c1021c742148edc4f81cb43d7f8c6816d2ede2ab72af5b84c749ade1"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.6,<1"
-filelock = ">=3.11,<4"
-platformdirs = ">=3.2,<4"
+filelock = ">=3.12,<4"
+platformdirs = ">=3.5.1,<4"
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
-test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.7.1)", "time-machine (>=2.9)"]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
 
 [[package]]
 name = "webencodings"
@@ -2967,8 +2983,8 @@ files = [
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
@@ -2979,11 +2995,7 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
-[extras]
-docs = ["recommonmark", "sphinx"]
-postgres = ["psycopg2"]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "29f6b7d6a60c430db285ddabb4ca8b7ca9409cb6ad770783dd82563ea9a633bb"
+content-hash = "e70b787d5518dc69f4e82f677cfbd920385dd80945d6beeef2ef99b3a3562072"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,50 +7,58 @@ license = "AGPL-3.0-or-later"
 
 [tool.poetry.dependencies]
 python = "^3.9"
+Django = "4.2.2"
 django-localflavor = "4.0"
-freezegun = "1.2.2"
-bleach = {extras = ["css"], version = "^6.0.0"}
 djangorestframework = "3.14.0"
 django-ical = "1.9.2"
-django-libsass = "0.8.0"
-python-magic = "0.4.27"
-Pillow = "9.5.0"
-Django = "4.2.2"
-django-compressor = "4.3.1"
-psycopg2 = {version = "2.9.6", optional = true}
-bcrypt = "4.0.1"
-argon2_cffi = "21.3.0"
-firebase-admin = "6.2.0"
-sentry-sdk = "1.26.0"
 django-sendfile2 = "0.7.0"
 django-queryable-properties = "1.8.4"
-google-api-python-client = "2.90.0"
 django-oauth-toolkit = "2.3.0"
 django-cors-headers = "3.14.0"
 django-debug-toolbar = "4.1.0"
 django-admin-autocomplete-filter = "0.7.1"
-PyYAML = "6.0"
 django-bootstrap5 = "^22.1"
 django-tinymce = "^3.4.0"
-beautifulsoup4 = "^4.11.1"
 django-storages = "^1.12.3"
-boto3 = "^1.23.7"
-gunicorn = "^20.1.0"
-
-# docs requirements
-recommonmark = { version = "0.7.1", optional = true }
-sphinx = { version = "6.2.1", optional = true }
-qrcode = {version = "^7.3.1", extras = ["pil"]}
 django-drf-filepond = "^0.5.0"
 django-filepond-widget = "^0.9.0"
 django-thumbnails = "^0.7.0"
 django-ratelimit = "^4.0.0"
+django-sass-processor = "^1.2.2"
+bleach = {extras = ["css"], version = "^6.0.0"}
+Pillow = "9.5.0"
+python-magic = "0.4.27"
+bcrypt = "4.0.1"
+argon2_cffi = "21.3.0"
+firebase-admin = "6.2.0"
+google-api-python-client = "2.90.0"
+sentry-sdk = "1.26.0"
+beautifulsoup4 = "^4.11.1"
+boto3 = "^1.23.7"
+gunicorn = "^20.1.0"
+qrcode = {version = "^7.3.1", extras = ["pil"]}
+freezegun = "1.2.2"
 
-[tool.poetry.extras]
-docs = ["recommonmark", "sphinx"]
-postgres = ["psycopg2"]
+[tool.poetry.group.scss.dependencies]
+# These dependencies are only needed to compile SASS, which can be done
+# offline during a build. So these are not needed in production.
+django-libsass = "0.8.0"
+django-compressor = "4.3.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.postgres]
+optional = true
+
+[tool.poetry.group.postgres.dependencies]
+psycopg2 = "2.9.6"
+
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
+recommonmark = "0.7.1"
+sphinx = "6.2.1"
+
+[tool.poetry.group.dev.dependencies]
 django-template-check = "0.4.0"
 factory_boy = "3.2.1"
 pydenticon = "0.3.1"
@@ -65,7 +73,7 @@ pydot = "^1.4.2"
 django-extensions = "^3.2.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.2.0"]
 build-backend = "poetry.masonry.api"
 
 [tool.coverage.run]

--- a/website/documents/templates/documents/index.html
+++ b/website/documents/templates/documents/index.html
@@ -6,7 +6,6 @@
 
 {% block css_head %}
     {{ block.super }}
-    {% comment %} TODO: SCSS per app is both imported in the main.scss, and included in html... We need only one of the 2. {% endcomment %}
     <link href="{% sass_src "documents/css/style.scss" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 

--- a/website/documents/templates/documents/index.html
+++ b/website/documents/templates/documents/index.html
@@ -1,15 +1,13 @@
 {% extends 'base.html' %}
-{% load static i18n compress document_cards %}
+{% load sass_tags i18n document_cards %}
 
 {% block title %}Documents — {{ block.super }}{% endblock %}
 {% block opengraph_title %}Documents — {{ block.super }}{% endblock %}
 
 {% block css_head %}
     {{ block.super }}
-    {% compress css %}
-        <link href="{% static "documents/css/style.scss" %}" rel="stylesheet"
-              type="text/x-scss">
-    {% endcompress %}
+    {% comment %} TODO: SCSS per app is both imported in the main.scss, and included in html... We need only one of the 2. {% endcomment %}
+    <link href="{% sass_src "documents/css/style.scss" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block body %}

--- a/website/education/templates/education/base.html
+++ b/website/education/templates/education/base.html
@@ -1,4 +1,4 @@
 {% extends 'simple_page.html' %}
-{% load static compress %}
+{% load static %}
 
 {% block header_image %}{% static "img/headers/fixed/banner3.jpg" %}{% endblock header_image%}

--- a/website/education/templates/education/base_small.html
+++ b/website/education/templates/education/base_small.html
@@ -1,4 +1,4 @@
 {% extends 'small_page.html' %}
-{% load static compress %}
+{% load static %}
 
 {% block header_image %}{% static "img/headers/fixed/banner3.jpg" %}{% endblock header_image%}

--- a/website/education/templates/education/courses.html
+++ b/website/education/templates/education/courses.html
@@ -1,5 +1,5 @@
 {% extends 'education/base.html' %}
-{% load i18n compress static %}
+{% load i18n static %}
 
 {% block title %}{% trans "Course overview" %} —
     {{ block.super }}{% endblock %}
@@ -99,10 +99,6 @@
 
 {% block js_body %}
     {{ block.super }}
-    {% compress js %}
-        <script type="text/javascript"
-                src="{% static 'js/mixitup.min.js' %}"></script>
-        <script type="text/javascript"
-                src="{% static 'education/js/main.js' %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static 'js/mixitup.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'education/js/main.js' %}"></script>
 {% endblock %}

--- a/website/events/templates/events/admin/details.html
+++ b/website/events/templates/events/admin/details.html
@@ -1,14 +1,12 @@
 {% extends 'admin/index.html' %}
-{% load i18n admin_urls static admin_modify compress %}
+{% load i18n admin_urls static sass_tags admin_modify %}
 
 {% block title %}{{ event.title }} | {{ site_title|default:_('Thalia site admin') }}{% endblock %}
 {% block opengraph_title %}{{ event.title }} | {{ site_title|default:_('Thalia site admin') }}{% endblock %}
 
 {% block extrastyle %}
     {{ block.super }}
-    {% compress css %}
-    <link href="{% static "events/css/admin.scss" %}" rel="stylesheet" type="text/x-scss">
-    {% endcompress %}
+    <link href="{% sass_src "events/css/admin.scss" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block extrahead %}

--- a/website/events/templates/events/index.html
+++ b/website/events/templates/events/index.html
@@ -1,5 +1,5 @@
 {% extends "simple_page.html" %}
-{% load i18n static compress personal_feed %}}
+{% load i18n static personal_feed %}}
 {% get_current_language as LANGUAGE_CODE %}
 
 {% block title %}{% trans "Calendar"|capfirst %} —
@@ -9,14 +9,9 @@
 
 {% block css_head %}
     {{ block.super }}
-    {% compress css %}
-        <link href="{% static "events/css/fullcalendar.core.css" %}"
-              rel="stylesheet" type="text/css">
-        <link href="{% static "events/css/fullcalendar.timegrid.css" %}"
-              rel="stylesheet" type="text/css">
-        <link href="{% static "events/css/fullcalendar.bootstrap.css" %}"
-              rel="stylesheet" type="text/css">
-    {% endcompress %}
+    <link href="{% static "events/css/fullcalendar.core.css" %}" rel="stylesheet" type="text/css">
+    <link href="{% static "events/css/fullcalendar.timegrid.css" %}" rel="stylesheet" type="text/css">
+    <link href="{% static "events/css/fullcalendar.bootstrap.css" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block page_title %}
@@ -60,20 +55,11 @@
 
 {% block js_body %}
     {{ block.super }}
-    {% compress js %}
-        <script type="text/javascript"
-                src="{% static "events/js/fullcalendar.locale.js" %}"></script>
-        <script type="text/javascript"
-                src="{% static "events/js/fullcalendar.core.js" %}"></script>
-        <script type="text/javascript"
-                src="{% static "events/js/fullcalendar.bootstrap.js" %}"></script>
-        <script type="text/javascript"
-                src="{% static "events/js/fullcalendar.daygrid.js" %}"></script>
-        <script type="text/javascript"
-                src="{% static "events/js/fullcalendar.timegrid.js" %}"></script>
-        <script type="text/javascript"
-                src="{% static "events/js/listview.js" %}"></script>
-        <script type="text/javascript"
-                src="{% static "events/js/main.js" %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static "events/js/fullcalendar.locale.js" %}"></script>
+    <script type="text/javascript" src="{% static "events/js/fullcalendar.core.js" %}"></script>
+    <script type="text/javascript" src="{% static "events/js/fullcalendar.bootstrap.js" %}"></script>
+    <script type="text/javascript" src="{% static "events/js/fullcalendar.daygrid.js" %}"></script>
+    <script type="text/javascript" src="{% static "events/js/fullcalendar.timegrid.js" %}"></script>
+    <script type="text/javascript" src="{% static "events/js/listview.js" %}"></script>
+    <script type="text/javascript" src="{% static "events/js/main.js" %}"></script>
 {% endblock js_body %}

--- a/website/facedetection/templates/facedetection/your-photos.html
+++ b/website/facedetection/templates/facedetection/your-photos.html
@@ -1,5 +1,5 @@
 {% extends "paginated_page.html" %}
-{% load static i18n compress photos_cards alert %}
+{% load static i18n sass_tags photos_cards alert %}
 
 {% block title %}Photos you're on — {{ block.super }}{% endblock %}
 {% block opengraph_title %}Photos you're on — {{ block.super }}{% endblock %}
@@ -65,16 +65,12 @@
 
 {% block css_head %}
     {{ block.super }}
-    {% compress css %}
-        <link href="{% static "photos/css/style.scss" %}" rel="stylesheet" type="text/x-scss">
-    {% endcompress %}
+    <link href="{% sass_src "photos/css/style.scss" %}" rel="stylesheet" type="text/css">
     <link href="{% static "css/fancybox.css" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block js_body %}
     {{ block.super }}
     <script src="{% static "js/fancybox.umd.js" %}"></script>
-    {% compress js %}
-        <script type="text/javascript" src="{% static "photos/js/main.js" %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static "photos/js/main.js" %}"></script>
 {% endblock %}

--- a/website/mailinglists/templates/admin/mailinglists/change_list.html
+++ b/website/mailinglists/templates/admin/mailinglists/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls static %}
 
 {% block search %}
     <div class="auto-lists-info">

--- a/website/members/templates/members/statistics.html
+++ b/website/members/templates/members/statistics.html
@@ -1,5 +1,5 @@
 {% extends "simple_page.html" %}
-{% load i18n static compress %}
+{% load i18n static %}
 
 {% block title %}{% trans "Statistics" %} — {{ block.super }}{% endblock %}
 {% block opengraph_title %}{% trans "Statistics" %} — {{ block.super }}{% endblock %}
@@ -62,8 +62,6 @@
 
 {% block js_body %}
     {{ block.super }}
-    {% compress js %}
-        <script type="text/javascript" src="{% static 'members/js/chart.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'members/js/statistics.js' %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static 'members/js/chart.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'members/js/statistics.js' %}"></script>
 {% endblock %}

--- a/website/newsletters/templates/admin/newsletters/change_form.html
+++ b/website/newsletters/templates/admin/newsletters/change_form.html
@@ -1,9 +1,9 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls sass_tags %}
 
 {% block extrastyle %}
     {{ block.super }}
-    {% compress css %}<link rel="stylesheet" type="text/x-scss" href="{% static 'admin/newsletters/css/forms.scss' %}" />{% endcompress %}
+    <link href="{% sass_src 'admin/newsletters/css/forms.scss' %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block object-tools %}

--- a/website/partners/templates/partners/partner.html
+++ b/website/partners/templates/partners/partner.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n bleach_tags google_map_url thumbnail compress partner_cards static %}
+{% load i18n bleach_tags google_map_url thumbnail partner_cards static %}
 
 {% block title %}{{ partner.name }} — {% trans "Partners" %} — {% trans "Career" %} — {{ block.super }}{% endblock %}
 {% block opengraph_title %}{{ partner.name }} — {% trans "Partners" %} — {% trans "Career" %} —
@@ -100,7 +100,5 @@
 {% block js_body %}
     {{ block.super }}
     <script src="{% static "js/fancybox.umd.js" %}"></script>
-    {% compress js %}
-        <script type="text/javascript" src="{% static 'partners/js/main.js' %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static 'partners/js/main.js' %}"></script>
 {% endblock %}

--- a/website/partners/templates/partners/vacancies.html
+++ b/website/partners/templates/partners/vacancies.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n bleach_tags thumbnail partner_cards compress static %}
+{% load i18n bleach_tags thumbnail partner_cards static %}
 
 {% block title %}{% trans "Vacancies" %} — {% trans "Career" %} — {{ block.super }}{% endblock %}
 {% block opengraph_title %}{% trans "Vacancies" %} — {% trans "Career" %} — {{ block.super }}{% endblock %}
@@ -74,8 +74,6 @@
 {% block js_body %}
     {{ block.super }}
     <script src="{% static "js/fancybox.umd.js" %}"></script>
-    {% compress js %}
-        <script type="text/javascript" src="{% static 'js/mixitup.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'partners/js/main.js' %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static 'js/mixitup.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'partners/js/main.js' %}"></script>
 {% endblock %}

--- a/website/payments/templates/admin/payments/change_form.html
+++ b/website/payments/templates/admin/payments/change_form.html
@@ -1,9 +1,9 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls static sass_tags %}
 
 {% block extrastyle %}
     {{ block.super }}
-    {% compress css %}<link rel="stylesheet" type="text/x-scss" href="{% static 'admin/payments/css/forms.scss' %}" />{% endcompress %}
+    <link href="{% sass_src 'admin/payments/css/forms.scss' %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block extrahead %}

--- a/website/payments/templates/admin/payments/change_list.html
+++ b/website/payments/templates/admin/payments/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls %}
 
 {% block object-tools-items %}
     {% if opts.model_name == "payment" or opts.model_name == "batch" %}

--- a/website/payments/templates/payments/bankaccount_form.html
+++ b/website/payments/templates/payments/bankaccount_form.html
@@ -1,5 +1,5 @@
 {% extends "simple_page.html" %}
-{% load i18n static django_bootstrap5 compress alert %}
+{% load i18n static django_bootstrap5 alert %}
 
 {% block title %}{% trans "add bank account"|capfirst %} —
     {% trans "finances"|capfirst %} — {{ block.super }}{% endblock %}
@@ -149,10 +149,6 @@
 
 {% block js_body %}
     {{ block.super }}
-    {% compress js %}
-        <script type="text/javascript"
-                src="{% static "payments/js/signature_pad.min.js" %}"></script>
-        <script type="text/javascript"
-                src="{% static "payments/js/main.js" %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static "payments/js/signature_pad.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "payments/js/main.js" %}"></script>
 {% endblock js_body %}

--- a/website/payments/templates/payments/bankaccount_list.html
+++ b/website/payments/templates/payments/bankaccount_list.html
@@ -1,5 +1,5 @@
 {% extends "simple_page.html" %}
-{% load i18n static django_bootstrap5 compress alert %}
+{% load i18n django_bootstrap5 alert %}
 
 {% block title %}{% trans "bank accounts"|capfirst %} —
     {% trans "finances"|capfirst %} — {{ block.super }}{% endblock %}

--- a/website/payments/templates/payments/payment_form.html
+++ b/website/payments/templates/payments/payment_form.html
@@ -1,5 +1,5 @@
 {% extends "small_page.html" %}
-{% load i18n static django_bootstrap5 compress alert %}
+{% load i18n django_bootstrap5 alert %}
 
 {% block title %}{% trans "confirm payment"|capfirst %} —
     {% trans "Thalia Pay"|capfirst %} — {{ block.super }}{% endblock %}

--- a/website/payments/templates/payments/payment_list.html
+++ b/website/payments/templates/payments/payment_list.html
@@ -1,5 +1,5 @@
 {% extends "simple_page.html" %}
-{% load i18n static django_bootstrap5 compress alert %}
+{% load i18n django_bootstrap5 alert %}
 
 {% block title %}{% trans "payments"|capfirst %} —
     {% trans "finances"|capfirst %} — {{ block.super }}{% endblock %}

--- a/website/photos/templates/photos/album.html
+++ b/website/photos/templates/photos/album.html
@@ -1,5 +1,5 @@
 {% extends 'simple_page.html' %}
-{% load static i18n compress photos_cards %}
+{% load static i18n sass_tags photos_cards %}
 
 {% block title %}{{ album.title }} — {% trans "Photos" %} — {{ block.super }}{% endblock %}
 {% block opengraph_title %}{{ album.title }} — {% trans "Photos" %} — {{ block.super }}{% endblock %}
@@ -42,16 +42,12 @@
 
 {% block css_head %}
     {{ block.super }}
-    {% compress css %}
-        <link href="{% static "photos/css/style.scss" %}" rel="stylesheet" type="text/x-scss">
-    {% endcompress %}
+    <link href="{% sass_src "photos/css/style.scss" %}" rel="stylesheet" type="text/css">
     <link href="{% static "css/fancybox.css" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block js_body %}
     {{ block.super }}
     <script src="{% static "js/fancybox.umd.js" %}"></script>
-    {% compress js %}
-        <script type="text/javascript" src="{% static "photos/js/main.js" %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static "photos/js/main.js" %}"></script>
 {% endblock %}

--- a/website/photos/templates/photos/index.html
+++ b/website/photos/templates/photos/index.html
@@ -1,5 +1,5 @@
 {% extends 'paginated_page.html' %}
-{% load i18n static compress photos_cards alert %}
+{% load i18n static photos_cards alert %}
 
 {% block title %}{% trans "Photos" %} — {{ block.super }}{% endblock %}
 {% block opengraph_title %}{% trans "Photos" %} — {{ block.super }}{% endblock %}

--- a/website/photos/templates/photos/liked-photos.html
+++ b/website/photos/templates/photos/liked-photos.html
@@ -1,5 +1,5 @@
 {% extends 'paginated_page.html' %}
-{% load static i18n compress photos_cards alert %}
+{% load static i18n sass_tags photos_cards alert %}
 
 {% block title %}{% trans "Photos you liked" %} — {{ block.super }}{% endblock %}
 {% block opengraph_title %}{% trans "Photos you liked" %} — {{ block.super }}{% endblock %}
@@ -42,16 +42,12 @@
 
 {% block css_head %}
     {{ block.super }}
-    {% compress css %}
-        <link href="{% static "photos/css/style.scss" %}" rel="stylesheet" type="text/x-scss">
-    {% endcompress %}
+    <link href="{% sass_src "photos/css/style.scss" %}" rel="stylesheet" type="text/css">
     <link href="{% static "css/fancybox.css" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block js_body %}
     {{ block.super }}
     <script src="{% static "js/fancybox.umd.js" %}"></script>
-    {% compress js %}
         <script type="text/javascript" src="{% static "photos/js/main.js" %}"></script>
-    {% endcompress %}
 {% endblock %}

--- a/website/pizzas/templates/pizzas/admin/orders.html
+++ b/website/pizzas/templates/pizzas/admin/orders.html
@@ -1,5 +1,5 @@
 {% extends 'admin/change_list.html' %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls static sass_tags %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
@@ -16,25 +16,17 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    {% compress css %}
-        <link href="{% static "pizzas/css/admin.scss" %}" rel="stylesheet"
-              type="text/x-scss">
-    {% endcompress %}
+        <link href="{% sass_src "pizzas/css/admin.scss" %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block extrahead %}
     {{ block.super }}
-    <script type="text/javascript"
-            src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
-    <script type="text/javascript"
-            src="{% static "admin/js/jquery.init.js" %}"></script>
-    <script type="text/javascript"
-            src="{% static "js/jquery.tablesorter.min.js" %}"></script>
-    <script type="text/javascript"
-            src="{% url 'javascript-catalog' %}"></script>
+    <script type="text/javascript" src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
+    <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/jquery.tablesorter.min.js" %}"></script>
+    <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
     <script type="text/javascript" src="{% static "js/js.cookie.min.js" %}"></script>
-    <script type="text/javascript"
-            src="{% static "pizzas/js/admin.js" %}"></script>
+    <script type="text/javascript" src="{% static "pizzas/js/admin.js" %}"></script>
 {% endblock %}
 
 {% block content %}

--- a/website/pushnotifications/templates/admin/pushnotifications/change_form.html
+++ b/website/pushnotifications/templates/admin/pushnotifications/change_form.html
@@ -1,9 +1,9 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls static sass_tags%}
 
 {% block extrastyle %}
     {{ block.super }}
-    {% compress css %}<link rel="stylesheet" type="text/x-scss" href="{% static 'admin/pushnotifications/css/forms.scss' %}" />{% endcompress %}
+    <link href="{% sass_src 'admin/pushnotifications/css/forms.scss' %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block submit_buttons_bottom %}

--- a/website/pushnotifications/templates/admin/pushnotifications/event_message_form.html
+++ b/website/pushnotifications/templates/admin/pushnotifications/event_message_form.html
@@ -1,9 +1,9 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls static sass_tags %}
 
 {% block extrastyle %}
     {{ block.super }}
-    {% compress css %}<link rel="stylesheet" type="text/x-scss" href="{% static 'admin/pushnotifications/css/forms.scss' %}" />{% endcompress %}
+    <link href="{% sass_src 'admin/pushnotifications/css/forms.scss' %}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block submit_buttons_bottom %}

--- a/website/registrations/templates/admin/registrations/change_form.html
+++ b/website/registrations/templates/admin/registrations/change_form.html
@@ -1,9 +1,9 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls static compress %}
+{% load i18n admin_urls static sass_tags %}
 
 {% block extrastyle %}
     {{ block.super }}
-    {% compress css %}<link rel="stylesheet" type="text/x-scss" href="{% static 'admin/registrations/css/forms.scss' %}" />{% endcompress %}
+    <link href="{% sass_src 'admin/registrations/css/forms.scss' %}" rel="stylesheet" type="text/css" >
 {% endblock %}
 
 {% block extrahead %}

--- a/website/registrations/templates/registrations/register_benefactor.html
+++ b/website/registrations/templates/registrations/register_benefactor.html
@@ -1,17 +1,14 @@
 {% extends "simple_page.html" %}
-{% load i18n static compress django_bootstrap5 %}
+{% load i18n static django_bootstrap5 %}
 
 {% block title %}{% trans "registration"|capfirst %} — {{ block.super }}{% endblock %}
 
 {% block js_body %}
     {{ block.super }}
-    <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places"></script>
-    {% compress js %}
-        <script type="text/javascript" src="{% static 'registrations/js/main.js' %}"></script>
-        <script type="text/javascript" src="{% static "payments/js/signature_pad.min.js" %}"></script>
-        <script type="text/javascript" src="{% static "payments/js/main.js" %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places"></script>
+    <script type="text/javascript" src="{% static 'registrations/js/main.js' %}"></script>
+    <script type="text/javascript" src="{% static "payments/js/signature_pad.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "payments/js/main.js" %}"></script>
 {% endblock %}
 
 {% block page_title %}{% trans "registration" %} {% trans "Benefactor" %}{% endblock %}

--- a/website/registrations/templates/registrations/register_member.html
+++ b/website/registrations/templates/registrations/register_member.html
@@ -1,17 +1,14 @@
 {% extends "simple_page.html" %}
-{% load i18n static compress django_bootstrap5 %}
+{% load i18n static django_bootstrap5 %}
 
 {% block title %}{% trans "registration"|capfirst %} — {{ block.super }}{% endblock %}
 
 {% block js_body %}
     {{ block.super }}
-    <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places"></script>
-    {% compress js %}
-        <script type="text/javascript" src="{% static 'registrations/js/main.js' %}"></script>
-        <script type="text/javascript" src="{% static "payments/js/signature_pad.min.js" %}"></script>
-        <script type="text/javascript" src="{% static "payments/js/main.js" %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places"></script>
+    <script type="text/javascript" src="{% static 'registrations/js/main.js' %}"></script>
+    <script type="text/javascript" src="{% static "payments/js/signature_pad.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "payments/js/main.js" %}"></script>
 {% endblock %}
 
 {% block page_title %}{% trans "registration" %} {% trans "Member" %}{% endblock %}

--- a/website/registrations/templates/registrations/renewal.html
+++ b/website/registrations/templates/registrations/renewal.html
@@ -1,14 +1,11 @@
 {% extends "simple_page.html" %}
-{% load i18n django_bootstrap5 alert compress static payments %}
+{% load i18n django_bootstrap5 alert static payments %}
 
 {% block title %}{% trans "renewal"|capfirst %} — {{ block.super }}{% endblock %}
 
 {% block js_body %}
     {{ block.super }}
-    {% compress js %}
-        <script type="text/javascript"
-                src="{% static 'registrations/js/main.js' %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static 'registrations/js/main.js' %}"></script>
 {% endblock %}
 
 {% block page_title %}{% trans "renewal" %}{% endblock %}

--- a/website/singlepages/templates/singlepages/student_participation.html
+++ b/website/singlepages/templates/singlepages/student_participation.html
@@ -1,5 +1,5 @@
 {% extends 'education/base.html' %}
-{% load static compress %}
+{% load static %}
 {% load i18n static grid_item %}
 
 {% block title %}{% trans "Student Participation" %} —

--- a/website/templates/oauth2_provider/authorize.html
+++ b/website/templates/oauth2_provider/authorize.html
@@ -1,5 +1,5 @@
 {% extends "small_page.html" %}
-{% load i18n static django_bootstrap5 compress alert %}
+{% load i18n django_bootstrap5 alert %}
 
 {% comment %}This page is automatically used by django-oauth-toolkit{% endcomment %}
 

--- a/website/templates/oauth2_provider/authorized-token-delete.html
+++ b/website/templates/oauth2_provider/authorized-token-delete.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static django_bootstrap5 compress alert %}
+{% load i18n django_bootstrap5 alert %}
 
 {% comment %}This page is automatically used by django-oauth-toolkit{% endcomment %}
 

--- a/website/templates/oauth2_provider/authorized-tokens.html
+++ b/website/templates/oauth2_provider/authorized-tokens.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static django_bootstrap5 compress alert %}
+{% load i18n django_bootstrap5 alert %}
 
 {% comment %}This page is automatically used by django-oauth-toolkit{% endcomment %}
 

--- a/website/thabloid/templates/thabloid/index.html
+++ b/website/thabloid/templates/thabloid/index.html
@@ -1,5 +1,5 @@
 {% extends 'simple_page.html' %}
-{% load i18n static compress thabloid_cards %}
+{% load i18n static thabloid_cards %}
 
 {% block title %}{% trans "Thabloid" %} — {{ block.super }}{% endblock %}
 {% block opengraph_title %}{% trans "Thabloid" %} —
@@ -72,7 +72,5 @@
     {{ block.super }}
     <script src="{% static "js/fancybox.umd.js" %}"></script>
     <script type="text/javascript" src="{% static 'js/mixitup.min.js' %}"></script>
-    {% compress js %}
-        <script type="text/javascript" src="{% static 'thabloid/js/main.js' %}"></script>
-    {% endcompress %}
+    <script type="text/javascript" src="{% static 'thabloid/js/main.js' %}"></script>
 {% endblock %}

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -771,17 +771,6 @@ STATICFILES_STORAGE = setting(
     production=MANIFEST_STATICFILES_STORAGE,
 )
 
-# # Compressor settings
-# COMPRESS_ENABLED = True
-# COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)
-# COMPRESS_FILTERS = {
-#     "css": [
-#         "compressor.filters.css_default.CssAbsoluteFilter",
-#         "compressor.filters.cssmin.rCSSMinFilter",
-#     ],
-#     "js": ["compressor.filters.jsmin.JSMinFilter"],
-# }
-
 # See utils/model/signals.py for explanation
 SUSPEND_SIGNALS = False
 

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -218,9 +218,6 @@ ALLOWED_HOSTS = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#internal-ips
 INTERNAL_IPS = setting(development=["127.0.0.1", "172.17.0.1"], production=[])
 
-# https://django-compressor.readthedocs.io/en/stable/settings/#django.conf.settings.COMPRESS_OFFLINE
-COMPRESS_OFFLINE = setting(development=False, production=False)
-
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
@@ -465,8 +462,8 @@ INSTALLED_APPS = [
     "tinymce",
     "rest_framework",
     "rest_framework.authtoken",
-    "compressor",
     "debug_toolbar",
+    "sass_processor",
     "admin_auto_filters",
     "django_drf_filepond",
     "django_filepond_widget",
@@ -758,9 +755,12 @@ LOCALE_PATHS = ("locale",)
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
-    # other finders
-    "compressor.finders.CompressorFinder",
+    "sass_processor.finders.CssFinder",
 )
+
+# Allow importing .scss files that don't start with an underscore.
+# See https://github.com/jrief/django-sass-processor
+SASS_PROCESSOR_INCLUDE_FILE_PATTERN = r"^.+\.scss$"
 
 NORMAL_STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 MANIFEST_STATICFILES_STORAGE = (
@@ -771,16 +771,16 @@ STATICFILES_STORAGE = setting(
     production=MANIFEST_STATICFILES_STORAGE,
 )
 
-# Compressor settings
-COMPRESS_ENABLED = True
-COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)
-COMPRESS_FILTERS = {
-    "css": [
-        "compressor.filters.css_default.CssAbsoluteFilter",
-        "compressor.filters.cssmin.rCSSMinFilter",
-    ],
-    "js": ["compressor.filters.jsmin.JSMinFilter"],
-}
+# # Compressor settings
+# COMPRESS_ENABLED = True
+# COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)
+# COMPRESS_FILTERS = {
+#     "css": [
+#         "compressor.filters.css_default.CssAbsoluteFilter",
+#         "compressor.filters.cssmin.rCSSMinFilter",
+#     ],
+#     "js": ["compressor.filters.jsmin.JSMinFilter"],
+# }
 
 # See utils/model/signals.py for explanation
 SUSPEND_SIGNALS = False

--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -1,4 +1,4 @@
-{% load django_bootstrap5 i18n static menu compress pick_header_image %}
+{% load django_bootstrap5 i18n static menu sass_tags pick_header_image %}
 {% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
 <html lang="en">
@@ -6,11 +6,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-    <title>{% block title %}
-        {% trans "Study Association Thalia" %}{% endblock %}</title>
+    <title>{% block title %}{% trans "Study Association Thalia" %}{% endblock %}</title>
 
-    <meta name="viewport"
-          content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
     {% if lustrumstyling %}
         <meta name="theme-color" content="#DAB34A"/>
     {% else %}
@@ -21,28 +20,20 @@
     {% else %}
         <link rel="icon" href="{% static "img/browser/icon.png" %}">
     {% endif %}
+
     <link rel="apple-touch-icon" href="{% static "img/browser/icon.png" %}">
-    <meta name="msapplication-square70x70logo"
-          content="{% static "img/browser/icon-smalltile.png" %}">
-    <meta name="msapplication-square150x150logo"
-          content="{% static "img/browser/icon-mediumtile.png" %}">
-    <meta name="msapplication-wide310x150logo"
-          content="{% static "img/browser/icon-widetile.png" %}">
-    <meta name="msapplication-square310x310logo"
-          content="{% static "img/browser/icon-largetile.png" %}">
+    <meta name="msapplication-square70x70logo" content="{% static "img/browser/icon-smalltile.png" %}">
+    <meta name="msapplication-square150x150logo" content="{% static "img/browser/icon-mediumtile.png" %}">
+    <meta name="msapplication-wide310x150logo" content="{% static "img/browser/icon-widetile.png" %}">
+    <meta name="msapplication-square310x310logo" content="{% static "img/browser/icon-largetile.png" %}">
 
-    <meta property="og:image"
-          content="{% if request.is_secure %}https://{% else %}http://{% endif %}{{ request.get_host }}{% static "img/browser/icon-largetile.png" %}"/>
+    <meta property="og:image" content="{% if request.is_secure %}https://{% else %}http://{% endif %}{{ request.get_host }}{% static "img/browser/icon-largetile.png" %}"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:title"
-          content="{% block opengraph_title %}{% trans 'Study Association Thalia' %}{% endblock %}"/>
+    <meta property="og:title" content="{% block opengraph_title %}{% trans 'Study Association Thalia' %}{% endblock %}"/>
     {% block opengraph %}{% endblock %}
-
     {% block css_head %}
         <link href="{% static "css/bootstrap.min.css" %}" rel="stylesheet" type="text/css">
-        {% compress css %}
-            <link href="{% static "css/main.scss" %}" rel="stylesheet" type="text/x-scss">
-        {% endcompress %}
+        <link href="{% sass_src "css/main.scss" %}" rel="stylesheet" type="text/css">
         {% if lustrumstyling %}
             <style>
             :root {
@@ -82,9 +73,7 @@
         {% endif %}
     {% endblock %}
 
-    {% block js_head %}
-    {% endblock %}
-
+    {% block js_head %}{% endblock %}
     <!-- served by: {{ SOURCE_COMMIT }} -->
 </head>
 <body class="{% block body_class %}{% endblock %}">
@@ -216,10 +205,7 @@
 
 <header id="page-header">
     {% block header_image_container %}
-        <img src="
-
-            {% block header_image %}{% pick_header_image %}{% endblock header_image %}"
-             class="image"/>
+        <img src="{% block header_image %}{% pick_header_image %}{% endblock header_image %}" class="image"/>
     {% endblock header_image_container %}
 </header>
 
@@ -262,18 +248,12 @@
 </footer>
 
 {% block js_body %}
-    <script type="text/javascript"
-            src="{% url 'javascript-catalog' %}"></script>
-    <script type="text/javascript"
-            src="{% static "js/bootstrap.bundle.min.js" %}"></script>
-    <script type="text/javascript"
-            src="{% static "js/jquery.min.js" %}"></script>
-    <script type="text/javascript"
-            src="{% static "js/js.cookie.min.js" %}"></script>
-    <script type="text/javascript"
-            src="{% static "announcements/js/announcements.js" %}"></script>
-    <script type="text/javascript"
-            src="{% static "js/loading-animation.js" %}"></script>
+    <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
+    <script type="text/javascript" src="{% static "js/bootstrap.bundle.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/jquery.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/js.cookie.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "announcements/js/announcements.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/loading-animation.js" %}"></script>
 {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Closes #3200.

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This replaces compressor with https://github.com/jrief/django-sass-processor. 
Note that django-sass-processor actually does more or less depend on compressor (and libsass) but only at build-time.

It looks like this also opens up S3 for staticfiles very nicely.

### How to test
I'll deploy to staging to check if it works nicely. I've modified the workflow to be able to do that manually from a PR instead of master.
