### PR TITLE
Update membership upgrade discount conditions to match HR

### DIFF
--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django import forms
 from django.conf import settings
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
@@ -222,7 +224,7 @@ class RenewalForm(forms.ModelForm):
             if Membership.objects.filter(
                 user=self.cleaned_data["member"],
                 type=Membership.MEMBER,
-                until__gte=now,
+                until__gte=now - timedelta(days=366),
                 since__lte=now,
             ).exists():
                 # The membership upgrade discount applies if, at the time a Renewal is


### PR DESCRIPTION
Closes #3612.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary

A user now gets the discount also in the year after last having been a member.

### How to test
<!-- Steps to test the changes you made: -->
1. Make a user with a membership that has ended recently.
2. Make upgrade renewal.
3. Get discount.
