### PR TITLE
Improve album upload error handling

### DIFF
--- a/website/photos/admin.py
+++ b/website/photos/admin.py
@@ -74,7 +74,11 @@ class AlbumAdmin(admin.ModelAdmin):
             # function call. In a real deployment, it has to be called only when the current db
             # transaction is committed,
             transaction.on_commit(
-                process_album_upload.s(archive.temporary_upload.upload_id, obj.id).delay
+                process_album_upload.s(
+                    archive.temporary_upload.upload_id,
+                    obj.id,
+                    uploader_id=request.user.id,
+                ).delay
             )
 
             self.message_user(

--- a/website/photos/tasks.py
+++ b/website/photos/tasks.py
@@ -1,22 +1,32 @@
+import logging
+
 from django.db import transaction
 from django.dispatch import Signal
 
 from celery import shared_task
 from django_drf_filepond.models import TemporaryUpload
 
+from mailinglists.services import get_member_email_addresses
+from members.models.member import Member
 from photos.models import Album
+from utils.snippets import send_email
 
 from .services import extract_archive
 
+logger = logging.getLogger(__name__)
 album_uploaded = Signal()
 
 
 @shared_task
-def process_album_upload(archive_upload_id: str, album_id: int):
+def process_album_upload(
+    archive_upload_id: str, album_id: int, uploader_id: int | None = None
+):
     try:
         album = Album.objects.get(id=album_id)
     except Album.DoesNotExist:
         return
+
+    uploader = Member.objects.get(id=uploader_id) if uploader_id is not None else None
 
     upload = TemporaryUpload.objects.get(upload_id=archive_upload_id)
     archive = upload.file
@@ -24,13 +34,31 @@ def process_album_upload(archive_upload_id: str, album_id: int):
         with transaction.atomic():
             # We make the upload atomic separately, so we can keep using the db if it fails.
             # See https://docs.djangoproject.com/en/4.2/topics/db/transactions/#handling-exceptions-within-postgresql-transactions.
-            extract_archive(album, archive)
+            warnings, count = extract_archive(album, archive)
             album.is_processing = False
             album.save()
 
             # Send signal to notify that an album has been uploaded. This is used
             # by facedetection, and possibly in the future to notify the uploader.
             album_uploaded.send(sender=None, album=album)
+
+            if uploader is not None:
+                # Notify uploader of the upload result.
+                send_email(
+                    to=get_member_email_addresses(uploader),
+                    subject=("Album upload processed completed."),
+                    txt_template="photos/email/upload-processed.txt",
+                    context={
+                        "name": uploader.first_name,
+                        "album": album,
+                        "upload_name": upload.file.name,
+                        "warnings": warnings,
+                        "num_processed": count,
+                    },
+                )
+    except Exception as e:
+        logger.exception(f"Failed to process album upload: {e}", exc_info=e)
+
     finally:
         archive.delete()
         upload.delete()

--- a/website/photos/templates/photos/emails/upload-processed.txt
+++ b/website/photos/templates/photos/emails/upload-processed.txt
@@ -1,0 +1,16 @@
+Hi {{ name }},
+
+You have recently uploaded an archive ('{{ upload_name }}') to this album: {{ album }}
+You can see it here: {% url "photos:album" album.slug %}
+
+{{ num_processed }} photos were successfully processed.
+{% if warnings %}
+The following warnings occurred while processing the upload:{% for file, warning in warnings%}
+{{ file }}: {{ warning }}
+{% endfor %}{% else %}
+There were no issues while processing the upload.</p>
+{% endif %}
+
+Kisses,
+
+The website


### PR DESCRIPTION
Closes #3636.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
We now send an email with a summary when the upload is done, catch OSError, and log more.

### TODO
- [ ] send email on other uncaught failures?
- [ ] Test it locally.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
