### PR TITLE
3325 handle invalid filter values

### DIFF
--- a/website/events/api/v2/admin/filters.py
+++ b/website/events/api/v2/admin/filters.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ObjectDoesNotExist
+
 from rest_framework import filters
 
 from utils.snippets import strtobool
@@ -10,7 +12,10 @@ class PublishedFilter(filters.BaseFilterBackend):
         published = request.query_params.get("published", None)
 
         if published is not None:
-            queryset = queryset.filter(published=strtobool(published))
+            try:
+                queryset = queryset.filter(published=strtobool(published))
+            except ObjectDoesNotExist:
+                raise Exception("Queryset could not be filtered.")
 
         return queryset
 
@@ -37,8 +42,11 @@ class EventRegistrationCancelledFilter(filters.BaseFilterBackend):
         if cancelled is None:
             return queryset
 
-        if strtobool(cancelled):
-            return queryset.exclude(date_cancelled=None)
+        try:
+            if strtobool(cancelled):
+                return queryset.exclude(date_cancelled=None)
+        except ObjectDoesNotExist:
+            raise Exception("Queryset could not be filtered.")
 
         return queryset.filter(date_cancelled=None)
 
@@ -65,8 +73,11 @@ class EventRegistrationQueuedFilter(filters.BaseFilterBackend):
         if queued is None:
             return queryset
 
-        if strtobool(queued):
-            return queryset.exclude(queue_position=None)
+        try:
+            if strtobool(queued):
+                return queryset.exclude(queue_position=None)
+        except ObjectDoesNotExist:
+            raise Exception("Queryset could not be filtered.")
 
         return queryset.filter(queue_position=None)
 

--- a/website/events/api/v2/admin/filters.py
+++ b/website/events/api/v2/admin/filters.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ValidationError
 
 from rest_framework import filters
 
@@ -14,8 +14,8 @@ class PublishedFilter(filters.BaseFilterBackend):
         if published is not None:
             try:
                 queryset = queryset.filter(published=strtobool(published))
-            except ObjectDoesNotExist:
-                raise Exception("Queryset could not be filtered.")
+            except ValueError as e:
+                raise ValidationError("Invalid filter value.") from e
 
         return queryset
 
@@ -45,8 +45,8 @@ class EventRegistrationCancelledFilter(filters.BaseFilterBackend):
         try:
             if strtobool(cancelled):
                 return queryset.exclude(date_cancelled=None)
-        except ObjectDoesNotExist:
-            raise Exception("Queryset could not be filtered.")
+        except ValueError as e:
+            raise ValidationError("Invalid filter value.") from e
 
         return queryset.filter(date_cancelled=None)
 
@@ -76,8 +76,8 @@ class EventRegistrationQueuedFilter(filters.BaseFilterBackend):
         try:
             if strtobool(queued):
                 return queryset.exclude(queue_position=None)
-        except ObjectDoesNotExist:
-            raise Exception("Queryset could not be filtered.")
+        except ValueError as e:
+            raise ValidationError("Invalid filter value.") from e
 
         return queryset.filter(queue_position=None)
 

--- a/website/events/api/v2/admin/filters.py
+++ b/website/events/api/v2/admin/filters.py
@@ -1,6 +1,5 @@
-from django.core.exceptions import ValidationError
-
 from rest_framework import filters
+from rest_framework.exceptions import ValidationError
 
 from utils.snippets import strtobool
 
@@ -15,7 +14,7 @@ class PublishedFilter(filters.BaseFilterBackend):
             try:
                 queryset = queryset.filter(published=strtobool(published))
             except ValueError as e:
-                raise ValidationError("Invalid filter value.") from e
+                raise ValidationError({"published": "Invalid filter value."}) from e
 
         return queryset
 
@@ -46,7 +45,7 @@ class EventRegistrationCancelledFilter(filters.BaseFilterBackend):
             if strtobool(cancelled):
                 return queryset.exclude(date_cancelled=None)
         except ValueError as e:
-            raise ValidationError("Invalid filter value.") from e
+            raise ValidationError({"cancelled": "Invalid filter value."}) from e
 
         return queryset.filter(date_cancelled=None)
 
@@ -77,7 +76,7 @@ class EventRegistrationQueuedFilter(filters.BaseFilterBackend):
             if strtobool(queued):
                 return queryset.exclude(queue_position=None)
         except ValueError as e:
-            raise ValidationError("Invalid filter value.") from e
+            raise ValidationError({"queued": "Invalid filter value."}) from e
 
         return queryset.filter(queue_position=None)
 

--- a/website/payments/api/v2/filters.py
+++ b/website/payments/api/v2/filters.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ObjectDoesNotExist
+
 from rest_framework import filters
 
 from utils.snippets import extract_date_range, strtobool
@@ -73,8 +75,11 @@ class PaymentSettledFilter(filters.BaseFilterBackend):
         if settled is None:
             return queryset
 
-        if strtobool(settled):
-            return queryset.filter(batch__processed=True)
+        try:
+            if strtobool(settled):
+                return queryset.filter(batch__processed=True)
+        except ObjectDoesNotExist:
+            raise Exception("Queryset could not be filtered.")
 
         return queryset.exclude(batch__processed=True)
 

