### PR TITLE
fix alumni acounts not getting a contract because there not a member

### DIFF
--- a/website/moneybirdsynchronization/models.py
+++ b/website/moneybirdsynchronization/models.py
@@ -258,13 +258,16 @@ class MoneybirdExternalInvoice(models.Model):
     def to_moneybird(self):
         moneybird = get_moneybird_api_service()
 
-        if self.payable.payment_payer is None:
-            contact_id = settings.MONEYBIRD_UNKNOWN_PAYER_CONTACT_ID
-        else:
-            moneybird_contact = MoneybirdContact.objects.get(
-                member=self.payable.payment_payer
-            )
-            contact_id = moneybird_contact.moneybird_id
+        contact_id = settings.MONEYBIRD_UNKNOWN_PAYER_CONTACT_ID
+
+        if self.payable.payment_payer is not None:
+            try:
+                moneybird_contact = MoneybirdContact.objects.get(
+                    member=self.payable.payment_payer
+                )
+                contact_id = moneybird_contact.moneybird_id
+            except MoneybirdContact.DoesNotExist:
+                pass
 
         invoice_date = date_for_payable_model(self.payable_object).strftime("%Y-%m-%d")
 


### PR DESCRIPTION
Closes #3603.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Added a check for MoneybirdContact.DoesNotExist exception so that it does not crash when accounts which are not members try to make a contract. This fixes the issue where alumni people don't get a contract.
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->

### How to test
<!-- Steps to test the changes you made: -->
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
