### PR TITLE
Always show ribbon

### DIFF
--- a/website/thaliawebsite/static/css/base.scss
+++ b/website/thaliawebsite/static/css/base.scss
@@ -482,10 +482,6 @@ img {
 
 @media(max-width: 991px) {
     .grid-item {
-        .ribbon-wrapper {
-            display: none;
-        }
-
         .name {
             font-size: 13px;
             padding: .8rem;
@@ -507,10 +503,6 @@ img {
 
 @media(max-width: 767px) {
     .grid-item {
-        .ribbon-wrapper {
-            display: none;
-        }
-
         .name {
             font-size: 11px;
             padding: .5rem;


### PR DESCRIPTION
Closes #3727.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Removes the display:none for the chair ribbon on the mobile layouts.

### How to test
<!-- Steps to test the changes you made: -->
1. Use the mobile layout (open on phone, zoom in, use devtools, whatever)
2. Go to board/committee page
3. See that the ribbon is visible

### Issue
It does seem that if the screen is extra small, the ribbon is kind of oversized. I tried looking into fixing this, but it seems to be written using 6-year old CSS using absolute positioning and `px` units.
