### PR TITLE
Disable crashing admin list filter facet counts

### DIFF
--- a/website/activemembers/admin.py
+++ b/website/activemembers/admin.py
@@ -200,6 +200,9 @@ class MemberGroupMembershipAdmin(admin.ModelAdmin):
     date_hierarchy = "since"
     actions = ("export",)
 
+    # Facet counts would crash for this admin.
+    show_facets = admin.ShowFacets.NEVER
+
     def changelist_view(self, request, extra_context=None):
         self.message_user(
             request,

--- a/website/members/admin.py
+++ b/website/members/admin.py
@@ -184,6 +184,9 @@ class UserAdmin(BaseUserAdmin):
         ),
     )
 
+    # Facet counts would crash for this admin. See #3584.
+    show_facets = admin.ShowFacets.NEVER
+
     def email_csv_export(self, request, queryset):
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = 'attachment;filename="email.csv"'

--- a/website/payments/admin.py
+++ b/website/payments/admin.py
@@ -684,6 +684,9 @@ class PaymentUserAdmin(admin.ModelAdmin):
         "email",
     )
 
+    # Facet counts would crash for this admin.
+    show_facets = admin.ShowFacets.NEVER
+
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
         queryset = queryset.prefetch_related("bank_accounts", "paid_payment_set")

--- a/website/sales/admin/order_admin.py
+++ b/website/sales/admin/order_admin.py
@@ -217,6 +217,9 @@ class OrderAdmin(admin.ModelAdmin):
         "payment_url",
     )
 
+    # Facet counts would crash for this admin. See #3585.
+    show_facets = admin.ShowFacets.NEVER
+
     def get_readonly_fields(self, request: HttpRequest, obj: Order = None):
         """Disallow changing shift when selected."""
         default_fields = self.readonly_fields


### PR DESCRIPTION
Closes #3585.
Closes #3584.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Disables some facet counts on admins that crashed when using them. I'm not sure why they crashed, but I don't think it matters much.

### How to test
<!-- Steps to test the changes you made: -->
1. Open the changed admins, and see that there's no facet counts button any more.