### PR TITLE
events/admin: disable delete if not organiser

### DIFF
--- a/website/events/admin/event.py
+++ b/website/events/admin/event.py
@@ -129,6 +129,12 @@ class EventAdmin(DoNextModelAdmin):
             title=obj.title,
         )
 
+    def has_delete_permission(self, request, obj=None):
+        """Only allow deleting an event if the user is an organiser."""
+        if obj is not None and not services.is_organiser(request.member, obj):
+            return False
+        return super().has_delete_permission(request, obj)
+
     def has_change_permission(self, request, obj=None):
         """Only allow access to the change form if the user is an organiser."""
         if obj is not None and not services.is_organiser(request.member, obj):


### PR DESCRIPTION


<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Active members are able to delete events that they do not organize. This PR fixes that.

### How to test
Steps to test the changes you made:
1. Have an active member user that has permissions to edit/view/change/add events
2. Create an event that they are NOT an organiser off
3. As that user, go to the events admin
4. Clicking already doesn't work, but Edit does work
5. On Edit, you can also delete the event without this PR applied, while applying it removes the big red Delete button.
