### PR TITLE
Handle 400 when archiving an already archived moneybird contact

### DIFF
--- a/website/moneybirdsynchronization/administration.py
+++ b/website/moneybirdsynchronization/administration.py
@@ -56,6 +56,9 @@ class Administration(ABC):
             if description:
                 msg += f": {description}"
 
+            self.status_code = status_code
+            self.description = description
+
             super().__init__(msg)
 
     class Unauthorized(Error):

--- a/website/moneybirdsynchronization/tests/test_services.py
+++ b/website/moneybirdsynchronization/tests/test_services.py
@@ -520,7 +520,7 @@ class ServicesTest(TestCase):
     @mock.patch("moneybirdsynchronization.services.create_or_update_contact")
     @mock.patch(
         "moneybirdsynchronization.services._sync_contacts_with_outdated_mandates"
-    )  # this is to prevent sync_contacts from actaully calling the function, since it is testet in another test
+    )  # Prevent sync_contacts from actaully calling the function, since it is tested separately.
     def test_sync_contacts(
         self,
         mock_sync_contacts_with_outdated_mandates,
@@ -591,4 +591,4 @@ class ServicesTest(TestCase):
 
         self.assertEqual(mock_create_or_update_contact.call_count, 0)
         self.assertEqual(mock_delete_contact.call_count, 1)
-        mock_delete_contact.assert_any_call(self.member)
+        mock_delete_contact.assert_any_call(self.member.moneybird_contact)


### PR DESCRIPTION
Closes #3713.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
This assumes that '400: Contact can not be archived' implies that the contact has already been archived.

