### PR TITLE
Delete Sources when deleting photos

### DIFF
--- a/website/photos/models.py
+++ b/website/photos/models.py
@@ -98,12 +98,6 @@ class Photo(models.Model):
 
         return super().clean()
 
-    def delete(self, using=None, keep_parents=False):
-        removed = super().delete(using, keep_parents)
-        if self.file.name:
-            self.file.delete()
-        return removed
-
     class Meta:
         """Meta class for Photo."""
 

--- a/website/photos/signals.py
+++ b/website/photos/signals.py
@@ -7,5 +7,9 @@ from utils.models.signals import suspendingreceiver
     pre_delete, sender="photos.Photo", dispatch_uid="photos_photo_delete"
 )
 def pre_photo_delete(sender, instance, **kwargs):
-    """Remove main photo file on deletion."""
-    instance.file.delete()
+    """Remove main photo file and thumbnails on deletion."""
+    name = instance.file.name  # First get the name, it is removed by the next line.
+    instance.file.delete()  # Delete the file and its thumbnails.
+
+    # Clean up the source metadata, django-thumbnails does not do this.
+    instance.file.metadata_backend.delete_source(name)


### PR DESCRIPTION
Closes #3441.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
This is a workaround for a problem in django-thumbnails. I've not applied it to all of the other FileFields, as we don't really need it so much. And the real solution is to get https://github.com/ui/django-thumbnails/issues/124 fixed. I'll probably open a PR there, but no idea how long it will take to get that released.

### How to test
<!-- Steps to test the changes you made: -->
1. Make an album and view it
2. `from thumbnails.models import Source; Source.objects.count()`
3. Delete the album.
4. Count Sources again and see that it decreased.