### PR TITLE
Fix concurrent payments

### DIFF
--- a/website/events/services.py
+++ b/website/events/services.py
@@ -444,21 +444,23 @@ def update_registration_by_organiser(registration, member, data):
     if not is_organiser(member, registration.event):
         raise RegistrationError(_("You are not allowed to update this registration."))
 
+    if "present" in data:
+        registration.present = data["present"]
+
+    registration.save()
+
     if "payment" in data:
         if data["payment"]["type"] == PaymentTypeField.NO_PAYMENT:
             if registration.payment is not None:
                 delete_payment(registration, member)
         else:
-            registration.payment = create_payment(
+            create_payment(
                 model_payable=registration,
                 processed_by=member,
                 pay_type=data["payment"]["type"],
             )
 
-    if "present" in data:
-        registration.present = data["present"]
-
-    registration.save()
+    registration.refresh_from_db(fields=["payment"])
 
 
 def generate_category_statistics() -> dict:

--- a/website/payments/admin_views.py
+++ b/website/payments/admin_views.py
@@ -54,8 +54,6 @@ class PaymentAdminView(View):
                 self.request.member,
                 request.POST["type"],
             )
-            payable_obj.model.payment = result
-            payable_obj.model.save()
         except Exception as e:
             capture_exception(e)
             messages.error(

--- a/website/payments/api/v1/viewsets/payments.py
+++ b/website/payments/api/v1/viewsets/payments.py
@@ -60,10 +60,10 @@ class PaymentViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
                 PaymentUser.objects.get(pk=request.user.pk),
                 Payment.TPAY,
             )
-            payable.model.save()
         except PaymentError as e:
             raise ValidationError(detail=str(e)) from e
 
