### PR TITLE
Require boards to have an end date

### DIFF
--- a/website/activemembers/models.py
+++ b/website/activemembers/models.py
@@ -215,6 +215,23 @@ class Board(MemberGroup):
         self.active = True
         super().save(**kwargs)
 
+    def clean(self):
+        if self.since is None:
+            raise ValidationError(
+                {
+                    "since": _("Please insert a starting year for the new board."),
+                }
+            )
+
+        if self.until is None:
+            raise ValidationError(
+                {
+                    "until": _(
+                        "Please insert the year until when the board is active."
+                    ),
+                }
+            )
+
     def get_absolute_url(self):
         return reverse(
             "activemembers:board", args=[str(self.since.year), str(self.until.year)]

--- a/website/activemembers/tests.py
+++ b/website/activemembers/tests.py
@@ -287,8 +287,5 @@ class BoardTest(TestCase):
         b.since = b.since.replace(year=1991, month=9, day=2)
         b.full_clean()
 
-        b.until = None
-        b.full_clean()
-
     def test_get_absolute_url(self):
         self.testboard.get_absolute_url()


### PR DESCRIPTION
Closes #2991.

### Summary
While end dates for board in principle aren't known until the board actually stepped down, that's hard to represent nicely. And it's always possible to change the `until` date later. 

So this just requires them to have one.

### How to test
1. Try to make a board without end date.
