### PR TITLE
Fix potentially incorrectly deleting old paid registrations/renewals

### DIFF
--- a/website/registrations/tasks.py
+++ b/website/registrations/tasks.py
@@ -17,22 +17,25 @@ def minimise_registrations():
 
 @shared_task
 def notify_old_entries():
-    # delete entries w updated_at 1 month ago and created_at 3m ago
-    # notify (and update updated_at) entries w updated_at 1 month ago
-
-    Registration.objects.filter(
+    """Delete very old entries and send a reminder to board for less old entries."""
+    Registration.objects.exclude(
+        status__in=(Registration.STATUS_COMPLETED, Registration.STATUS_REJECTED)
+    ).filter(
+        payment=None,
         updated_at__lt=timezone.now() - timedelta(days=30),
         created_at__lt=timezone.now() - timedelta(days=90),
     ).delete()
-    Renewal.objects.filter(
+    Renewal.objects.exclude(
+        status__in=(Renewal.STATUS_COMPLETED, Renewal.STATUS_REJECTED)
+    ).filter(
+        payment=None,
         updated_at__lt=timezone.now() - timedelta(days=30),
         created_at__lt=timezone.now() - timedelta(days=90),
     ).delete()
 
-    for registration in Registration.objects.filter(
-        updated_at__lt=timezone.now() - timedelta(days=30)
-    ):
-        # send email
+    for registration in Registration.objects.exclude(
+        status__in=(Registration.STATUS_COMPLETED, Registration.STATUS_REJECTED)
+    ).filter(payment=None, updated_at__lt=timezone.now() - timedelta(days=30)):
         emails.send_reminder_open_registration(registration)
         registration.updated_at = timezone.now()
         registration.save()


### PR DESCRIPTION
While this should be impossible in practice already, this ensures that no registations/renewals are deleted *outside of dataminimisation* that were actually paid/completed.

This makes it more certain that invoices for paid registrations are not accidentally getting deleted.

This is related to [CONCREXIT-1ER](https://thalia.sentry.io/issues/5500844214/). There, old renewals were deleted by this task, and then their invoices were marked to be deleted from moneybird, even though they should not be. 

The problem was that they should actually have been deleted by dataminimisation, which would _not_ mark the invoices for deletion. This PR changes the task to not touch paid or rejected or completed registrations and renewals, because those should already be handled by dataminimisation.
