### PR TITLE
Redirect to next or LOGIN_REDIRECT_URL after loggin in with django otp

### DIFF
--- a/website/templates/two_factor/core/login.html
+++ b/website/templates/two_factor/core/login.html
@@ -18,7 +18,6 @@
   <form action="" method="post">{% csrf_token %}
     {% if wizard.steps.current == 'auth' %}
         {{ wizard.management_form }}
-        <input type="hidden" name="next" value="{{ next }}">
 
         {% if form.errors %}
           {% trans "Invalid username or password." as error_text %}

--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -1,6 +1,5 @@
 """General views for the website."""
 
-from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.views import LogoutView as BaseLogoutView
 from django.contrib.auth.views import PasswordResetView

--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -81,7 +81,7 @@ class RateLimitedLoginView(LoginView):
         response = super().post(request, *args, **kwargs)
 
         if request.member:
-            return redirect(request.GET.get("next", settings.LOGIN_REDIRECT_URL))
+            return redirect(self.get_success_url())
         else:
             return response
 

--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -77,12 +77,7 @@ class RateLimitedLoginView(LoginView):
     @method_decorator(ratelimit(key="ip", rate="30/h"))
     @method_decorator(ratelimit(key="post:username", rate="30/h"))
     def post(self, request, *args, **kwargs):
-        response = super().post(request, *args, **kwargs)
-
-        if request.member:
-            return redirect(self.get_success_url())
-        else:
-            return response
+        return super().post(request, *args, **kwargs)
 
 
 class LogoutView(BaseLogoutView):

--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -1,5 +1,6 @@
 """General views for the website."""
 
+from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.views import LogoutView as BaseLogoutView
 from django.contrib.auth.views import PasswordResetView
@@ -77,7 +78,12 @@ class RateLimitedLoginView(LoginView):
     @method_decorator(ratelimit(key="ip", rate="30/h"))
     @method_decorator(ratelimit(key="post:username", rate="30/h"))
     def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
+        response = super().post(request, *args, **kwargs)
+
+        if request.member:
+            return redirect(request.GET.get("next", settings.LOGIN_REDIRECT_URL))
+        else:
+            return response
 
 
 class LogoutView(BaseLogoutView):


### PR DESCRIPTION
Closes #3680.

### Summary
Fixes the issue that users always get redirected to '/' after login

### How to test
1. Go to 'Photos'
2. You will get redirected to login with a next parameter
3. Login with your credentials
4. You are redirected to /members/photos/
