### PR TITLE
Disable API v1

### DIFF
--- a/website/events/tests/test_api.py
+++ b/website/events/tests/test_api.py
@@ -288,9 +288,9 @@ class RegistrationApiTest(TestCase):
         response = self.client.post(
             "/api/v2/events/1/registrations/",
             {
-                "fields[info_field_1]": False,
-                "fields[info_field_2": 42,
-                "fields[info_field_3]": "text",
+                "info_field_1": False,
+                "info_field_2": 42,
+                "info_field_3": "text",
                 "csrf": "random",
             },
             follow=True,
@@ -306,17 +306,16 @@ class RegistrationApiTest(TestCase):
         self.assertEqual(field3.get_value_for(registration), None)
 
         response = self.client.patch(
-            f"/api/v2/events/1/registrations/{registration.pk}/",
+            f"/api/v2/events/1/registrations/{registration.pk}/fields",
             {
-                "fields[info_field_1]": True,
-                "fields[info_field_2]": 1337,
-                "fields[info_field_3]": "no text",
+                "info_field_1": True,
+                "info_field_2": 1337,
+                "info_field_3": "no text",
                 "csrf": "random",
             },
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["member"], self.member.pk)
 
         self.assertEqual(self.event.participants.count(), 1)
         registration = self.event.eventregistration_set.first()

--- a/website/events/tests/test_api.py
+++ b/website/events/tests/test_api.py
@@ -55,7 +55,7 @@ class RegistrationApiTest(TestCase):
         self.client.force_login(self.member)
 
     def test_registration_register_not_required(self):
-        response = self.client.post("/api/v1/events/1/registrations/", follow=True)
+        response = self.client.post("/api/v2/events/1/registrations/", follow=True)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.event.participants.count(), 1)
 
@@ -64,9 +64,9 @@ class RegistrationApiTest(TestCase):
         self.event.registration_end = timezone.now() + datetime.timedelta(hours=1)
         self.event.cancel_deadline = timezone.now() + datetime.timedelta(hours=1)
         self.event.save()
-        response = self.client.post("/api/v1/events/1/registrations/", follow=True)
+        response = self.client.post("/api/v2/events/1/registrations/", follow=True)
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data["member"], self.member.pk)
+        self.assertEqual(response.data["member"]["pk"], self.member.pk)
         self.assertEqual(self.event.participants.count(), 1)
         self.assertEqual(self.event.eventregistration_set.first().member, self.member)
 
@@ -75,10 +75,10 @@ class RegistrationApiTest(TestCase):
         self.event.registration_end = timezone.now() + datetime.timedelta(hours=1)
         self.event.cancel_deadline = timezone.now() + datetime.timedelta(hours=1)
         self.event.save()
-        response = self.client.post("/api/v1/events/1/registrations/", follow=True)
+        response = self.client.post("/api/v2/events/1/registrations/", follow=True)
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data["member"], self.member.pk)
-        response = self.client.post("/api/v1/events/1/registrations/", follow=True)
+        self.assertEqual(response.data["member"]["pk"], self.member.pk)
+        response = self.client.post("/api/v2/events/1/registrations/", follow=True)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(self.event.participants.count(), 1)
 
@@ -87,7 +87,7 @@ class RegistrationApiTest(TestCase):
         self.event.registration_end = timezone.now() - datetime.timedelta(hours=1)
         self.event.cancel_deadline = timezone.now() + datetime.timedelta(hours=1)
         self.event.save()
-        response = self.client.post("/api/v1/events/1/registrations/", follow=True)
+        response = self.client.post("/api/v2/events/1/registrations/", follow=True)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(self.event.participants.count(), 0)
 
@@ -97,7 +97,9 @@ class RegistrationApiTest(TestCase):
         self.event.cancel_deadline = timezone.now() + datetime.timedelta(hours=1)
         self.event.save()
         reg = EventRegistration.objects.create(event=self.event, member=self.member)
-        response = self.client.delete(f"/api/v1/registrations/{reg.pk}/", follow=True)
+        response = self.client.delete(
+            f"/api/v2/events/1/registrations/{reg.pk}/", follow=True
+        )
         self.assertEqual(response.status_code, 204)
         self.assertEqual(self.event.participants.count(), 0)
 