+        payable.model.refresh_from_db()
         headers = {
             "Location": reverse(
                 "api:v1:payment-detail", kwargs={"pk": payable.payment.pk}

--- a/website/payments/api/v2/admin/views.py
+++ b/website/payments/api/v2/admin/views.py
@@ -156,12 +156,12 @@ class PayableDetailView(APIView):
                 PaymentUser.objects.get(pk=request.user.pk),
                 serializer.data["payment_type"],
             )
-            payable.model.save()
         except PaymentError as e:
             raise ValidationError(
                 detail={api_settings.NON_FIELD_ERRORS_KEY: [str(e)]}
             ) from e
 
+        payable.model.refresh_from_db()
         return Response(
             PayableAdminSerializer(payable, context=self.get_serializer_context()).data,
             status=status.HTTP_201_CREATED,

--- a/website/payments/api/v2/views.py
+++ b/website/payments/api/v2/views.py
@@ -119,12 +119,12 @@ class PayableDetailView(RetrieveAPIView):
                 PaymentUser.objects.get(pk=request.user.pk),
                 Payment.TPAY,
             )
-            payable.model.save()
         except PaymentError as e:
             raise ValidationError(
                 detail={api_settings.NON_FIELD_ERRORS_KEY: [str(e)]}
             ) from e
 
+        payable.model.refresh_from_db()
         return Response(
             PayableSerializer(payable, context=self.get_serializer_context()).data,
             status=status.HTTP_201_CREATED,

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from django.conf import settings
 from django.core import mail
+from django.db import transaction
 from django.db.models import Model, Q, QuerySet, Sum
 from django.urls import reverse
 from django.utils import timezone
@@ -33,51 +34,71 @@ def create_payment(
     if pay_type not in (Payment.CASH, Payment.CARD, Payment.WIRE, Payment.TPAY):
         raise PaymentError("Invalid payment type")
 
-    if isinstance(model_payable, Payable):
-        payable = model_payable
-    else:
+    with transaction.atomic():
+        if isinstance(model_payable, Payable):
+            model_payable = model_payable.model
+
+        try:
+            # Fully refresh and lock the payable object until we've created the payment.
+            # This ensures we have fresh data, and that the payable can't be paid twice
+            # at the same time.
+            model_payable = (
+                model_payable._meta.model.objects.filter(pk=model_payable.pk)
+                .select_for_update(of=("self",))
+                .get()
+            )
+        except AttributeError:
+            # In case we're testing with Mock models.
+            model_payable = (
+                model_payable.model
+                if isinstance(model_payable, Payable)
+                else model_payable
+            )
+
         payable = payables.get_payable(model_payable)
 
-    payer = (
-        PaymentUser.objects.get(pk=payable.payment_payer.pk)
-        if payable.payment_payer
-        else None
-    )
-
-    if not (
-        (payer and payer == processed_by and pay_type == Payment.TPAY)
-        or (payable.can_manage_payment(processed_by) and pay_type != Payment.TPAY)
-    ):
-        raise PaymentError(
-            _("User processing payment does not have the right permissions")
+        payer = (
+            PaymentUser.objects.get(pk=payable.payment_payer.pk)
+            if payable.payment_payer
+            else None
         )
 
-    if payable.payment_amount == 0:
-        raise PaymentError(_("Payment amount 0 is not accepted"))
+        if not (
+            (payer and payer == processed_by and pay_type == Payment.TPAY)
+            or (payable.can_manage_payment(processed_by) and pay_type != Payment.TPAY)
+        ):
+            raise PaymentError(
+                _("User processing payment does not have the right permissions")
+            )
 
-    if pay_type == Payment.TPAY and not payer.tpay_enabled:
-        raise PaymentError(_("This user does not have Thalia Pay enabled"))
+        if payable.payment_amount == 0:
+            raise PaymentError(_("Payment amount 0 is not accepted"))
 
-    if not payable.paying_allowed:
-        raise PaymentError(_("Payment restricted"))
+        if pay_type == Payment.TPAY and not payer.tpay_enabled:
+            raise PaymentError(_("This user does not have Thalia Pay enabled"))
 
-    if payable.payment is not None:
-        payable.payment.amount = payable.payment_amount
-        payable.payment.notes = payable.payment_notes
-        payable.payment.topic = payable.payment_topic
-        payable.payment.paid_by = payer
-        payable.payment.processed_by = processed_by
-        payable.payment.type = pay_type
-        payable.payment.save()
-    else:
-        payable.payment = Payment.objects.create(
-            processed_by=processed_by,
-            amount=payable.payment_amount,
-            notes=payable.payment_notes,
-            topic=payable.payment_topic,
-            paid_by=payer,
-            type=pay_type,
-        )
+        if not payable.paying_allowed:
+            raise PaymentError(_("Payment restricted"))
+
+        if payable.payment is not None:
+            payable.payment.amount = payable.payment_amount
+            payable.payment.notes = payable.payment_notes
+            payable.payment.topic = payable.payment_topic
+            payable.payment.paid_by = payer
+            payable.payment.processed_by = processed_by
+            payable.payment.type = pay_type
+            payable.payment.save()
+        else:
+            payable.payment = Payment.objects.create(
+                processed_by=processed_by,
+                amount=payable.payment_amount,
+                notes=payable.payment_notes,
+                topic=payable.payment_topic,
+                paid_by=payer,
+                type=pay_type,
+            )
+
+        payable.model.save()
     return payable.payment
 
 

--- a/website/payments/views.py
+++ b/website/payments/views.py
@@ -273,7 +273,6 @@ class PaymentProcessView(SuccessMessageMixin, FormView):
                 PaymentUser.objects.get(pk=self.request.member.pk),
                 Payment.TPAY,
             )
-            self.payable.model.save()
         except PaymentError as e:
             messages.error(self.request, str(e))
         return super().form_valid(form)

--- a/website/registrations/tests/test_signals.py
+++ b/website/registrations/tests/test_signals.py
@@ -80,12 +80,10 @@ class ServicesTest(TestCase):
             "registrations.services.process_entry_save"
         ) as process_entry_save:
             process_entry_save.side_effect = [Exception("An exception occurred"), None]
-            self.registration.payment = create_payment(
-                self.registration, self.user, Payment.CASH
-            )
             with self.assertRaises(Exception):
-                self.registration.save()
+                payment = create_payment(self.registration, self.user, Payment.CASH)
+
             self.registration.refresh_from_db()
-            self.assertEqual(Entry.STATUS_REVIEW, self.registration.status)
+            self.assertEqual(Entry.STATUS_ACCEPTED, self.registration.status)
             self.assertIsNone(self.registration.payment)
             self.assertQuerysetEqual(Payment.objects.all(), Payment.objects.none())


### PR DESCRIPTION
Closes #3367.
<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
This locks the payable model row while creating payments. This forces concurrent attempts to create payments for a specific payable to wait until the first attempt finishes.

To create the lock, we have to refetch the payable model (but that's also generally safer than passing around unsaved instances).

### How to test
Since sqlite doesn't support `select_for_update`, I can't easily test it locally, but I'll try setting up a local postgres. (Locally at least I can easily add a sleep in the middle of payment creation to make the race condition likely to occur).
