### PR TITLE
Fix every photo being in the url

### DIFF
--- a/website/photos/static/photos/js/main.js
+++ b/website/photos/static/photos/js/main.js
@@ -72,15 +72,19 @@ Fancybox.Plugins.Toolbar.defaults.items.like = {
 };
 
 
+
+
 Fancybox.bind('[data-fancybox="gallery"]',
     {
+        Hash: false,
+        
         Toolbar: {
             display: [
                 { id: "like", position: "center" },
                 { id: "numLikes", position: "center" },
                 { id: "counter", position: "left" },
                 "slideshow",
-                "fullscreen",
+                "fullscreen",   
                 "download",
                 "thumbs",
                 "close",

--- a/website/photos/static/photos/js/main.js
+++ b/website/photos/static/photos/js/main.js
@@ -71,20 +71,16 @@ Fancybox.Plugins.Toolbar.defaults.items.like = {
     },
 };
 
-
-
-
 Fancybox.bind('[data-fancybox="gallery"]',
     {
         Hash: false,
-        
         Toolbar: {
             display: [
                 { id: "like", position: "center" },
                 { id: "numLikes", position: "center" },
                 { id: "counter", position: "left" },
                 "slideshow",
-                "fullscreen",   
+                "fullscreen",
                 "download",
                 "thumbs",
                 "close",


### PR DESCRIPTION
Closes #3694.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Now you can simply use the back button to go back to albums even when having looked at multiple pictures.


### How to test
<!-- Steps to test the changes you made: -->
1. Go to an album
2. Click on a photo
3. Scroll down to press back button in browser
