### PR TITLE
improve layout for newsletter

### DIFF
--- a/website/newsletters/services.py
+++ b/website/newsletters/services.py
@@ -1,6 +1,5 @@
 import base64
 import logging
-import math
 from io import BytesIO
 
 from django.core.files.base import ContentFile
@@ -92,10 +91,12 @@ def send_newsletter(newsletter):
 
 
 def split_local_partners():
-    all_local_partners = Partner.objects.filter(is_local_partner=True).order_by("?")
+    all_local_partners = Partner.objects.filter(
+        is_local_partner=True, is_active=True
+    ).order_by("?")
     local_partner_count = len(all_local_partners)
     local_partners = []
-    for i in range(math.floor(local_partner_count / 2)):
+    for i in range(local_partner_count // 2):
         local_partners.append(
             [all_local_partners[i * 2], all_local_partners[i * 2 + 1]]
         )

--- a/website/newsletters/templates/newsletters/email.html
+++ b/website/newsletters/templates/newsletters/email.html
@@ -206,7 +206,7 @@
                 <td align="center" style="color: black; font-size: 12px;">
                     <p style="margin: 10px; font-family: 'Gill Sans', 'Trebuchet MS', sans-serif;">
                         <a href="{{ main_partner.link }}">
-                            <img src="{% thumbnail main_partner.logo "fit_medium" absolute_url=True %}" height="95" style="height: 95px;" alt="{{ main_partner.name }}"/>
+                            <img src="{% thumbnail main_partner.logo "fit_medium_pad" absolute_url=True %}" height="150" style="height: 150px;" alt="{{ main_partner.name }}"/>
                         </a><br>
                         OUR MAIN PARTNER
                     </p>
@@ -232,7 +232,7 @@
                             <td align="center" style="color: black; font-size: 12px;">
                                 <p style="margin: 10px; font-family: 'Gill Sans', 'Trebuchet MS', sans-serif;">
                                     <a href="{{ local_partner.link }}">
-                                        <img src="{% thumbnail local_partner.logo "fit_medium" absolute_url=True %}" height="70" style="height: 70px; margin-bottom: 25px" alt="{{ local_partner.name }}"/>
+                                        <img src="{% thumbnail local_partner.logo "fit_small_pad" absolute_url=True %}" height="100" style="height: 100px; margin-bottom: 25px" alt="{{ local_partner.name }}"/>
                                     </a><br>
                                     OUR LOCAL PARTNER
                                 </p>

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -1038,7 +1038,17 @@ THUMBNAILS = {
             "PROCESSORS": [
                 {
                     "PATH": "utils.media.processors.thumbnail",
-                    "size": (600, 250),
+                    "size": (750, 300),
+                    "mode": "pad",
+                },
+            ],
+        },
+        "fit_small_pad": {
+            "FORMAT": "webp",
+            "PROCESSORS": [
+                {
+                    "PATH": "utils.media.processors.thumbnail",
+                    "size": (500, 200),
                     "mode": "pad",
                 },
             ],


### PR DESCRIPTION
Closes #3360.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Add a fit_small_pad to make using the same idea when fixing the partners' layout. I don't know how it will look in the mail on IOS, but the web version of the mail looks nicer. 

### How to test
1. Go to newsletter via administration
2. Click on a newsletter and view it.