### PR TITLE
Add rate limit to registration view

### DIFF
--- a/website/registrations/views.py
+++ b/website/registrations/views.py
@@ -14,6 +14,8 @@ from django.views import View
 from django.views.generic import CreateView, FormView
 from django.views.generic.base import TemplateResponseMixin, TemplateView
 
+from django_ratelimit.decorators import ratelimit
+
 from members.decorators import membership_required
 from members.models import Membership
 
@@ -137,6 +139,10 @@ class BaseRegistrationFormView(FormView):
         form.save()
         emails.send_registration_email_confirmation(form.instance)
         return redirect("registrations:register-success")
+
+    @method_decorator(ratelimit(key="ip", rate="10/d"))
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
 
 
 class MemberRegistrationFormView(BaseRegistrationFormView):


### PR DESCRIPTION
Closes #3036.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->


### How to test
<!-- Steps to test the changes you made: -->
1. Go to association -> become a member -> become a member
2. Fill in the form 11 times in a day
3. Get a rate-limited screen. It is not possible to fill in the form again on the same IP address
