### PR TITLE
Check that deletion is forbidden in event admin tests

### DIFF
--- a/website/events/tests/test_views.py
+++ b/website/events/tests/test_views.py
@@ -46,10 +46,14 @@ class AdminTest(TestCase):
         cls.permission_change_event = Permission.objects.get(
             content_type__model="event", codename="change_event"
         )
+        cls.permission_delete_event = Permission.objects.get(
+            content_type__model="event", codename="delete_event"
+        )
         cls.permission_override_orga = Permission.objects.get(
             content_type__model="event", codename="override_organiser"
         )
         cls.member.user_permissions.add(cls.permission_change_event)
+        cls.member.user_permissions.add(cls.permission_delete_event)
         cls.member.is_superuser = False
         cls.member.save()
 
@@ -58,6 +62,7 @@ class AdminTest(TestCase):
 
     def _remove_event_permission(self):
         self.member.user_permissions.remove(self.permission_change_event)
+        self.member.user_permissions.remove(self.permission_delete_event)
 
     def _add_override_organiser_permission(self):
         self.member.user_permissions.add(self.permission_override_orga)
@@ -120,10 +125,15 @@ class AdminTest(TestCase):
         self.assertIn("Change event", str(response.content))
 
     def test_modeladmin_change_organiser_denied(self):
-        """If I'm not an organiser I should not be allowed access."""
+        """If I'm not an organiser I should not be allowed edit access."""
         response = self.client.get("/admin/events/event/1/change/")
         self.assertEqual(200, response.status_code)
         self.assertIn("View event", str(response.content))
+
+    def test_modeladmin_delete_organiser_denied(self):
+        """If I'm not an organiser I should not be allowed delete access."""
+        response = self.client.get("/admin/events/event/1/delete/")
+        self.assertEqual(403, response.status_code)
 
     def test_mark_present_qr_organiser_denied(self):
         response = self.client.get("/admin/events/event/1/mark-present-qr/")


### PR DESCRIPTION
Closes #ISSUE

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Adds a test for #3384 to ensure correctness

### How to test
Steps to test the changes you made:
1. Run `make test` and see that it succeeds
2. Revert PR #3384 
3. Run `make test` again and see that it now fails because it fails to give a 403.
