### PR TITLE
Optimize latest memberships everywhere

### DIFF
--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -56,6 +56,7 @@ class EventListView(ListAPIView):
                 "organisers__board",
                 "organisers__committee",
                 "organisers__society",
+                "organisers__contact_mailinglist",
             )
         )
         if self.request.member:

--- a/website/events/api/v2/views.py
+++ b/website/events/api/v2/views.py
@@ -20,9 +20,9 @@ from events.api.v2.serializers.event import EventListSerializer, EventSerializer
 from events.api.v2.serializers.event_registration import EventRegistrationSerializer
 from events.api.v2.serializers.external_event import ExternalEventSerializer
 from events.exceptions import RegistrationError
-from events.models import Event, EventRegistration
-from events.models.external_event import ExternalEvent
+from events.models import Event, EventRegistration, ExternalEvent
 from events.services import is_user_registered
+from members.models import Membership
 from thaliawebsite.api.v2.permissions import IsAuthenticatedOrTokenHasScopeForMethod
 from thaliawebsite.api.v2.serializers import EmptySerializer
 from utils.media.services import fetch_thumbnails_db
@@ -120,9 +120,17 @@ class EventRegistrationsView(ListAPIView):
 
     def get_queryset(self):
         if self.event:
-            return EventRegistration.objects.filter(
-                event=self.event, date_cancelled=None
-            ).select_related("member__profile")[: self.event.max_participants]
+            return (
+                EventRegistration.objects.filter(event=self.event, date_cancelled=None)
+                .select_related("member__profile")
+                .prefetch_related(
+                    Prefetch(
+                        "member__membership_set",
+                        queryset=Membership.objects.order_by("-since")[:1],
+                        to_attr="_latest_membership",
+                    ),
+                )[: self.event.max_participants]
+            )
         return EventRegistration.objects.none()
 
     def get_serializer(self, *args, **kwargs):

--- a/website/events/models/__init__.py
+++ b/website/events/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .event import EVENT_CATEGORIES, Event
 from .event_registration import EventRegistration, registration_member_choices_limit
