### PR TITLE
Add connection pooling to postgresql

### DIFF
--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -468,6 +468,7 @@ if DATABASE_ENGINE == "postgresql":
             "NAME": os.environ.get("POSTGRES_DB", ""),
             "HOST": os.environ.get("POSTGRES_HOST", ""),
             "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+            "CONN_MAX_AGE": 300,
         }
     }
 


### PR DESCRIPTION
### Summary
Add connection pooling to the postgresql backend for django ORM

### How to test
When used on top of #3544 you can test this using k6:
```
import http from 'k6/http';

export default function () {
  const url = 'http://localhost:443/events/${EVENT_SLUG}}';

  const params = {
    headers: {
      'Cookie': '${COOKIE HEADER FROM BROWSER}',
    },
  };

  http.get(url, params);
}
```

Locally on my machine this results in the following results post-warmup without connection pool and 100 concurrent users
```
     data_received..................: 16 MB  454 kB/s
     data_sent......................: 161 kB 4.7 kB/s
     http_req_blocked...............: avg=1ms      min=4.81µs   med=8.45µs  max=42.15ms  p(90)=338.31µs p(95)=2.62ms
     http_req_connecting............: avg=942.74µs min=0s       med=0s      max=42.09ms  p(90)=253.1µs  p(95)=2.2ms
     http_req_duration..............: avg=4.04s    min=266.13ms med=3.24s   max=13.72s   p(90)=11s      p(95)=12.73s
       { expected_response:true }...: avg=4.04s    min=266.13ms med=3.24s   max=13.72s   p(90)=11s      p(95)=12.73s
     http_req_failed................: 0.00%  ✓ 0         ✗ 791
     http_req_receiving.............: avg=153.58µs min=62.01µs  med=121.8µs max=8.55ms   p(90)=159.79µs p(95)=180.08µs
     http_req_sending...............: avg=37.01µs  min=11.1µs   med=25.28µs max=563.27µs p(90)=50.14µs  p(95)=106.4µs
     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s
     http_req_waiting...............: avg=4.04s    min=265.99ms med=3.24s   max=13.72s   p(90)=11s      p(95)=12.73s
     http_reqs......................: 791    23.222691/s
     iteration_duration.............: avg=4.05s    min=266.3ms  med=3.24s   max=13.72s   p(90)=11s      p(95)=12.73s
     iterations.....................: 791    23.222691/s
     vus............................: 3      min=3       max=100
     vus_max........................: 100    min=100     max=100
```

and with pooling:
```
     data_received..................: 28 MB  872 kB/s
     data_sent......................: 290 kB 9.1 kB/s
     http_req_blocked...............: avg=1.58ms   min=4.74µs  med=8.03µs   max=48.53ms p(90)=10.75µs  p(95)=4.52ms
     http_req_connecting............: avg=527.51µs min=0s      med=0s       max=43.36ms p(90)=0s       p(95)=377.35µs
     http_req_duration..............: avg=2.17s    min=44.17ms med=382.15ms max=10.4s   p(90)=6.31s    p(95)=8.08s
       { expected_response:true }...: avg=2.17s    min=44.17ms med=382.15ms max=10.4s   p(90)=6.31s    p(95)=8.08s
     http_req_failed................: 0.00%  ✓ 0         ✗ 1421
     http_req_receiving.............: avg=275.16µs min=76.4µs  med=123.89µs max=34.63ms p(90)=163.63µs p(95)=182.84µs
     http_req_sending...............: avg=1.08ms   min=13.96µs med=24.37µs  max=45.05ms p(90)=35.54µs  p(95)=106.71µs
     http_req_tls_handshaking.......: avg=0s       min=0s      med=0s       max=0s      p(90)=0s       p(95)=0s
     http_req_waiting...............: avg=2.17s    min=42.86ms med=381.24ms max=10.4s   p(90)=6.31s    p(95)=8.08s
     http_reqs......................: 1421   44.592471/s
     iteration_duration.............: avg=2.17s    min=49.88ms med=384.15ms max=10.4s   p(90)=6.31s    p(95)=8.08s
     iterations.....................: 1421   44.592471/s
     vus............................: 45     min=45      max=100
     vus_max........................: 100    min=100     max=100
```

Table with results:


| users | pooling | no pooling |
|---------|-----------|---------------|
| 10      | 44.5r/s | 22.3r/s      |
| 100    | 44.6r/s | 20.7r/s       |
| 500    | 44.0r/s | 21.4r/s       |
| 1000  | 43.8r/s | 21.4r/s       |

EDIT: more benchmarks 
EDIT2: markdown