### PR TITLE
Small payments fixes

### DIFF
--- a/website/payments/api/v2/admin/serializers/payment.py
+++ b/website/payments/api/v2/admin/serializers/payment.py
@@ -1,11 +1,20 @@
 from rest_framework.fields import HiddenField
 
 from payments.api.v2.serializers.payment_user import PaymentUserSerializer
-from payments.models import Payment
+from payments.models import Payment, PaymentUser
 from thaliawebsite.api.v2.fields import CurrentMemberDefault
 from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
     CleanedModelSerializer,
 )
+
+
+class MemberAsPaymentUserSerializer(PaymentUserSerializer):
+    """Serializer that renders a Member as if it is a PaymentUser."""
+
+    def to_representation(self, instance):
+        if isinstance(instance, PaymentUser):
+            return super().to_representation(instance)
+        return super().to_representation(PaymentUser.objects.get(id=instance.id))
 
 
 class PaymentCreateSerializer(CleanedModelSerializer):
@@ -50,5 +59,5 @@ class PaymentAdminSerializer(CleanedModelSerializer):
             "notes",
         )
 
-    paid_by = PaymentUserSerializer(read_only=False)
-    processed_by = PaymentUserSerializer(read_only=False)
+    paid_by = MemberAsPaymentUserSerializer(read_only=False)
+    processed_by = MemberAsPaymentUserSerializer(read_only=False)

--- a/website/payments/api/v2/serializers/payment_user.py
+++ b/website/payments/api/v2/serializers/payment_user.py
@@ -1,9 +1,14 @@
 from rest_framework.fields import BooleanField, DecimalField
 from rest_framework.serializers import Serializer
 
+from payments.models import PaymentUser
+
 
 class PaymentUserSerializer(Serializer):
     """Serializer to show payment users."""
+
+    class Meta:
+        model = PaymentUser
 
     tpay_balance = DecimalField(decimal_places=2, max_digits=1000)
     tpay_allowed = BooleanField()

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -129,9 +129,10 @@ def delete_payment(model: Model, member: Member = None, ignore_change_window=Fal
             _("This payment has already been processed and hence cannot be deleted.")
         )
 
-    payable.payment = None
-    payable.model.save()
-    payment.delete()
+    with transaction.atomic():
+        payable.payment = None
+        payment.delete()
+        payable.model.save()
 
 
 def update_last_used(queryset: QuerySet, date: datetime.date = None) -> int:


### PR DESCRIPTION
### Summary
This fixes two small bugs in payments:
- The PaymentSerializer's paid_by is a Member object, but expects a PaymentUser. I added a serializer that accepts both.
- delete_payment was never possible, since the prevent_saving signal. The signal would detect the payment being unlinked, as that was saved before deleting the payment. I switched the order, and made it atomic just for safety.

### How to test
Steps to test the changes you made:
1. Try out all payments-related APIs (that indirectly render a paymentuser)
2. Try creating, chaning and deleting some payments.