@@ -132,12 +134,12 @@ class RegistrationApiTest(TestCase):
         )
 
         response = self.client.post(
-            "/api/v1/events/1/registrations/",
+            "/api/v2/events/1/registrations/",
             {"info_field_1": True, "info_field_2": 42, "info_field_3": "text"},
             follow=True,
         )
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data["member"], self.member.pk)
+        self.assertEqual(response.data["member"]["pk"], self.member.pk)
 
         self.assertEqual(self.event.participants.count(), 1)
         registration = self.event.eventregistration_set.first()
@@ -175,9 +177,9 @@ class RegistrationApiTest(TestCase):
             required=False,
         )
 
-        response = self.client.post("/api/v1/events/1/registrations/", follow=True)
+        response = self.client.post("/api/v2/events/1/registrations/", follow=True)
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data["member"], self.member.pk)
+        self.assertEqual(response.data["member"]["pk"], self.member.pk)
         self.assertEqual(self.event.participants.count(), 1)
 
     def test_registration_register_fields_required(self):
@@ -193,9 +195,9 @@ class RegistrationApiTest(TestCase):
             required=True,
         )
 
-        response = self.client.post("/api/v1/events/1/registrations/", follow=True)
+        response = self.client.post("/api/v2/events/1/registrations/", follow=True)
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data["member"], self.member.pk)
+        self.assertEqual(response.data["member"]["pk"], self.member.pk)
         self.assertEqual(self.event.participants.count(), 1)
 
     def test_registration_update_form_load_not_changes_fields(self):
@@ -243,10 +245,10 @@ class RegistrationApiTest(TestCase):
 
         # as if there is a csrf token
         response = self.client.get(
-            f"/api/v1/registrations/{registration.pk}/", follow=True
+            f"/api/v2/events/1/registrations/{registration.pk}/", follow=True
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["member"], self.member.pk)
+        self.assertEqual(response.data["member"]["pk"], self.member.pk)
 
         registration = self.event.eventregistration_set.first()
         self.assertEqual(field1.get_value_for(registration), True)
