### PR TITLE
Fixed alumni newsletter opt out without filling in extra information

### DIFF
--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -15,8 +15,9 @@ from .models import Profile
 class ProfileForm(forms.ModelForm):
     """Form with all the user editable fields of a Profile model.
 
-    If the profile is minimised no fields are required, unless the extra parameter
-    require_address parameter was passed when opening the form.
+    If the profile is minimized, no fields are required, unless the `require_address`
+    keyword argument is True, which is set if a user is filling a minimized profile
+    in order to be able to create a Renewal.
     """
 
     birthday = forms.DateField()

--- a/website/members/forms.py
+++ b/website/members/forms.py
@@ -13,7 +13,11 @@ from .models import Profile
 
 
 class ProfileForm(forms.ModelForm):
-    """Form with all the user editable fields of a Profile model."""
+    """Form with all the user editable fields of a Profile model.
+
+    If the profile is minimised no fields are required, unless the extra parameter
+    require_address parameter was passed when opening the form.
+    """
 
     birthday = forms.DateField()
 
@@ -43,8 +47,9 @@ class ProfileForm(forms.ModelForm):
         ]
         model = Profile
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, require_address=False, **kwargs):
         super().__init__(*args, **kwargs)
+        user = Member.objects.get(pk=kwargs["instance"].user_id)
         for field in [
             "birthday",
             "address_street",
@@ -53,16 +58,17 @@ class ProfileForm(forms.ModelForm):
             "address_city",
             "address_country",
         ]:
-            self.fields[field].required = True
+            if require_address or not user.profile.is_minimized:
+                self.fields[field].required = True
+            else:
+                self.fields[field].required = False
+
         if not kwargs["instance"].user.is_staff:
             self.fields["email_gsuite_only"].widget = self.fields[
                 "email_gsuite_only"
             ].hidden_widget()
 
-        if (
-            not Member.objects.get(pk=kwargs["instance"].user_id).has_been_member()
-            and not kwargs["instance"].receive_oldmembers
-        ):
+        if not user.has_been_member() and not kwargs["instance"].receive_oldmembers:
             self.fields["receive_oldmembers"].disabled = True
             self.fields["receive_oldmembers"].help_text = (
                 "If you are a past member, receive emails about Thalia events aimed at alumni. "
@@ -72,7 +78,7 @@ class ProfileForm(forms.ModelForm):
             )
 
         self.fields["birthday"].widget.input_type = "date"
-        if not Member.objects.get(pk=kwargs["instance"].user_id).profile.is_minimized:
+        if not user.profile.is_minimized:
             self.fields["birthday"].disabled = True
 
         self.render_app_specific_profile_form_fields()

--- a/website/members/views.py
+++ b/website/members/views.py
@@ -182,6 +182,11 @@ class UserProfileUpdateView(RedirectURLMixin, SuccessMessageMixin, UpdateView):
     def get_object(self, queryset=None) -> Profile:
         return get_object_or_404(models.Profile, user=self.request.user)
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["require_address"] = bool(self.request.GET.get("require_address", False))
+        return kwargs
+
 
 @method_decorator(login_required, "dispatch")
 class StatisticsView(TemplateView):

--- a/website/registrations/templates/registrations/renewal.html
+++ b/website/registrations/templates/registrations/renewal.html
@@ -187,7 +187,7 @@
 
                         You have a minimized profile. You can't renew your
                         membership until you have filled in all the required
-                        fields.<a href="{% url "members:edit-profile"  %}?next={% url "registrations:renew" %}"> Click here</a> to complete your profile.
+                        fields.<a href="{% url "members:edit-profile"  %}?require_address=1&next={% url "registrations:renew" %}"> Click here</a> to complete your profile.
                 </p>
             {% endif %}
         </div>


### PR DESCRIPTION
Closes #3378 .

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Changed that for minimised user fields are not required anymore, such that  a minimised user can opt-out of the alumni newsletter without refilling in information. In case that one makes a renewal request however, a minimised user has to reenter the normally required information. 


### How to test
<!-- Steps to test the changes you made: -->
1. Go to the admin and delete your membership
2. In the terminal run the dataminimisation management command
3. Go to the edit profile page and opt out from some preferences and click safe. 
4. See that the profile has been saved successfully. 
5. Now go on manage membership and click on change here to add the extra information
6. Change an preference and try to safe. Saving will now not work and require you to put in more information.
