### PR TITLE
Fixed Album Pagination Erasing Search Terms

### DIFF
--- a/website/thaliawebsite/templates/paginated_page.html
+++ b/website/thaliawebsite/templates/paginated_page.html
@@ -6,28 +6,26 @@
 <nav>
     <ul class="pagination mt-4">
         {% if page_obj.has_previous %}
-            <li class="page-item">
-                <a class="page-link"
-                    href="{{ base_url }}&page={{ page_obj.previous_page_number }}">
-                    <span aria-hidden="true">&laquo;</span>
-                    <span class="sr-only">Previous</span>
-                </a>
-            </li>
+        <li class="page-item">
+            <a class="page-link" href="{{ base_url }}page={{ page_obj.previous_page_number }}">
+                <span aria-hidden="true">&laquo;</span>
+                <span class="sr-only">Previous</span>
+            </a>
+        </li>
         {% endif %}
         {% for page in page_range %}
-            <li class="page-item{% if page == page_obj.number %} active{% endif %}">
-                <a class="page-link" href="{{ base_url }}&page={{ page }}">{{ page }}
-                </a>
-            </li>
+        <li class="page-item{% if page == page_obj.number %} active{% endif %}">
+            <a class="page-link" href="{{ base_url }}page={{ page }}">{{ page }}
+            </a>
+        </li>
         {% endfor %}
         {% if page_obj.has_next %}
-            <li class="page-item">
-                <a class="page-link"
-                    href="{{ base_url }}&page={{ page_obj.next_page_number }}">
-                    <span aria-hidden="true">&raquo;</span>
-                    <span class="sr-only">Next</span>
-                </a>
-            </li>
+        <li class="page-item">
+            <a class="page-link" href="{{ base_url }}page={{ page_obj.next_page_number }}">
+                <span aria-hidden="true">&raquo;</span>
+                <span class="sr-only">Next</span>
+            </a>
+        </li>
         {% endif %}
     </ul>
 </nav>

--- a/website/thaliawebsite/templates/paginated_page.html
+++ b/website/thaliawebsite/templates/paginated_page.html
@@ -8,7 +8,7 @@
         {% if page_obj.has_previous %}
             <li class="page-item">
                 <a class="page-link"
-                    href="{{ request.path }}?page={{ page_obj.previous_page_number }}">
+                    href="{{ base_url }}&page={{ page_obj.previous_page_number }}">
                     <span aria-hidden="true">&laquo;</span>
                     <span class="sr-only">Previous</span>
                 </a>
@@ -16,14 +16,14 @@
         {% endif %}
         {% for page in page_range %}
             <li class="page-item{% if page == page_obj.number %} active{% endif %}">
-                <a class="page-link" href="{{ request.path }}?page={{ page }}">{{ page }}
+                <a class="page-link" href="{{ base_url }}&page={{ page }}">{{ page }}
                 </a>
             </li>
         {% endfor %}
         {% if page_obj.has_next %}
             <li class="page-item">
                 <a class="page-link"
-                    href="{{ request.path }}?page={{ page_obj.next_page_number }}">
+                    href="{{ base_url }}&page={{ page_obj.next_page_number }}">
                     <span aria-hidden="true">&raquo;</span>
                     <span class="sr-only">Next</span>
                 </a>

--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -49,19 +49,17 @@ class PagedView(ListView):
 
         page_range = range(page_range_start, page_range_stop)
 
-        # generates the string of keywords, and applies these to the base_url
-        keyword_string = ""
+        querydict = self.request.GET.copy()
 
-        for keyword in self.keywords:
-            if keyword_string == "":
-                keyword_string += f"{keyword}"
-            else:
-                keyword_string += f"+{keyword}"
+        if "page" in querydict:
+            del querydict["page"]
 
         context.update(
             {
                 "page_range": page_range,
-                "base_url": self.request.path + f"?keywords={keyword_string}",
+                "base_url": f"{self.request.path}?{querydict.urlencode()}&"
+                if querydict
+                else f"{self.request.path}?",
             }
         )
 

--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -31,6 +31,7 @@ class PagedView(ListView):
 
     def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)
+        print(kwargs)
         page = context["page_obj"].number
         paginator = context["paginator"]
 
@@ -48,9 +49,19 @@ class PagedView(ListView):
 
         page_range = range(page_range_start, page_range_stop)
 
+        # generates the string of keywords, and applies these to the base_url
+        keyword_string = ""
+
+        for keyword in self.keywords:
+            if keyword_string == "":
+                keyword_string += f"{keyword}"
+            else:
+                keyword_string += f"+{keyword}"
+
         context.update(
             {
                 "page_range": page_range,
+                "base_url": self.request.path + f"?keywords={keyword_string}",
             }
         )
 


### PR DESCRIPTION
Closes #3509 .

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
When changing pages on the list of albums, any search terms you inserted will no longer be deleted.

### How to test
1. Go to the list of albums on the Thalia Website
2. Choose a search word such that the results take up more than one page
3. Switch between pages and check whether the search word you pack has been erased
