### PR TITLE
Set registration queue_position=None when cancelled

### DIFF
--- a/website/events/tests/test_models.py
+++ b/website/events/tests/test_models.py
@@ -239,8 +239,10 @@ class RegistrationTest(TestCase):
         cls.event.organisers.add(Committee.objects.get(pk=1))
         cls.member1 = Member.objects.first()
         cls.member2 = Member.objects.all()[1]
+        cls.member3 = Member.objects.all()[2]
         cls.r1 = EventRegistration.objects.create(event=cls.event, member=cls.member1)
         cls.r2 = EventRegistration.objects.create(event=cls.event, member=cls.member2)
+        cls.r3 = EventRegistration.objects.create(event=cls.event, member=cls.member3)
 
     def setUp(self):
         self.r1.refresh_from_db()
@@ -272,6 +274,17 @@ class RegistrationTest(TestCase):
         self.r2.event = self.r1.event
         self.assertEqual(self.r1.queue_position, None)
         self.assertEqual(self.r2.queue_position, 1)
+
+    def test_queue_cancel(self):
+        self.r1.event.max_participants = 0
+        self.r1.event.save()
+
+        self.r2.date_cancelled = timezone.now()
+        self.r2.save()
+
+        self.assertEqual(self.r1.queue_position, 1)
+        self.assertEqual(self.r2.queue_position, None)
+        self.assertEqual(self.r3.queue_position, 2)
 
     def test_registration_either_name_or_member(self):
         self.r2.delete()


### PR DESCRIPTION
Closes #3315 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Sets `queue_position=None` when a registration is cancelled.

### How to test
Steps to test the changes you made:
1. Create an event with queued registrations
2. Cancel a queued registration
3. See that before this PR it gets a duplicate queue position on `/api/v2/admin/events/1234/registrations/?ordering=-date_cancelled`, and with this PR applied it gets.

Alternatively:
1. Run tests
2. Revert 1d7a0e1
3. Run tests again and see them failing