+from .external_event import ExternalEvent
 from .feed_token import FeedToken
 from .registration_information_field import (
     BooleanRegistrationInformation,
@@ -14,6 +15,7 @@ __all__ = [
     "Event",
     "EVENT_CATEGORIES",
     "EventRegistration",
+    "ExternalEvent",
     "registration_member_choices_limit",
     "FeedToken",
     "BooleanRegistrationInformation",

--- a/website/members/models/member.py
+++ b/website/members/models/member.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User, UserManager
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from activemembers.models import MemberGroup, MemberGroupMembership
@@ -96,9 +97,11 @@ class Member(User):
     def __str__(self):
         return f"{self.get_full_name()} ({self.username})"
 
-    @property
+    @cached_property
     def current_membership(self):
         """Return the currently active membership of the user, one if not active.
+
+        Warning: this property is cached.
 
         :return: the currently active membership or None
         :rtype: Membership or None
@@ -108,9 +111,12 @@ class Member(User):
             return None
         return membership
 
-    @property
+    @cached_property
     def latest_membership(self):
-        """Get the most recent membership of this user."""
+        """Get the most recent membership of this user.
+
+        Warning: this property is cached.
+        """
         if hasattr(self, "_latest_membership"):
             return self._latest_membership[0]
 

--- a/website/photos/tests/test_services.py
+++ b/website/photos/tests/test_services.py
@@ -45,6 +45,8 @@ class IsAlbumAccesibleTest(TestCase):
             type=Membership.MEMBER,
             since=datetime(year=2016, month=1, day=1),
         )
+        self.member.refresh_from_db()  # Clear the cached membership
+
         with self.subTest(
             membership_since=membership.since, membership_until=membership.until
         ):
@@ -52,6 +54,8 @@ class IsAlbumAccesibleTest(TestCase):
 
         membership.until = datetime(year=2016, month=1, day=1)
         membership.save()
+        self.member.refresh_from_db()  # Clear the cached membership
+
         with self.subTest(
             membership_since=membership.since, membership_until=membership.until
         ):
@@ -59,6 +63,8 @@ class IsAlbumAccesibleTest(TestCase):
 
         membership.until = datetime(year=2017, month=1, day=1)
         membership.save()
+        self.member.refresh_from_db()  # Clear the cached membership
+
         with self.subTest(
             membership_since=membership.since, membership_until=membership.until
         ):
@@ -105,6 +111,8 @@ class GetAnnotatedAccessibleAlbumsTest(TestCase):
             type=Membership.MEMBER,
             since=datetime(year=2016, month=1, day=1),
         )
+        self.member.refresh_from_db()  # Clear the cached membership
+
         with self.subTest(
             membership_since=membership.since, membership_until=membership.until
         ):
@@ -115,6 +123,8 @@ class GetAnnotatedAccessibleAlbumsTest(TestCase):
 
         membership.until = datetime(year=2016, month=1, day=1)
         membership.save()
+        self.member.refresh_from_db()  # Clear the cached membership
+
         with self.subTest(
             membership_since=membership.since, membership_until=membership.until
         ):
@@ -125,6 +135,8 @@ class GetAnnotatedAccessibleAlbumsTest(TestCase):
 
         membership.until = datetime(year=2017, month=1, day=1)
         membership.save()
+        self.member.refresh_from_db()  # Clear the cached membership
+
         with self.subTest(
             membership_since=membership.since, membership_until=membership.until
         ):

--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -502,8 +502,9 @@ class Renewal(Entry):
                 _("You already have a renewal request queued for review.")
             )
 
-        # Invalid form for study and honorary members
+        self.member.refresh_from_db()
         current_membership = self.member.current_membership
+        # Invalid form for study and honorary members
         if current_membership is not None and current_membership.until is None:
             errors.update(
                 {

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -310,6 +310,14 @@ def _create_membership_from_entry(
     :return: The created or updated membership
     :rtype: Membership
     """
+    # Ensure all data is up to date.
+    entry.refresh_from_db()
+    if hasattr(entry, "renewal"):
+        entry.renewal.refresh_from_db()
+        entry.renewal.member.refresh_from_db()
+    if member is not None:
+        member.refresh_from_db()
+
     lecture_year = datetime_to_lectureyear(timezone.now())
     since = calculate_membership_since()
     until = None

--- a/website/registrations/tests/test_models.py
+++ b/website/registrations/tests/test_models.py
@@ -395,7 +395,7 @@ class RenewalTest(TestCase):
         self.renewal.length = Entry.MEMBERSHIP_STUDY
         self.renewal.membership_type = Membership.BENEFACTOR
         membership = self.member.latest_membership
-        membership.until = timezone.now()
+        membership.until = timezone.now().date()
         membership.save()
 
         with self.assertRaises(ValidationError):

--- a/website/registrations/tests/test_services.py
+++ b/website/registrations/tests/test_services.py
@@ -324,6 +324,7 @@ class ServicesTest(TestCase):
         self.e1.iban = "NL91ABNA0417164300"
         self.e1.initials = "J"
         self.e1.signature = "base64,png"
+        self.e1.save()
 
         member = services._create_member_from_registration(self.e1)
         bankaccount = BankAccount.objects.get(owner=member)
@@ -380,6 +381,7 @@ class ServicesTest(TestCase):
         with freeze_time("2017-01-12"):
             # Renewal to new 'study' membership starting today
             self.e3.length = Entry.MEMBERSHIP_STUDY
+            self.e3.save()
             membership3 = services._create_membership_from_entry(self.e3)
 
             self.assertEqual(membership3.since, timezone.now().date())
@@ -391,6 +393,7 @@ class ServicesTest(TestCase):
 
             # Renewal to new 'year' membership starting today
             self.e3.length = Entry.MEMBERSHIP_YEAR
+            self.e3.save()
             membership3 = services._create_membership_from_entry(self.e3)
 
             self.assertEqual(membership3.since, timezone.now().date())
@@ -403,6 +406,7 @@ class ServicesTest(TestCase):
             membership3.delete()
 
             self.e3.length = Entry.MEMBERSHIP_YEAR
+            self.e3.save()
             existing_membership = Membership.objects.create(
                 type=Membership.MEMBER,
                 since=timezone.datetime(year=2016, month=9, day=1).date(),
@@ -413,6 +417,7 @@ class ServicesTest(TestCase):
             # Renewal to new 'year' membership starting 1 day after
             # end of the previous membership
             self.e3.length = Entry.MEMBERSHIP_YEAR
+            self.e3.save()
             membership3 = services._create_membership_from_entry(self.e3)
             self.assertEqual(membership3.since, existing_membership.until)
             self.assertEqual(
@@ -423,6 +428,7 @@ class ServicesTest(TestCase):
 
             membership3.delete()
             self.e3.length = Entry.MEMBERSHIP_STUDY
+            self.e3.save()
 
             # Renewal (aka upgrade) existing membership to 'study' membership
             # It doesn't work when the entry was made after the renewal
@@ -453,6 +459,7 @@ class ServicesTest(TestCase):
 
             # Fail 'year' renewal of existing 'study' membership
             self.e3.length = Entry.MEMBERSHIP_YEAR
+            self.e3.save()
             existing_membership.until = None
             existing_membership.save()
             with self.assertRaises(ValueError):


### PR DESCRIPTION


### Summary
This is a continuation of #3229. I'm trying to get rid of membership-related N+1 queries everywhere (they are in lots of places) with a few tricks:

- Making `latest_membership` cached. 
  _This is a logical difference, that may be problematic for the registrations app. There are already bugs (#3298, ???) caused by incorrectly working with memberships. #3298 might actually get worked around by this caching, but a core problem in the registrations app is that it uses properties as if they're normal fields (not expected to change). This is a fine assumption everywhere, except in registrations, where memberships should be expected to change within a request-response cycle. Registrations should IMO never use the `latest/current_membership` properties, and only use normal explicit model methods (called with `()` to be explicitly recalculated) or only access the Membership model directly without any convenience methods._
- Prefetching memberships for more (API) views: event registrations, ...?


I looked through registrations, and think that after some small fixes this shouldn't break anything. Refactoring/fixing registrations further is another thing for another (bugfix) PR.

This improves at least:
- `/api/v2/events/`
- `/api/v2/events/:pk/registrations`
- `/api/calendarjs/birthdays`

And likely several other (non-api) views.

### How to test
Steps to test the changes you made:
1. Open the changed views with and without these changes.
2. Check that the results are exactly the same.
3. Check that the queries are much better.

