### PR TITLE
Use alpine base image

### DIFF
--- a/infra/concrexit/Dockerfile
+++ b/infra/concrexit/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye AS base
+FROM python:3.11-alpine AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -16,9 +16,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 RUN pip install "poetry==1.3.1" && pip install --upgrade setuptools
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    build-essential libpq-dev libjpeg-dev zlib1g-dev libwebp-dev libmagic1
+RUN apk update && \
+    apk add  \
+    build-base libpq-dev jpeg-dev zlib-dev libwebp-dev libmagic
 
 RUN  python -m venv /venv
 ENV PATH=/venv/bin:$PATH \
@@ -32,10 +32,32 @@ ARG WITH_DEV
 RUN if [ "$WITH_DEV" = "1" ]; then poetry install --only dev --only scss; fi
 
 
-FROM build-venv as build-scss
+FROM python:3.11-slim-bookworm as build-scss
 # This stage builds the SASS, using dependencies that are not needed in the final image.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DJANGO_ENV=production \
+    TZ=Europe/Amsterdam
 
-RUN poetry install --only main --only postgres --only scss
+WORKDIR /app
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN pip install "poetry==1.3.1" && pip install --upgrade setuptools
+
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends  \
+    build-essential libpq-dev libmagic1
+
+RUN  python -m venv /venv
+ENV PATH=/venv/bin:$PATH \
+    VIRTUAL_ENV=/venv
+
+COPY pyproject.toml poetry.lock ./
+
+RUN poetry install --only main  --only postgres --only scss
 
 COPY website /app/website
 
@@ -55,9 +77,9 @@ ENV PATH=/venv/bin:$PATH \
     SENDFILE_ROOT="/volumes/media"
 
 # Install runtime dependencies.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    postgresql-client libjpeg-dev zlib1g-dev libwebp-dev libmagic1 && \
+RUN apk update && \
+    apk add \
+    postgresql-client jpeg-dev zlib-dev libwebp-dev libmagic runuser && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/infra/concrexit/Dockerfile
+++ b/infra/concrexit/Dockerfile
@@ -16,8 +16,8 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 RUN pip install "poetry==1.3.1" && pip install --upgrade setuptools
 
-RUN apk update && \
-    apk add  \
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk update && apk add  \
     build-base libpq-dev jpeg-dev zlib-dev libwebp-dev libmagic
 
 RUN  python -m venv /venv
@@ -47,8 +47,8 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN pip install "poetry==1.3.1" && pip install --upgrade setuptools
 
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends  \
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y --no-install-recommends  \
     build-essential libpq-dev libmagic1
 
 RUN  python -m venv /venv
@@ -77,10 +77,9 @@ ENV PATH=/venv/bin:$PATH \
     SENDFILE_ROOT="/volumes/media"
 
 # Install runtime dependencies.
-RUN apk update && \
-    apk add \
-    postgresql-client jpeg-dev zlib-dev libwebp-dev libmagic runuser && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apk\
+    apk update && apk add \
+    postgresql-client jpeg-dev zlib-dev libwebp-dev libmagic runuser
 
 
 COPY infra/concrexit/server-entrypoint.sh /app/server-entrypoint.sh


### PR DESCRIPTION
Closes #3026.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Added alpine base image to switch from deb to alpine because it's smaller. Saves about 100MiB in the base image. 

