### PR TITLE
3714 Fix not able to order when not allowed

### DIFF
--- a/website/thaliawebsite/templates/admin/base_site.html
+++ b/website/thaliawebsite/templates/admin/base_site.html
@@ -77,7 +77,7 @@
             --thalia-accent-contrast: #000000;
             --accent: var(--thalia-accent);
             --primary: var(--thalia-base);
-            --secondary: var(--thalia-accent);
+            --secondary: var(--thalia-base);
             --link-fg: var(--body-fg);
             --link-hover-color: var(--thalia-dark);
             --link-selected-fg: var(--thalia-base);


### PR DESCRIPTION
Closes #3714.

- bug: something is fixed.

### Summary
Made it so that you are not able to order food when the ordering has not started or the event has ended. Also fixed that you were able to order food to registration required events if you are not registered or are in the queue of the event you are ordering food at.

### How to test
<!-- Steps to test the changes you made: -->
Make a new Food event and set the time to expire in like a minute. Try to order food when the food event has ended if you are back to the index page of pizza, then this is correct. You should not be able to order food when the event has expired. Make a new food event and do not register for the event that requires registration, then try to order food if you are redirected to the index page of pizza, this is correct. You should again not be able to order food. 