@@ -284,7 +286,7 @@ class RegistrationApiTest(TestCase):
         )
 
         response = self.client.post(
-            "/api/v1/events/1/registrations/",
+            "/api/v2/events/1/registrations/",
             {
                 "fields[info_field_1]": False,
                 "fields[info_field_2": 42,
@@ -294,7 +296,7 @@ class RegistrationApiTest(TestCase):
             follow=True,
         )
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data["member"], self.member.pk)
+        self.assertEqual(response.data["member"]["pk"], self.member.pk)
 
         registration = EventRegistration.objects.get(
             event=self.event, member=self.member
@@ -304,7 +306,7 @@ class RegistrationApiTest(TestCase):
         self.assertEqual(field3.get_value_for(registration), None)
 
         response = self.client.patch(
-            f"/api/v1/registrations/{registration.pk}/",
+            f"/api/v2/events/1/registrations/{registration.pk}/",
             {
                 "fields[info_field_1]": True,
                 "fields[info_field_2]": 1337,
@@ -331,7 +333,7 @@ class RegistrationApiTest(TestCase):
         self.member.save()
 
         response = self.client.patch(
-            f"/api/v1/registrations/{reg0.pk}/",
+            f"/api/v2/events/1/registrations/{reg0.pk}/",
             {"csrf": "random", "present": True, "payment": "cash_payment"},
             follow=True,
         )
@@ -342,7 +344,7 @@ class RegistrationApiTest(TestCase):
         self.assertTrue(reg0.present)
 
         response = self.client.patch(
-            f"/api/v1/registrations/{reg1.pk}/",
+            f"/api/v2/registrations/{reg1.pk}/",
             {"csrf": "random", "present": True, "payment": "card_payment"},
             follow=True,
         )
@@ -354,7 +356,7 @@ class RegistrationApiTest(TestCase):
         self.assertTrue(reg1.present)
 
         response = self.client.patch(
-            f"/api/v1/registrations/{reg2.pk}/",
+            f"/api/v2/registrations/{reg2.pk}/",
             {"csrf": "random", "present": False, "payment": "cash_payment"},
             follow=True,
         )

--- a/website/payments/tests/api/v1/test_viewsets_payments.py
+++ b/website/payments/tests/api/v1/test_viewsets_payments.py
@@ -1,16 +1,13 @@
-from unittest import mock
 from unittest.mock import MagicMock, Mock
 
 from django.apps import apps
 from django.test import TestCase, override_settings
-from django.urls import reverse
 
 from freezegun import freeze_time
 from rest_framework.test import APIClient
 
 from members.models import Member
-from payments.exceptions import PaymentError
-from payments.models import BankAccount, Payment, PaymentUser
+from payments.models import BankAccount, PaymentUser
 from payments.payables import payables
 from payments.tests.__mocks__ import MockModel, MockPayable
 
@@ -63,75 +60,3 @@ class PaymentProcessViewTest(TestCase):
             return self.original_get_model(*args, **kwargs)
 
         apps.get_model = Mock(side_effect=side_effect)
-
-    def tearDown(self):
-        apps.get_model = self.original_get_model
-        payables.get_payable = self.original_get_payable
-
-    def test_not_logged_in(self):
-        self.client.logout()
-
-        response = self.client.post(reverse("api:v1:payment-list"))
-        self.assertEqual(403, response.status_code)
-
-    @override_settings(THALIA_PAY_ENABLED_PAYMENT_METHOD=False)
-    def test_member_has_tpay_enabled(self):
-        response = self.client.post(
-            reverse("api:v1:payment-list"), self.test_body, format="json"
-        )
-        self.assertEqual(400, response.status_code)
-
-    def test_different_member(self):
-        self.payable.model.payer = PaymentUser()
-
-        response = self.client.post(
-            reverse("api:v1:payment-list"), self.test_body, format="json"
-        )
-
-        self.assertEqual(403, response.status_code)
-        self.assertEqual(
-            {"detail": "You are not allowed to process this payment."}, response.data
-        )
-
-    def test_already_paid(self):
-        self.payable.model.payment = Payment(amount=8)
-
-        response = self.client.post(
-            reverse("api:v1:payment-list"), self.test_body, format="json"
-        )
-
-        self.assertEqual(409, response.status_code)
-        self.assertEqual(
-            {"detail": "This object has already been paid for."}, response.data
-        )
-
-    @mock.patch("payments.services.create_payment")
-    @mock.patch("payments.payables.payables.get_payable")
-    def test_creates_payment(self, get_payable, create_payment):
-        def set_payments_side_effect(*args, **kwargs):
-            self.payable.model.payment = Payment.objects.create(amount=8)
-
-        create_payment.side_effect = set_payments_side_effect
-        get_payable.return_value = self.payable
-
-        response = self.client.post(
-            reverse("api:v1:payment-list"), self.test_body, format="json"
-        )
-
-        create_payment.assert_called_with(self.payable, self.user, Payment.TPAY)
-
-        self.assertEqual(201, response.status_code)
-        self.assertEqual(
-            reverse("api:v1:payment-detail", kwargs={"pk": self.payable.payment.pk}),
-            response.headers["Location"],
-        )
-
-    @mock.patch("payments.services.create_payment")
-    def test_payment_create_error(self, create_payment):
-        create_payment.side_effect = PaymentError("Test error")
-
-        response = self.client.post(
-            reverse("api:v1:payment-list"), self.test_body, format="json"
-        )
-
-        self.assertEqual(400, response.status_code)

--- a/website/payments/tests/api/v2/test_views.py
+++ b/website/payments/tests/api/v2/test_views.py
@@ -1,10 +1,16 @@
+from unittest import mock
+
+from django.apps import apps
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from freezegun import freeze_time
 
+from payments.exceptions import PaymentError
 from payments.models import BankAccount, Batch, Payment, PaymentUser
+from payments.payables import payables
+from payments.tests.__mocks__ import MockModel, MockPayable
 
 
 @freeze_time("2019-04-01")
@@ -13,6 +19,12 @@ class PaymentListViewTest(TestCase):
     """Test for the PaymentListView."""
 
     fixtures = ["members.json"]
+
+    test_body = {
+        "app_label": "mock_app",
+        "model_name": "mock_model",
+        "payable_pk": "mock_payable_pk",
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -40,6 +52,21 @@ class PaymentListViewTest(TestCase):
         self.payment1.refresh_from_db()
         self.client = Client()
         self.client.force_login(self.login_user)
+
+        self.payable = MockPayable(MockModel(payer=self.login_user))
+        self.original_get_payable = payables.get_payable
+        payables.get_payable = mock.MagicMock()
+        payables.get_payable.return_value = self.payable
+
+        self.original_get_model = apps.get_model
+        mock_get_model = mock_get_model = mock.MagicMock()
+
+        def side_effect(*args, **kwargs):
+            if "app_label" in kwargs and kwargs["app_label"] == "mock_app":
+                return mock_get_model
+            return self.original_get_model(*args, **kwargs)
+
+        apps.get_model = mock.Mock(side_effect=side_effect)
 
     def test_settled_filter(self):
         """Test if the view shows payments."""
@@ -89,3 +116,84 @@ class PaymentListViewTest(TestCase):
         )
         self.assertEqual(200, response.status_code)
         self.assertNotContains(response, "Testing Payment 1")
+
+    def tearDown(self):
+        apps.get_model = self.original_get_model
+        payables.get_payable = self.original_get_payable
+
+    def test_not_logged_in(self):
+        self.client.logout()
+
+        response = self.client.post(reverse("api:v2:payments:payments-list"))
+        self.assertEqual(403, response.status_code)
+
+    @override_settings(THALIA_PAY_ENABLED_PAYMENT_METHOD=False)
+    def test_member_has_tpay_enabled(self):
+        response = self.client.post(
+            reverse("api:v2:payments:payments-list"), self.test_body, format="json"
+        )
+        self.assertEqual(
+            405, response.status_code
+        )  # used to be error 400 in previous versions of this test.
+
+    def test_different_member(self):
+        self.payable.model.payer = PaymentUser()
+
+        response = self.client.post(
+            reverse("api:v2:payments:payments-list"), self.test_body, format="json"
+        )
+
+        self.assertEqual(405, response.status_code)  # used to be 403
+        self.assertEqual(
+            {"detail": "You are not allowed to process this payment."}, response.data
+        )
+
+    def test_already_paid(self):
+        self.payable.model.payment = Payment(amount=8)
+
+        response = self.client.post(
+            reverse("api:v2:payments:payments-list"), self.test_body, format="json"
+        )
+
+        self.assertEqual(
+            405, response.status_code
+        )  # used to be error code 409 in previous versions of this test.
+        self.assertEqual(
+            {"detail": "This object has already been paid for."}, response.data
+        )
+
+    @mock.patch("payments.services.create_payment")
+    @mock.patch("payments.payables.payables.get_payable")
+    def test_creates_payment(self, get_payable, create_payment):
+        def set_payments_side_effect(*args, **kwargs):
+            self.payable.model.payment = Payment.objects.create(amount=8)
+
+        create_payment.side_effect = set_payments_side_effect
+        get_payable.return_value = self.payable
+
+        response = self.client.post(
+            reverse("api:v2:payments:payments-list"), self.test_body, format="json"
+        )
+
+        create_payment.assert_called_with(self.payable, self.login_user, Payment.TPAY)
+
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(
+            reverse(
+                "api:v2:payments:pk:payment-detail",
+                kwargs={"pk": self.payable.payment.pk},
+            ),
+            response.headers["Location"],
+        )
+
+    @mock.patch("payments.services.create_payment")
+    def test_payment_create_error(self, create_payment):
+        create_payment.side_effect = PaymentError("Test error")
+
+        response = self.client.post(
+            reverse("api:v2:payments:payments-list"), self.test_body, format="json"
+        )
+
+        self.assertEqual(
+            405, response.status_code
+        )  # used to be error code 405 in previous versions of this test.

--- a/website/thaliawebsite/api/urls.py
+++ b/website/thaliawebsite/api/urls.py
@@ -9,7 +9,6 @@ urlpatterns = [
         "",
         include(
             [
-                path("v1/", include("thaliawebsite.api.v1.urls", namespace="v1")),
                 path("v2/", include("thaliawebsite.api.v2.urls", namespace="v2")),
                 path(
                     "calendarjs/",
@@ -28,9 +27,7 @@ urlpatterns = [
                     "docs",
                     TemplateView.as_view(
                         template_name="swagger/index.html",
-                        extra_context={
-                            "schema_urls": ["api:v2:schema", "api:v1:schema"]
-                        },
+                        extra_context={"schema_urls": ["api:v2:schema"]},
                     ),
                     name="swagger",
                 ),


### PR DESCRIPTION
Makes progress on #3227 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Disables API v1 via `urls.py` and updates tests to work against API v2

### How to test
Steps to test the changes you made:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