--- a/website/payments/api/v2/filters.py
+++ b/website/payments/api/v2/filters.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ValidationError
 
 from rest_framework import filters
 
@@ -78,8 +78,8 @@ class PaymentSettledFilter(filters.BaseFilterBackend):
         try:
             if strtobool(settled):
                 return queryset.filter(batch__processed=True)
-        except ObjectDoesNotExist:
-            raise Exception("Queryset could not be filtered.")
+        except ValueError as e:
+            raise ValidationError("Invalid filter value.") from e
 
         return queryset.exclude(batch__processed=True)
 

--- a/website/payments/api/v2/filters.py
+++ b/website/payments/api/v2/filters.py
@@ -1,6 +1,5 @@
-from django.core.exceptions import ValidationError
-
 from rest_framework import filters
+from rest_framework.exceptions import ValidationError
 
 from utils.snippets import extract_date_range, strtobool
 
@@ -79,7 +78,7 @@ class PaymentSettledFilter(filters.BaseFilterBackend):
             if strtobool(settled):
                 return queryset.filter(batch__processed=True)
         except ValueError as e:
-            raise ValidationError("Invalid filter value.") from e
+            raise ValidationError({"settled": "Invalid filter value."}) from e
 
         return queryset.exclude(batch__processed=True)
 

--- a/website/sales/api/v2/filters.py
+++ b/website/sales/api/v2/filters.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ObjectDoesNotExist
+
 from rest_framework import filters
 
 from utils.snippets import extract_date_range, strtobool
@@ -10,7 +12,10 @@ class ShiftActiveFilter(filters.BaseFilterBackend):
         active = request.query_params.get("active", None)
 
         if active is not None:
-            queryset = queryset.filter(active=strtobool(active))
+            try:
+                queryset = queryset.filter(active=strtobool(active))
+            except ObjectDoesNotExist:
+                raise Exception("Queryset could not be filtered.")
 
         return queryset
 
@@ -35,7 +40,10 @@ class ShiftLockedFilter(filters.BaseFilterBackend):
         locked = request.query_params.get("locked", None)
 
         if locked is not None:
-            queryset = queryset.filter(locked=strtobool(locked))
+            try:
+                queryset = queryset.filter(locked=strtobool(locked))
+            except ObjectDoesNotExist:
+                raise Exception("Queryset could not be filtered.")
 
         return queryset
 

--- a/website/sales/api/v2/filters.py
+++ b/website/sales/api/v2/filters.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ValidationError
 
 from rest_framework import filters
 
@@ -14,8 +14,8 @@ class ShiftActiveFilter(filters.BaseFilterBackend):
         if active is not None:
             try:
                 queryset = queryset.filter(active=strtobool(active))
-            except ObjectDoesNotExist:
-                raise Exception("Queryset could not be filtered.")
+            except ValueError as e:
+                raise ValidationError("Invalid filter value.") from e
 
         return queryset
 
@@ -42,8 +42,8 @@ class ShiftLockedFilter(filters.BaseFilterBackend):
         if locked is not None:
             try:
                 queryset = queryset.filter(locked=strtobool(locked))
-            except ObjectDoesNotExist:
-                raise Exception("Queryset could not be filtered.")
+            except ValueError as e:
+                raise ValidationError("Invalid filter value.") from e
 
         return queryset
 

--- a/website/sales/api/v2/filters.py
+++ b/website/sales/api/v2/filters.py
@@ -1,6 +1,5 @@
-from django.core.exceptions import ValidationError
-
 from rest_framework import filters
+from rest_framework.exceptions import ValidationError
 
 from utils.snippets import extract_date_range, strtobool
 
@@ -15,7 +14,7 @@ class ShiftActiveFilter(filters.BaseFilterBackend):
             try:
                 queryset = queryset.filter(active=strtobool(active))
             except ValueError as e:
-                raise ValidationError("Invalid filter value.") from e
+                raise ValidationError({"active": "Invalid filter value."}) from e
 
         return queryset
 
@@ -43,7 +42,7 @@ class ShiftLockedFilter(filters.BaseFilterBackend):
             try:
                 queryset = queryset.filter(locked=strtobool(locked))
             except ValueError as e:
-                raise ValidationError("Invalid filter value.") from e
+                raise ValidationError({"locked": "Invalid filter value."}) from e
 
         return queryset
 


### PR DESCRIPTION
Closes #3325

### Summary
Bug: https://thalia.sentry.io/issues/4448548023/?project=1463433&query=is%3Aunresolved+issue.category%3Aerror&referrer=issue-stream&stream_index=8

Instead of a 500 error, it should now through a 400 ValidationError.

### How to test
Steps to test the changes you made:
1. Go to http://staging.thalia.nu/api/v2/admin/events/183/registrations/
2. Apply a filter that in the list: "y", "yes", "t", "true", "on", "1"; or "n", "no", "f", "false", "off", "0".
3. Page should throw a 400 error.