### PR TITLE
Revert "Fix PaymentAmountSerializer min_value that was not Decimal"

### DIFF
--- a/website/sales/api/v2/admin/serializers/shift.py
+++ b/website/sales/api/v2/admin/serializers/shift.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 from rest_framework import serializers
 
 from payments.api.v2.serializers.payment_amount import PaymentAmountSerializer
@@ -44,8 +42,8 @@ class ShiftSerializer(serializers.ModelSerializer):
             "product_sales",
         )
 
-    total_revenue = PaymentAmountSerializer(min_value=Decimal(0), read_only=True)
-    total_revenue_paid = PaymentAmountSerializer(min_value=Decimal(0), read_only=True)
+    total_revenue = PaymentAmountSerializer(min_value=0, read_only=True)
+    total_revenue_paid = PaymentAmountSerializer(min_value=0, read_only=True)
 
     products = ProductListItemSerializer(
         source="product_list.product_items", many=True, read_only=True


### PR DESCRIPTION
This reverts commit 17ebc7b78ee6e26b2f07c938c2ffc11521463de4.

It broke API docs, unfortunately.

Closes #3745.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
I'm not sure why the original commit was made, but it seems to have at least this unintended side effect.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
