### PR TITLE
Add and use CaseInsensitiveFilter for promotion admin assignment filter

### DIFF
--- a/website/promotion/admin.py
+++ b/website/promotion/admin.py
@@ -1,11 +1,83 @@
 """Registers admin interfaces for the models defined in this module."""
+
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
+from django.db import models
+from django.db.models.functions import Lower
 
 from events.services import is_organiser
 from promotion.forms import PromotionRequestForm
 
 from .models import PromotionChannel, PromotionRequest
+
+
+class CaseInsensitiveFilter(admin.FieldListFilter):
+    def __init__(self, field, request, params, model, model_admin, field_path):
+        self.lookup_kwarg = f"{field_path}__iexact"
+        self.lookup_kwarg2 = f"{field_path}__isnull"
+        self.lookup_val = params.get(self.lookup_kwarg)
+        self.lookup_val2 = params.get(self.lookup_kwarg2)
+        super().__init__(field, request, params, model, model_admin, field_path)
+        self.empty_value_display = model_admin.get_empty_value_display()
+        queryset = model_admin.get_queryset(request)
+        lookup_choices = (
+            queryset.annotate(lowered=Lower(field.name))
+            .order_by(field.name)
+            .distinct()
+            .values_list(field.name, flat=True)
+        )
+        self.lookup_choices = set(
+            map(lambda x: x.lower() if x is not None else x, lookup_choices)
+        )
+
+    def get_facet_counts(self, pk_attname, filtered_qs):
+        return {
+            f"{i}__c": models.Count(
+                pk_attname,
+                filter=models.Q(
+                    (self.lookup_kwarg, value)
+                    if value is not None
+                    else (self.lookup_kwarg2, True)
+                ),
+            )
+            for i, value in enumerate(self.lookup_choices)
+        }
+
+    def choices(self, changelist):
+        add_facets = changelist.add_facets
+        facet_counts = self.get_facet_queryset(changelist)
+        yield {
+            "selected": self.lookup_val is None,
+            "query_string": changelist.get_query_string(
+                remove=[self.lookup_kwarg, self.lookup_kwarg2]
+            ),
+            "display": "All",
+        }
+        include_none = False
+        empty_title = self.empty_value_display
+        for key, val in enumerate(self.lookup_choices):
+            if add_facets:
+                count = facet_counts[f"{key}__c"]
+            if val is None:
+                include_none = True
+                empty_title = f"{empty_title} ({count})" if add_facets else empty_title
+                continue
+            yield {
+                "selected": self.lookup_val is not None and val in self.lookup_val,
+                "query_string": changelist.get_query_string({self.lookup_kwarg: val}),
+                "display": f"{val} ({count})" if add_facets else val,
+            }
+        if include_none:
+            yield {
+                "selected": self.lookup_val2 is True,
+                "query_string": changelist.get_query_string(
+                    {self.lookup_kwarg2: "True"}, remove=[self.lookup_kwarg]
+                ),
+                "display": empty_title,
+            }
+
+    def expected_parameters(self):
+        return [self.lookup_kwarg, self.lookup_kwarg2]
 
 
 @admin.register(PromotionRequest)
@@ -15,7 +87,7 @@ class PromotionRequestAdmin(admin.ModelAdmin):
     list_display = ("event", "publish_date", "channel", "assigned_to", "status")
     list_filter = (
         "publish_date",
-        "assigned_to",
+        ("assigned_to", CaseInsensitiveFilter),
         "status",
     )
     date_hierarchy = "publish_date"


### PR DESCRIPTION
Closes #3085.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Adds a `CaseInsensitiveFilter` inside the promo admin, and uses it for `assigned_to`.

Maybe this should be in some more central directory, so we can reuse it more widely? I don't know if we want this in other places too. The code is also a bit messy, but it seems pretty much all of it is needed and Django offers no easier way, sadly.

I also used in-Python code for managing the lower-casing, since I think doing it directly would require Postgres or something and we don't want to break SQLite.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to promo admin
2. Assign some requests to different capitalizations of the same name (e.g. one to `quinten` and the other to `Quinten`)
3. Observe that these are merged together in one filter option
