### PR TITLE
Fix empty cancellations table layout

### DIFF
--- a/website/events/static/events/js/admin.js
+++ b/website/events/static/events/js/admin.js
@@ -80,7 +80,7 @@ django.jQuery(function () {
             return false;
         },
         format: function(s, t, node) {
-            const val = node.firstElementChild.value;
+            const val = node.firstElementChild?.value;
             if (val === 'no_payment') {
                 return 'z';
             }


### PR DESCRIPTION
Closes #3523.

The tablesorter initialization was crashing for tables without payment thing.

