### PR TITLE
Fix Partner layout

### DIFF
--- a/website/partners/templates/partners/index.html
+++ b/website/partners/templates/partners/index.html
@@ -33,7 +33,7 @@
     <div class="row mt-4 justify-content-center">
         {% for local_partner in local_partners %}
             <div class="col-12 col-md-6 mt-4">
-                <img src="{% thumbnail local_partner.logo "fit_medium" %}"/>
+                <img src="{% thumbnail local_partner.logo "fit_medium_pad" %}"/>
 
                 <div class="mt-3">
                     <h2>{% trans "our local partner"|capfirst %}</h2>

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -1026,6 +1026,16 @@ THUMBNAILS = {
                 },
             ],
         },
+        "fit_medium_pad": {
+            "FORMAT": "webp",
+            "PROCESSORS": [
+                {
+                    "PATH": "utils.media.processors.thumbnail",
+                    "size": (600, 250),
+                    "mode": "pad",
+                },
+            ],
+        },
         "fit_large": {
             "FORMAT": "webp",
             "PROCESSORS": [

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -926,7 +926,7 @@ THUMBNAILS = {
                 {
                     "PATH": "utils.media.processors.thumbnail",
                     "size": (300, 300),
-                    "cover": True,
+                    "mode": "cover",
                 },
             ],
         },
@@ -936,7 +936,7 @@ THUMBNAILS = {
                 {
                     "PATH": "utils.media.processors.thumbnail",
                     "size": (600, 600),
-                    "cover": True,
+                    "mode": "cover",
                 },
             ],
         },
@@ -946,7 +946,7 @@ THUMBNAILS = {
                 {
                     "PATH": "utils.media.processors.thumbnail",
                     "size": (1200, 900),
-                    "cover": True,
+                    "mode": "cover",
                 },
             ],
         },
@@ -974,7 +974,7 @@ THUMBNAILS = {
                 {
                     "PATH": "utils.media.processors.thumbnail",
                     "size": (900, 900),
-                    "cover": True,
+                    "mode": "cover",
                 },
             ],
         },
@@ -984,7 +984,7 @@ THUMBNAILS = {
                 {
                     "PATH": "utils.media.processors.thumbnail",
                     "size": (500, 108),
-                    "cover": True,
+                    "mode": "cover",
                 },
             ],
         },
@@ -994,7 +994,7 @@ THUMBNAILS = {
                 {
                     "PATH": "utils.media.processors.thumbnail",
                     "size": (1000, 215),
-                    "cover": True,
+                    "mode": "cover",
                 },
             ],
         },
@@ -1004,7 +1004,7 @@ THUMBNAILS = {
                 {
                     "PATH": "utils.media.processors.thumbnail",
                     "size": (2000, 430),
-                    "cover": True,
+                    "mode": "cover",
                 },
             ],
         },


### PR DESCRIPTION
Closes #3513.

### Summary
Images of local partners are padded on the top and bottom to make the image including padding always 250px. Images are 600px wide.

### How to test
1. (optional) Add images for the local partners to see the results better
2. Go to the partners' page
3. Better layout
![partners](https://github.com/svthalia/concrexit/assets/102288378/4af206b8-82fd-4c3a-95ab-118b523391a2)
