### PR TITLE
Fix check if you are allowed to order food

### DIFF
--- a/website/events/templates/events/event.html
+++ b/website/events/templates/events/event.html
@@ -256,9 +256,17 @@
                                     </th>
                                     <td>
                                     {% if event.food_event == event.food_event.current or event.food_event.just_ended %}
-                                        <a href="{% url "pizzas:index" %}" class="btn btn-primary">
-                                            {% trans "Order" context "pizzas" %}
-                                        </a>
+                                        {% if event.registration_required and not registration.is_invited %}
+                                            <div class="d-inline-block" data-bs-toggle="tooltip" data-placement="auto" title="{% trans 'You do not seem to be registered, which you need to be to order food. '%} {{event.food_event.start}}">
+                                                <a class="btn btn-primary disabled">
+                                                    {% trans "Order" context "pizzas" %}
+                                                </a>
+                                            </div>
+                                        {% else %}
+                                            <a href="{% url "pizzas:index" %}" class="btn btn-primary">
+                                                {% trans "Order" context "pizzas" %}
+                                            </a>
+                                        {% endif %}
                                     {% elif event.food_event.in_the_future %}
                                         <div class="d-inline-block" data-bs-toggle="tooltip" data-placement="auto" title="{% trans 'Ordering pizza for this event will be possible starting '%} {{event.food_event.start}}">
                                             <a class="btn btn-primary disabled">
@@ -300,7 +308,6 @@
             </div>
         </div>
     </section>
-
     {% if event.documents.exists %}
         <section class="page-section" id="events-documents">
             <div class="container">

--- a/website/pizzas/templates/pizzas/index.html
+++ b/website/pizzas/templates/pizzas/index.html
@@ -10,7 +10,7 @@
 {% block opengraph %}
     {% if event %}
         <meta property="og:description"
-              content="{% blocktrans with title=event.title %}Order food for {{ title }}{% endblocktrans %}"/>
+                content="{% blocktrans with title=event.title %}Order food for {{ title }}{% endblocktrans %}"/>
     {% else %}
         <meta property="og:description"
               content="{% trans "There is no current event for which you can order food" %}"/>
@@ -42,7 +42,17 @@
 {% block section_tags %}id="pizzas-index"{% endblock %}
 
 {% block page_content %}
-    {% if event %}
+    {% if event and not_registered or not event %}
+        {% if not event %}
+            <p>
+                {% trans "There are no current events for which you can order food" %}
+            </p>
+        {% else %}
+            <p>
+                {% trans "You are not registered for the current food event" %}
+            </p>
+        {% endif %}
+    {% else %}
         <div class="mb-3 row">
             {% if perms.pizzas.change_product %}
                 <div class="col-12 col-md-4 my-1">
@@ -201,9 +211,5 @@
                 {% endif %}
             {% endif %}
         {% endif %}
-    {% else %}
-        <p>
-            {% trans "There is no current event for which you can order food" %}l
-        </p>
     {% endif %}
 {% endblock %}

--- a/website/pizzas/views.py
+++ b/website/pizzas/views.py
@@ -24,7 +24,27 @@ def index(request):
         obj = FoodOrder.objects.get(food_event=event, member=request.member)
     except FoodOrder.DoesNotExist:
         obj = None
-    context = {"event": event, "products": products, "order": obj}
+
+    registrated_required = (
+        event is not None
+        and event.event is not None
+        and event.event.registration_required
+    )
+    not_registered = False
+    if registrated_required:
+        registration = event.event.registrations.filter(
+            member=request.member, date_cancelled=None
+        ).first()
+
+        if registration is None or not registration.is_invited:
+            not_registered = True
+
+    context = {
+        "event": event,
+        "products": products,
+        "order": obj,
+        "not_registered": not_registered,
+    }
     return render(request, "pizzas/index.html", context)
 
 

--- a/website/pizzas/views.py
+++ b/website/pizzas/views.py
@@ -75,7 +75,7 @@ def place_order(request):
     if not event:
         return redirect("pizzas:index")
 
-    if event.start < timezone.now:
+    if event.start > timezone.now():
         return redirect("pizzas:index")
 
     if event.has_ended:


### PR DESCRIPTION
Closes #3714.

Supersedes #3718 which had a wrong target branch.

### Summary
Made it so that you are not able to order food when the ordering has not started or the event has ended. Also fixed that you were able to order food to registration required events if you are not registered or are in the queue of the event you are ordering food at.

### How to test
<!-- Steps to test the changes you made: -->
Make a new Food event and set the time to expire in like a minute. Try to order food when the food event has ended if you are back to the index page of pizza, then this is correct. You should not be able to order food when the event has expired. Make a new food event and do not register for the event that requires registration, then try to order food if you are redirected to the index page of pizza, this is correct. You should again not be able to order food. 
