### PR TITLE
Run collectstatic only once per container

### DIFF
--- a/infra/concrexit/server-entrypoint.sh
+++ b/infra/concrexit/server-entrypoint.sh
@@ -3,11 +3,13 @@
 chown -R appuser /volumes/static
 chown -R appuser /volumes/media
 
-MANAGE_PY=1 runuser -u appuser -- ./manage.py collectstatic --no-input
+if [ ! -f /app/.collectstatic_done ]; then # Only run collectstatic if it hasn't been run before in this container.s
+    MANAGE_PY=1 runuser -u appuser -- ./manage.py collectstatic --no-input && touch /app/.collectstatic_done
+fi
 MANAGE_PY=1 runuser -u appuser -- ./manage.py migrate --no-input
 MANAGE_PY=1 runuser -u appuser -- ./manage.py createcachetable
 
 
 exec runuser -u appuser -- /venv/bin/gunicorn \
-  --config=/app/gunicorn.conf.py \
+  --config /app/gunicorn.conf.py \
   thaliawebsite.wsgi:application


### PR DESCRIPTION
Closes #3290.


### Summary
Creates a file after running collectstatic successfully, and skips collectstatic if that file already exists. As every release a new container is started, this effectively runs the slow collectstatic once per release, so that normal reboots are quick.

