### PR TITLE
Optimize member API views

### DIFF
--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -91,4 +91,4 @@ class MemberCurrentView(MemberDetailView, UpdateAPIView):
     }
 
     def get_object(self):
-        return get_object_or_404(MemberDetailView.queryset, pk=self.request.user.pk)
+        return get_object_or_404(self.get_queryset(), pk=self.request.user.pk)

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -67,7 +67,9 @@ class MemberDetailView(RetrieveAPIView):
     """Returns details of a member."""
 
     serializer_class = MemberSerializer
-    queryset = Member.objects.all()
+    queryset = Member.objects.all().prefetch_related(
+        "membergroupmembership_set", "mentorship_set"
+    )
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
     ]
@@ -89,4 +91,4 @@ class MemberCurrentView(MemberDetailView, UpdateAPIView):
     }
 
     def get_object(self):
-        return get_object_or_404(Member, pk=self.request.user.pk)
+        return get_object_or_404(MemberDetailView.queryset, pk=self.request.user.pk)

--- a/website/members/models/member.py
+++ b/website/members/models/member.py
@@ -111,6 +111,9 @@ class Member(User):
     @property
     def latest_membership(self):
         """Get the most recent membership of this user."""
+        if hasattr(self, "_latest_membership"):
+            return self._latest_membership[0]
+
         if not self.membership_set.exists():
             return None
         return self.membership_set.latest("since")


### PR DESCRIPTION
Closes #3228 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
I added support for prefetching the `latest_membership` property. (Perhaps I should make it so that it becomes cached too.)

The code isn't the prettiest, so maybe this can also be refactored in some way (e.g. by putting the `Prefetch` object in the model somewhere?)

I believe that using a subquery will not work because Django does not support putting entire ORM objects in a subquery, only single values :disappointed: 

### How to test
Steps to test the changes you made:
1. Go to /api/v2/members
2. Observe that the results are still correct.
3. Observe that the number of queries has gone down significantly.