### PR TITLE
Fix color scheme toggle in admin

### DIFF
--- a/website/thaliawebsite/templates/admin/base_site.html
+++ b/website/thaliawebsite/templates/admin/base_site.html
@@ -70,7 +70,7 @@
             font-weight: normal;
             font-style: normal;
         }
-        :root {
+        html:root {
             --thalia-base: #E62272;
             --thalia-dark: #CF1760;
             --thalia-accent: #FFFFFF;
@@ -85,6 +85,7 @@
             --header-color: var(--thalia-accent);
             --default-button-bg: var(--thalia-dark);
             --default-button-hover-bg: var(--thalia-base);
+            --button-bg: var(--thalia-base);
             --button-hover-bg: var(--thalia-dark);
             --breadcrumbs-link-fg: var(--thalia-accent);
             --breadcrumbs-fg: var(--thalia-accent-contrast);


### PR DESCRIPTION
Also solves an incorrect button color introduced in Django 5.0.

Closes #2984.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Makes our color overrides get higher specificity than django's.

