### PR TITLE
Optimize fetch_thumbnails

### DIFF
--- a/website/utils/media/services.py
+++ b/website/utils/media/services.py
@@ -89,6 +89,9 @@ def fetch_thumbnails(images: list, sizes=None):
     :param sizes: A list of sizes to prefetch. If None, all sizes will be prefetched.
     :return: None
     """
+    # Filter out empty ImageFieldFiles.
+    images = list(filter(bool, images))
+
     if not images:
         return
 


### PR DESCRIPTION
In case of a redis backend, this should prevent doing a redis pipeline that looks for a thumbnail for image "" many times, for each empty image field (such as a member without profile picture).

Consider for example this (partial) redis pipeline call from sentry:

```
"HGETALL 'djthumbs:thumbnails:avatars/98a3dd0519bae43a2bfc45f2bb8653a0.jpg'",
"HGETALL 'djthumbs:thumbnails:'",
"HGETALL 'djthumbs:thumbnails:'",
"HGETALL 'djthumbs:thumbnails:avatars/1152ba8439c354c207967279fcbf4fcb.jpg'",
"HGETALL 'djthumbs:thumbnails:'",
// ... (45 more)
```
<img width="1390" alt="image" src="https://github.com/svthalia/concrexit/assets/41264528/aac326e7-05e6-4f36-b56d-84a65def9add">
