### PR TITLE
Member profile permission

### DIFF
--- a/website/members/api/v2/permissions.py
+++ b/website/members/api/v2/permissions.py
@@ -3,5 +3,6 @@ from rest_framework.permissions import BasePermission
 
 class HasActiveMembership(BasePermission):
     """DRF permission equivalent of the `@membership_required` view decorator."""
+
     def has_permission(self, request, view):
         return request.member and request.member.has_active_membership()

--- a/website/members/api/v2/permissions.py
+++ b/website/members/api/v2/permissions.py
@@ -1,0 +1,6 @@
+from rest_framework.permissions import BasePermission
+
+
+class HasActiveMembership(BasePermission):
+    def has_permission(self, request, view):
+        return request.member and request.member.has_active_membership()

--- a/website/members/api/v2/permissions.py
+++ b/website/members/api/v2/permissions.py
@@ -2,5 +2,6 @@ from rest_framework.permissions import BasePermission
 
 
 class HasActiveMembership(BasePermission):
+    """DRF permission equivalent of the `@membership_required` view decorator."""
     def has_permission(self, request, view):
         return request.member and request.member.has_active_membership()

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -71,6 +71,7 @@ class MemberDetailView(RetrieveAPIView):
     )
     permission_classes = [
         IsAuthenticatedOrTokenHasScope,
+        HasActiveMembership,
     ]
     required_scopes = ["members:read"]
 

--- a/website/members/api/v2/views.py
+++ b/website/members/api/v2/views.py
@@ -8,6 +8,7 @@ from rest_framework import filters as framework_filters
 from rest_framework.generics import ListAPIView, RetrieveAPIView, UpdateAPIView
 
 from members.api.v2 import filters
+from members.api.v2.permissions import HasActiveMembership
 from members.api.v2.serializers.member import (
     MemberCurrentSerializer,
     MemberListSerializer,
@@ -42,9 +43,7 @@ class MemberListView(ListAPIView):
             fetch_thumbnails([member.profile.photo for member in members])
         return super().get_serializer(*args, **kwargs)
 
-    permission_classes = [
-        IsAuthenticatedOrTokenHasScope,
-    ]
+    permission_classes = [IsAuthenticatedOrTokenHasScope, HasActiveMembership]
     required_scopes = ["members:read"]
     filter_backends = (
         framework_filters.OrderingFilter,

--- a/website/members/views.py
+++ b/website/members/views.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.messages.views import SuccessMessageMixin
+from django.core.exceptions import PermissionDenied
 from django.db.models import Q, QuerySet
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
@@ -134,6 +135,8 @@ class ProfileDetailView(DetailView):
     def setup(self, request, *args, **kwargs) -> None:
         if "pk" not in kwargs and request.member:
             kwargs["pk"] = request.member.pk
+        elif not (request.member and request.member.has_active_membership()):
+            raise PermissionDenied
         super().setup(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs) -> dict:


### PR DESCRIPTION
Closes #3444.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
This adds an HasActiveMembership permission, so that non-member users cannot view the member list.

Additionally, I restricted the ability of non-member users to view profiles except their own in the final commit. Not sure if this is actually desirable.

### How to test
<!-- Steps to test the changes you made: -->
1. Have a non-member user
2. go to /api/v2/members, /api/v2/members/ID, /members/profile/ID, and view the 403 errors
3. go to /members/profile and /api/v2/members/me and check that theyre still accessible

### Additional context
@Scarletto wanted to do this via `members:read` scope, but that doesn't seem to be set or used anywhere. This implementation mirrors what is done for the normal view.
