### PR TITLE
Fix sales admin autocomplete filters pk exact

### DIFF
--- a/website/sales/admin/order_admin.py
+++ b/website/sales/admin/order_admin.py
@@ -95,6 +95,7 @@ class OrderShiftFilter(AutocompleteFilter):
     title = _("shift")
     field_name = "shift"
     rel_model = Order
+    use_pk_exact = False
 
     def queryset(self, request, queryset):
         if self.value():
@@ -106,6 +107,7 @@ class OrderMemberFilter(AutocompleteFilter):
     title = _("member")
     field_name = "payer"
     rel_model = Order
+    use_pk_exact = False
 
     def queryset(self, request, queryset):
         if self.value():


### PR DESCRIPTION
Closes #3669.



### Summary
Changes the filters to not use __pk__exact.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to the admin
2. enable one of the filters
3. dont get 400
