### PR TITLE
"Live" registration

### DIFF
--- a/website/events/services.py
+++ b/website/events/services.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django.utils.datetime_safe import date
 from django.utils.formats import localize
+from django.utils.timezone import timedelta
 from django.utils.translation import gettext_lazy as _
 
 from events import emails
@@ -226,7 +227,13 @@ def event_permissions(member, event, name=None, registration_prefetch=False):
     )
     perms["create_registration_when_open"] = (
         (registration is None or registration.date_cancelled is not None)
-        and (bool(event.registration_start) and now < event.registration_start)
+        and (
+            event.registration_start is not None
+            and (
+                now < event.registration_start
+                and now > event.registration_start - timedelta(hours=2)
+            )
+        )
         and (
             name
             or member.can_attend_events

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -206,12 +206,26 @@ def event_permissions(member, event, name=None, registration_prefetch=False):
         except EventRegistration.DoesNotExist:
             pass
 
+    now = timezone.now()
+
     perms["create_registration"] = (
         (registration is None or registration.date_cancelled is not None)
         and (
             event.registration_allowed
             or (event.optional_registration_allowed and not event.registration_required)
         )
+        and (
+            name
+            or member.can_attend_events
+            or (
+                event.registration_without_membership
+                and member.can_attend_events_without_membership
+            )
+        )
+    )
+    perms["create_registration_when_open"] = (
+        (registration is None or registration.date_cancelled is not None)
+        and (bool(event.registration_start) and now < event.registration_start)
         and (
             name
             or member.can_attend_events

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -185,6 +185,7 @@ def event_permissions(member, event, name=None, registration_prefetch=False):
     """
     perms = {
         "create_registration": False,
+        "create_registration_when_open": False,
         "cancel_registration": False,
         "update_registration": False,
         "manage_event": is_organiser(member, event),

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -181,48 +181,27 @@
                                         <input type="submit" class="btn btn-primary" id="register-button"
                                                 value="{% trans "Register" %}"
                                                 disabled />
-                                        <i id="countdown">Registration will open in ...</i>
+                                        <i id="countdown">Opens in ...</i>
                                     </form>
                                     <script>
-                                        function FormatSecondsAsDurationString(seconds) {
-                                            var s = "";
-
-                                            var days = Math.floor( ( seconds / 3600 ) / 24 );
-                                            if ( days >= 1 )
-                                            {
-                                                s += days.toString() + " day" + ( ( days == 1 ) ? "" : "s" ) + " + ";
-                                                seconds -= days * 24 * 3600;
-                                            }
-
+                                        function formatDuration(seconds) {
                                             var hours = Math.floor( seconds / 3600 );
-                                            s += GetPaddedIntString( hours.toString(), 2 ) + ":";
                                             seconds -= hours * 3600;
-
                                             var minutes = Math.floor( seconds / 60 );
-                                            s += GetPaddedIntString( minutes.toString(), 2 ) + ":";
                                             seconds -= minutes * 60;
 
-                                            s += GetPaddedIntString( Math.floor( seconds ).toString(), 2 );
-
-                                            return s;
+                                            return pad2(hours) + ":" + pad2(minutes) + ":" + pad2(Math.floor(seconds));
                                         }
 
-                                        function GetPaddedIntString( n, numDigits )
-                                        {
-                                            var nPadded = n;
-                                            for ( ; nPadded.length < numDigits ; )
-                                            {
-                                                nPadded = "0" + nPadded;
-                                            }
-
-                                            return nPadded;
+                                        function pad2(x) {
+                                            return x < 10 ? "0" + x.toString() : x.toString();
                                         }
 
                                         let open_datetime = new Date("{{ event.registration_start.isoformat }}");
                                         function updateCountdown() {
                                             const diff = (open_datetime - new Date()) / 1000;
                                             let elem = document.getElementById("countdown");
-                                            elem.innerText = "Will open in " + FormatSecondsAsDurationString(diff);
+                                            elem.innerText = "Opens in " + formatDuration(diff);
                                         }
                                         updateCountdown()
                                         var updater = setInterval(updateCountdown, 1000);

--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -167,6 +167,71 @@
                                                    value="{% trans "Register" %}"/>
                                         {% endif %}
                                     </form>
+                                {% elif permissions.create_registration_when_open %}
+                                    <p>
+                                        {% url 'singlepages:event-registration-terms' as terms_url %}
+                                        {% blocktrans trimmed %}
+                                            By registering,
+                                            you confirm that you have read the
+                                            <a target="_blank" href="{{ terms_url }}">terms and conditions</a>,
+                                            that you understand them and that you agree to be bound by them.
+                                        {% endblocktrans %}
+                                    </p>
+                                    <form id="registration-info" action="{% url 'events:register' event.id %}" method="post">{% csrf_token %}
+                                        <input type="submit" class="btn btn-primary" id="register-button"
+                                                value="{% trans "Register" %}"
+                                                disabled />
+                                        <i id="countdown">Registration will open in ...</i>
+                                    </form>
+                                    <script>
+                                        function FormatSecondsAsDurationString(seconds) {
+                                            var s = "";
+
+                                            var days = Math.floor( ( seconds / 3600 ) / 24 );
+                                            if ( days >= 1 )
+                                            {
+                                                s += days.toString() + " day" + ( ( days == 1 ) ? "" : "s" ) + " + ";
+                                                seconds -= days * 24 * 3600;
+                                            }
+
+                                            var hours = Math.floor( seconds / 3600 );
+                                            s += GetPaddedIntString( hours.toString(), 2 ) + ":";
+                                            seconds -= hours * 3600;
+
+                                            var minutes = Math.floor( seconds / 60 );
+                                            s += GetPaddedIntString( minutes.toString(), 2 ) + ":";
+                                            seconds -= minutes * 60;
+
+                                            s += GetPaddedIntString( Math.floor( seconds ).toString(), 2 );
+
+                                            return s;
+                                        }
+
+                                        function GetPaddedIntString( n, numDigits )
+                                        {
+                                            var nPadded = n;
+                                            for ( ; nPadded.length < numDigits ; )
+                                            {
+                                                nPadded = "0" + nPadded;
+                                            }
+
+                                            return nPadded;
+                                        }
+
+                                        let open_datetime = new Date("{{ event.registration_start.isoformat }}");
+                                        function updateCountdown() {
+                                            const diff = (open_datetime - new Date()) / 1000;
+                                            let elem = document.getElementById("countdown");
+                                            elem.innerText = "Will open in " + FormatSecondsAsDurationString(diff);
+                                        }
+                                        updateCountdown()
+                                        var updater = setInterval(updateCountdown, 1000);
+                                        var finalizer = setTimeout(function() {
+                                            document.getElementById("countdown").style.display = "none";
+                                            document.getElementById("register-button").removeAttribute("disabled");
+                                            clearInterval(updater);
+                                        }, open_datetime - new Date());
+                                    </script>
                                 {% elif permissions.cancel_registration %}
                                     {# Special message to accept costs when cancelling after the deadline, unless member is on the waiting list #}
                                     <form action="{% url 'events:cancel' event.id %}" method="post">{% csrf_token %}

--- a/website/events/tests/test_services.py
+++ b/website/events/tests/test_services.py
@@ -87,6 +87,7 @@ class ServicesTest(TestCase):
         self.assertEqual(
             {
                 "create_registration": False,
+                "create_registration_when_open": False,
                 "cancel_registration": False,
                 "update_registration": False,
                 "manage_event": False,
@@ -99,6 +100,7 @@ class ServicesTest(TestCase):
         self.assertEqual(
             {
                 "create_registration": False,
+                "create_registration_when_open": False,
                 "cancel_registration": False,
                 "update_registration": False,
                 "manage_event": False,
@@ -111,6 +113,7 @@ class ServicesTest(TestCase):
         self.assertEqual(
             {
                 "create_registration": True,
+                "create_registration_when_open": False,
                 "cancel_registration": False,
                 "update_registration": False,
                 "manage_event": False,
@@ -125,6 +128,7 @@ class ServicesTest(TestCase):
         self.assertEqual(
             {
                 "create_registration": False,
+                "create_registration_when_open": False,
                 "cancel_registration": True,
                 "update_registration": False,
                 "manage_event": False,
@@ -142,6 +146,7 @@ class ServicesTest(TestCase):
         self.assertEqual(
             {
                 "create_registration": False,
+                "create_registration_when_open": False,
                 "cancel_registration": True,
                 "update_registration": True,
                 "manage_event": False,
@@ -155,6 +160,7 @@ class ServicesTest(TestCase):
         self.assertEqual(
             {
                 "create_registration": True,
+                "create_registration_when_open": False,
                 "cancel_registration": False,
                 "update_registration": False,
                 "manage_event": False,


### PR DESCRIPTION
Closes #3522.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Adds a permission `create_registration_when_open`, that indicates a user will be able to register for an event as soon as it opens. Additionally, when this permission is true, the event page will contain a disabled register button and some JavaScript that will automatically enable it at the right time.

For the app, we can use this new permission in combination with `registration_start`.

### How to test
<!-- Steps to test the changes you made: -->
1. Create an event that opens in the future
2. Open the event page
3. See that there is a countdown
4. Ensure the button activates when the countdown is done.

### RFC
Should we maybe limit the countdown to e.g. something in the same day (e.g. what if a user has a stale tab?)

Is the styling OK?