### PR TITLE
Switch to chached_db session backend

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -744,6 +744,8 @@ CACHES = {
     },
 }
 
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
 WSGI_APPLICATION = "thaliawebsite.wsgi.application"
 
 # Login pages


### PR DESCRIPTION
Closes #3363 .

### Summary
This does exactly what is described in #3363, in which redis is used to cache sessions.

### How to test
Dirk said this was fine.
