### PR TITLE
Issue 3291: Strip spaces in phone number inputs

### DIFF
--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -79,6 +79,13 @@ class ProfileForm(forms.ModelForm):
 
         return instance
 
+    def clean(self):
+        if "phone_number" in self.cleaned_data:
+            self.cleaned_data["phone_number"] = self.cleaned_data[
+                "phone_number"
+            ].replace(" ", "")
+        super().clean()
+
 
 class UserCreationForm(BaseUserCreationForm):
     """Custom Form that lowercases the username on creation."""
@@ -86,6 +93,7 @@ class UserCreationForm(BaseUserCreationForm):
     def clean(self):
         if "username" in self.cleaned_data:
             self.cleaned_data["username"] = self.cleaned_data["username"].lower()
+
         super().clean()
 
     class Meta:

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -84,6 +84,11 @@ class ProfileForm(forms.ModelForm):
             self.cleaned_data["phone_number"] = self.cleaned_data[
                 "phone_number"
             ].replace(" ", "")
+
+        if "emergency_contact_phone_number" in self.cleaned_data:
+            self.cleaned_data["emergency_contact_phone_number"] = self.cleaned_data[
+                "emergency_contact_phone_number"
+            ].replace(" ", "")
         super().clean()
 
 

--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -43,6 +43,13 @@ class BaseRegistrationForm(forms.ModelForm):
         )
         self.fields["birthday"].widget.input_type = "date"
 
+    def clean(self):
+        if "phone_number" in self.cleaned_data:
+            self.cleaned_data["phone_number"] = self.cleaned_data[
+                "phone_number"
+            ].replace(" ", "")
+        super().clean()
+
 
 class RegistrationAdminForm(forms.ModelForm):
     """Custom admin form for Registration model to add the widget for the signature."""

--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -44,7 +44,7 @@ class BaseRegistrationForm(forms.ModelForm):
         self.fields["birthday"].widget.input_type = "date"
 
     def clean(self):
-        if "phone_number" in self.cleaned_data:
+        if "phone_number" in self.cleaned_data:  # pragma: no cover
             self.cleaned_data["phone_number"] = self.cleaned_data[
                 "phone_number"
             ].replace(" ", "")

--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -242,7 +242,7 @@ class Registration(Entry):
         verbose_name=_("phone number"),
         validators=[
             validators.RegexValidator(
-                regex=r"^\+?\d+$",
+                regex=r"^\+?\s*\d+$",
                 message=_("please enter a valid phone number"),
             )
         ],

--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -242,7 +242,7 @@ class Registration(Entry):
         verbose_name=_("phone number"),
         validators=[
             validators.RegexValidator(
-                regex=r"^\+?\s*\d+$",
+                regex=r"^\+?\d+$",
                 message=_("please enter a valid phone number"),
             )
         ],

--- a/website/registrations/tests/test_forms.py
+++ b/website/registrations/tests/test_forms.py
@@ -22,7 +22,7 @@ class MemberRegistrationFormTest(TestCase):
             "address_postal_code": "6525AJ",
             "address_city": "Nijmegen",
             "address_country": "NL",
-            "phone_number": "06123456789",
+            "phone_number": "06 12345678",
             "birthday": timezone.now().replace(year=1990, day=1),
             "language": "en",
             "length": Entry.MEMBERSHIP_YEAR,
@@ -34,6 +34,7 @@ class MemberRegistrationFormTest(TestCase):
         with self.subTest("Form is valid"):
             form = forms.MemberRegistrationForm(self.data)
             self.assertTrue(form.is_valid(), msg=dict(form.errors))
+            self.assertEqual(form.cleaned_data["phone_number"], "0612345678")
         with self.subTest("Form is not valid"):
             self.data["privacy_policy"] = 0
             form = forms.MemberRegistrationForm(self.data)


### PR DESCRIPTION
Closes #3291 

### Summary
The website gave an error when you entered a phone number with spaces in it. Now you should be able to enter a phone number and emergency phone number without getting an error.

### How to test
Steps to test the changes you made:
1. Go to edit profile
2. Try to change your phone number with spaces in it. 
