### PR TITLE
Fix current membership is inactive future membership

### DIFF
--- a/website/activemembers/tests.py
+++ b/website/activemembers/tests.py
@@ -180,7 +180,7 @@ class PermissionsBackendTest(TestCase):
         self.u1.latest_membership.until = (
             timezone.now() - timezone.timedelta(days=2)
         ).date()
-        self.u1.save()
+        self.u1.latest_membership.save()
 
         self.assertEqual(set(), self.u1.get_all_permissions())
 

--- a/website/facedetection/api/v2/views.py
+++ b/website/facedetection/api/v2/views.py
@@ -22,7 +22,7 @@ class YourPhotosView(ListAPIView):
     schema = AutoSchema(operation_id_base="FacedetectionMatches")
 
     def get(self, request, *args, **kwargs):
-        if not request.member or request.member.current_membership is None:
+        if not request.member or not request.member.has_active_membership():
             raise PermissionDenied(
                 detail="You need to be a member in order to view your facedetection photos."
             )
@@ -55,7 +55,7 @@ class ReferenceFaceListView(ListCreateAPIView):
         return super().get_serializer(*args, **kwargs)
 
     def create(self, request, *args, **kwargs):
-        if request.member.current_membership is None:
+        if not request.member.has_active_membership():
             raise PermissionDenied(
                 detail="You need to be a member to use this feature."
             )

--- a/website/facedetection/views.py
+++ b/website/facedetection/views.py
@@ -24,7 +24,7 @@ class YourPhotosView(LoginRequiredMixin, PagedView):
     context_object_name = "photos"
 
     def get(self, request, *args, **kwargs):
-        if not request.member or request.member.current_membership is None:
+        if not request.member or not request.member.has_active_membership():
             messages.error(request, _("You need to be a member to use this feature."))
             return redirect("index")
 
@@ -94,7 +94,7 @@ class ReferenceFaceUploadView(LoginRequiredMixin, FormView):
     success_url = reverse_lazy("facedetection:reference-faces")
 
     def dispatch(self, request, *args, **kwargs):
-        if not request.member or request.member.current_membership is None:
+        if not request.member or not request.member.has_active_membership():
             messages.error(request, "You need to be a member to use this feature.")
             return redirect("index")
         return super().dispatch(request, *args, **kwargs)

--- a/website/members/apps.py
+++ b/website/members/apps.py
@@ -62,7 +62,7 @@ class MembersConfig(AppConfig):
             return []
 
         announcements = []
-        if request.member and request.member.current_membership is None:
+        if request.member and not request.member.has_active_membership():
             announcements.append(
                 {"rich_text": render_to_string("members/announcement_not_member.html")}
             )

--- a/website/members/models/member.py
+++ b/website/members/models/member.py
@@ -184,7 +184,7 @@ class Member(User):
 
         return (
             self.profile.event_permissions in ("all", "no_drinks")
-            and self.current_membership is not None
+            and self.has_active_membership()
         )
 
     @property

--- a/website/members/models/member.py
+++ b/website/members/models/member.py
@@ -99,39 +99,47 @@ class Member(User):
         return f"{self.get_full_name()} ({self.username})"
 
     def refresh_from_db(self, **kwargs):
-        # Clear the cached latest_membership
-        if hasattr(self, "_latest_membership"):
-            del self._latest_membership
+        # Clear the cached current- and latest_membership
+        if hasattr(self, "_current_membership"):
+            del self._current_membership
+        if hasattr(self, "current_membership"):
+            del self.current_membership
         if hasattr(self, "latest_membership"):
             del self.latest_membership
 
         return super().refresh_from_db(**kwargs)
 
-    @property
+    @cached_property
     def current_membership(self) -> Membership | None:
         """Return the currently active membership of the user, None if not active.
 
-        Warning: this property uses the *cached* `latest_membership`.
-        You can use `refresh_from_db` to clear it.
-        """
-        membership = self.latest_membership
-        if membership and not membership.is_active():
-            return None
-        return membership
-
-    @cached_property
-    def latest_membership(self) -> Membership | None:
-        """Get the most recent membership of this user.
+        This might not be the latest membership, as a latest membership may be in the future.
 
         Warning: this property is cached.
         You can use `refresh_from_db` to clear it.
         """
         # Use membership from a Prefetch object if available.
-        if hasattr(self, "_latest_membership"):
-            if not self._latest_membership:
+        if hasattr(self, "_current_membership"):
+            if not self._current_membership:
                 return None
-            return self._latest_membership[0]
+            return self._current_membership[0]
 
+        today = timezone.now().date()
+        try:
+            return self.membership_set.filter(
+                Q(until__isnull=True) | Q(until__gt=today),
+                since__lte=today,
+            ).latest("since")
+        except Membership.DoesNotExist:
+            return None
+
+    @cached_property
+    def latest_membership(self) -> Membership | None:
+        """Get the most recent (potentially future) membership of this user.
+
+        Warning: this property is cached.
+        You can use `refresh_from_db` to clear it.
+        """
         if not self.membership_set.exists():
             return None
         return self.membership_set.latest("since")

--- a/website/members/tests/test_models.py
+++ b/website/members/tests/test_models.py
@@ -1,16 +1,9 @@
-import doctest
 from datetime import datetime
 
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from members import models
 from members.models import Member, Profile
-
-
-def load_tests(loader, tests, ignore):
-    """Load doctests."""
-    tests.addTests(doctest.DocTestSuite(models))
 
 
 @override_settings(SUSPEND_SIGNALS=True)

--- a/website/members/tests/test_models.py
+++ b/website/members/tests/test_models.py
@@ -3,7 +3,10 @@ from datetime import datetime
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
+from freezegun import freeze_time
+
 from members.models import Member, Profile
+from members.models.membership import Membership
 
 
 @override_settings(SUSPEND_SIGNALS=True)
@@ -78,6 +81,60 @@ class MemberTest(TestCase):
         m1.type = "honorary"
         m1.save()
         self.assertTrue(member.has_been_honorary_member())
+
+    def test_membership_properties(self):
+        member = Member.objects.get(pk=1)
+        member.membership_set.all().delete()
+
+        old_membership = Membership.objects.create(
+            user=member,
+            since="2022-09-01",
+            until="2023-09-01",
+            type=Membership.MEMBER,
+        )
+        middle_membership = Membership.objects.create(
+            user=member,
+            since="2023-09-01",
+            until="2024-09-01",
+            type=Membership.MEMBER,
+        )
+        latest_membership = Membership.objects.create(
+            user=member,
+            since="2024-09-01",
+            until="2025-09-01",
+            type=Membership.MEMBER,
+        )
+
+        with freeze_time("2022-08-25"):
+            member.refresh_from_db()
+            self.assertFalse(member.has_active_membership())
+            self.assertIsNone(member.current_membership)
+            self.assertEqual(member.latest_membership, latest_membership)
+
+        with freeze_time("2022-09-01"):
+            member.refresh_from_db()
+            self.assertTrue(member.has_active_membership())
+            self.assertEqual(member.current_membership, old_membership)
+            self.assertEqual(member.latest_membership, latest_membership)
+
+        with freeze_time("2024-08-25"):
+            # A membership has been renewed before the end of the current one.
+            member.refresh_from_db()
+            self.assertTrue(member.has_active_membership())
+            self.assertEqual(member.current_membership, middle_membership)
+            self.assertEqual(member.latest_membership, latest_membership)
+
+        with freeze_time("2024-09-01"):
+            member.refresh_from_db()
+            self.assertTrue(member.has_active_membership())
+            self.assertEqual(member.current_membership, latest_membership)
+            self.assertEqual(member.latest_membership, latest_membership)
+
+        with freeze_time("2025-09-01"):
+            member.refresh_from_db()
+            self.assertFalse(member.has_active_membership())
+            self.assertIsNone(member.current_membership)
+            self.assertEqual(member.latest_membership, latest_membership)
 
 
 class MemberDisplayNameTest(TestCase):

--- a/website/photos/services.py
+++ b/website/photos/services.py
@@ -25,9 +25,9 @@ def check_shared_album_token(album, token):
 
 def is_album_accessible(request, album):
     """Check if the request user can access an album."""
-    if request.member and request.member.current_membership is not None:
+    if request.member and request.member.has_active_membership():
         return True
-    if request.member and request.member.current_membership is None:
+    if request.member and not request.member.has_active_membership():
         # This user is currently not a member, so need to check if he/she
         # can view this album by checking the membership
         return request.member.membership_set.filter(
@@ -38,11 +38,11 @@ def is_album_accessible(request, album):
 
 def get_annotated_accessible_albums(request, albums):
     """Annotate the albums which are accessible by the user."""
-    if request.member and request.member.current_membership is not None:
+    if request.member and request.member.has_active_membership():
         albums = albums.annotate(
             accessible=ExpressionWrapper(Value(True), output_field=BooleanField())
         )
-    elif request.member and request.member.current_membership is None:
+    elif request.member and not request.member.has_active_membership():
         albums_filter = Q(pk__in=[])
         for membership in request.member.membership_set.all():
             albums_filter |= Q(date__gte=membership.since) & Q(

--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, timedelta
 
 from django import forms
 from django.conf import settings
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 
 from members.models import Membership
 from payments.widgets import SignatureWidget
-from registrations import services
+from utils.snippets import datetime_to_lectureyear
 
 from .models import Reference, Registration, Renewal
 
@@ -256,10 +256,15 @@ class ReferenceForm(forms.ModelForm):
             raise ValidationError(_("Benefactors cannot give references."))
 
         membership = self.cleaned_data["member"].latest_membership
+        today = timezone.now().date()
+        lecture_year = datetime_to_lectureyear(today)
+        if today.month == 8:
+            lecture_year += 1
+
         if (
             membership
             and membership.until
-            and membership.until < services.calculate_membership_since()
+            and membership.until <= date(lecture_year, 9, 1)
         ):
             raise ValidationError(
                 "It's not possible to give references for memberships "

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -247,43 +247,36 @@ def complete_renewal(renewal: Renewal):
     member: Member = renewal.member
     member.refresh_from_db()
 
-    since = calculate_membership_since()
+    since = timezone.now().date()
     lecture_year = datetime_to_lectureyear(since)
+    if since.month == 8:
+        lecture_year += 1
 
     latest_membership = member.latest_membership
-    # Not that currently, Member. current_membership can be a future membership if a new
-    # membership has been created but it's not yet september. This does not matter here,
-    # but it is kind of incorrect.
     current_membership = member.current_membership
+    if current_membership is not None and current_membership.until is None:
+        raise ValueError("This member already has a never ending membership")
 
     with transaction.atomic():
         if renewal.length == Entry.MEMBERSHIP_STUDY:
             # Handle the 'membership upgrade' case.
-            if latest_membership is not None:  # pragma: no cover
-                if latest_membership.until is None:
-                    raise ValueError(
-                        "This member already has a never ending membership"
-                    )
-
-                if renewal.created_at.date() < latest_membership.until:
-                    # If a membership exists that was still valid when the renewal was created, the
-                    # original membership can be upgraded. This is defined in the Huishoudelijk
-                    # Reglement (article 2.8 in the version of 2022-07-22).
-                    latest_membership.until = None
-                    latest_membership.save()
-                    renewal.membership = latest_membership
-
-            # Handle the 'normal' non-(discounted)-upgrade case.
-            if renewal.membership is None:
+            if (
+                latest_membership
+                and renewal.created_at.date() < latest_membership.until
+            ):
+                # If a membership exists that was still valid when the renewal was created, the
+                # original membership can be upgraded. This is defined in the Huishoudelijk
+                # Reglement (article 2.8 in the version of 2022-07-22).
+                latest_membership.until = None
+                latest_membership.save()
+                renewal.membership = latest_membership
+            else:
+                # Handle the 'normal' non-(discounted)-upgrade case.
                 renewal.membership = Membership.objects.create(
                     type=renewal.membership_type, user=member, since=since, until=None
                 )
         else:
-            if current_membership is not None:
-                if current_membership.until is None:
-                    raise ValueError(
-                        "This member already has a never ending membership"
-                    )
+            if current_membership:
                 since = current_membership.until
 
             until = timezone.datetime(year=lecture_year + 1, month=9, day=1).date()
@@ -378,12 +371,14 @@ def _create_membership_from_registration(
     registration: Registration, member: Member
 ) -> Membership:
     """Create a membership from a Registration."""
-    since = calculate_membership_since()
-    lecture_year = datetime_to_lectureyear(since)
-
-    if registration.membership_type == Membership.BENEFACTOR:
-        until = timezone.datetime(year=lecture_year + 1, month=9, day=1).date()
-    elif registration.length == Registration.MEMBERSHIP_YEAR:
+    since = timezone.now().date()
+    if registration.length == Registration.MEMBERSHIP_YEAR:
+        lecture_year = datetime_to_lectureyear(since)
+        if since.month == 8:
+            # Memberships created in august are for the next lecture year,
+            # but can start already in august. This allows first year students
+            # to use their membership already in the introduction week.
+            lecture_year += 1
         until = timezone.datetime(year=lecture_year + 1, month=9, day=1).date()
     else:
         until = None

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -290,18 +290,6 @@ def complete_renewal(renewal: Renewal):
     emails.send_renewal_complete_message(renewal)
 
 
-def calculate_membership_since() -> timezone.datetime:
-    """Calculate the start date of a membership.
-
-    If it's August we act as if it's the next lecture year
-    already and we start new memberships in September.
-    """
-    since = timezone.now().date()
-    if timezone.now().month == 8:
-        since = since.replace(month=9, day=1)
-    return since
-
-
 _PASSWORD_CHARS = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 
 

--- a/website/registrations/tests/test_forms.py
+++ b/website/registrations/tests/test_forms.py
@@ -338,7 +338,6 @@ class ReferenceFormTest(TestCase):
         self.entry = Renewal.objects.create(
             member=self.member, length=Entry.MEMBERSHIP_YEAR
         )
-        self.member.membership_set.all().delete()
         self.data = {"member": self.member.pk, "entry": self.entry.pk}
 
     @freeze_time("2018-08-01")
@@ -379,6 +378,17 @@ class ReferenceFormTest(TestCase):
                 },
             )
             m.delete()
+        with self.subTest("Form is valid with membership for current year"):
+            with freeze_time("2018-09-01"):
+                m = Membership.objects.create(
+                    type=Membership.MEMBER,
+                    user=self.member,
+                    since="2018-09-01",
+                    until="2019-08-31",
+                )
+                form = forms.ReferenceForm(self.data)
+                self.assertTrue(form.is_valid())
+                m.delete()
         with self.subTest("Form throws error about uniqueness"):
             Reference.objects.create(member=self.member, entry=self.entry)
             form = forms.ReferenceForm(self.data)

--- a/website/registrations/tests/test_services.py
+++ b/website/registrations/tests/test_services.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.core import mail
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -43,7 +45,7 @@ class ServicesTest(TestCase):
             address_city="Nijmegen",
             address_country="NL",
             phone_number="06123456789",
-            birthday=timezone.now().replace(year=1990, day=1).date(),
+            birthday="1990-01-01",
             length=Entry.MEMBERSHIP_YEAR,
             contribution=7.5,
             membership_type=Membership.MEMBER,
@@ -64,7 +66,7 @@ class ServicesTest(TestCase):
             address_city="Nijmegen",
             address_country="NL",
             phone_number="06123456789",
-            birthday=timezone.now().replace(year=1990, day=1).date(),
+            birthday="1990-01-01",
             length=Entry.MEMBERSHIP_YEAR,
             contribution=7.5,
             membership_type=Membership.BENEFACTOR,
@@ -85,7 +87,7 @@ class ServicesTest(TestCase):
             address_city="Nijmegen",
             address_country="NL",
             phone_number="06123456789",
-            birthday=timezone.now().replace(year=1990, day=1).date(),
+            birthday="1990-01-01",
             length=Entry.MEMBERSHIP_STUDY,
             contribution=30,
             membership_type=Membership.MEMBER,
@@ -270,14 +272,15 @@ class ServicesTest(TestCase):
             self.assertEqual(member.first_name, "John")
             self.assertEqual(member.last_name, "Doe")
             self.assertEqual(member.username, "jdoe")
-            self.assertEqual(
-                membership.since,
-                timezone.now().replace(year=2023, month=9, day=1).date(),
-            )
-            self.assertEqual(
-                membership.until,
-                timezone.now().replace(year=2024, month=9, day=1).date(),
-            )
+
+            # Membership starts on the day the registration is completed,
+            # even though this is before the start of the year (2023-09-01).
+            # This makes it possible for first-year students to become a member during
+            # the introduction week without having to wait for another week to actually
+            # be a member and use the website.
+            self.assertEqual(membership.since, date(2023, 8, 28))
+
+            self.assertEqual(membership.until, date(2024, 9, 1))
             self.assertEqual(membership.type, Membership.MEMBER)
             self.assertFalse(member.bank_accounts.all().exists())
 
@@ -443,14 +446,8 @@ class ServicesTest(TestCase):
             self.assertIsNotNone(membership)
             self.assertEqual(self.member.membership_set.all().count(), 2)
 
-            self.assertEqual(
-                membership.since,
-                timezone.now().replace(year=2023, month=9, day=1).date(),
-            )
-            self.assertEqual(
-                membership.until,
-                timezone.now().replace(year=2024, month=9, day=1).date(),
-            )
+            self.assertEqual(membership.since, date(2023, 9, 1))
+            self.assertEqual(membership.until, date(2024, 9, 1))
 
         # Restore data.
         with freeze_time("2023-08-25"):
@@ -475,14 +472,8 @@ class ServicesTest(TestCase):
             membership = self.renewal.membership
             self.assertIsNotNone(membership)
 
-            self.assertEqual(
-                membership.since,
-                timezone.now().replace(year=2023, month=9, day=10).date(),
-            )
-            self.assertEqual(
-                membership.until,
-                timezone.now().replace(year=2024, month=9, day=1).date(),
-            )
+            self.assertEqual(membership.since, date(2023, 9, 10))
+            self.assertEqual(membership.until, date(2024, 9, 1))
 
         # Restore data.
         with freeze_time("2023-08-25"):
@@ -611,18 +602,15 @@ class ServicesTest(TestCase):
             with self.subTest("Complete benefactor renewal."):
                 create_payment(self.renewal, self.admin, Payment.CASH)
 
-                self.renewal.refresh_from_db()
-                self.assertEqual(self.renewal.status, Entry.STATUS_COMPLETED)
-                membership = self.renewal.membership
-                self.assertIsNotNone(membership)
-                self.assertNotEqual(self.membership.pk, membership.pk)
+            self.renewal.refresh_from_db()
+            self.assertEqual(self.renewal.status, Entry.STATUS_COMPLETED)
+            membership = self.renewal.membership
+            self.assertIsNotNone(membership)
+            self.assertNotEqual(self.membership.pk, membership.pk)
 
-                self.assertEqual(membership.since, timezone.now().date())
-                self.assertEqual(
-                    membership.until,
-                    timezone.now().replace(year=2024, month=9, day=1).date(),
-                )
-                self.assertEqual(membership.type, Membership.BENEFACTOR)
+            self.assertEqual(membership.since, date(2023, 9, 10))
+            self.assertEqual(membership.until, date(2024, 9, 1))
+            self.assertEqual(membership.type, Membership.BENEFACTOR)
 
     def test_data_minimisation(self):
         with freeze_time("2025-01-01"):

--- a/website/registrations/tests/test_services.py
+++ b/website/registrations/tests/test_services.py
@@ -355,6 +355,23 @@ class ServicesTest(TestCase):
                 "[THALIA] Welcome to Study Association Thalia",
             )
 
+    def test_complete_registration_after_start_of_year(self):
+        self.member_registration.status = Entry.STATUS_ACCEPTED
+        self.member_registration.save()
+
+        # Signal triggers call to complete_registration.
+        with freeze_time("2023-09-10"):
+            create_payment(self.member_registration, self.admin, Payment.CASH)
+
+        self.member_registration.refresh_from_db()
+        self.assertEqual(self.member_registration.status, Entry.STATUS_COMPLETED)
+        membership = self.member_registration.membership
+        self.assertIsNotNone(membership)
+
+        # Membership starts on the day the registration is completed.
+        self.assertEqual(membership.since, date(2023, 9, 10))
+        self.assertEqual(membership.until, date(2024, 9, 1))
+
     def test_accept_renewal(self):
         services.accept_renewal(self.renewal, actor=self.admin)
 


### PR DESCRIPTION
Closes #3776.


### Summary
Before this, two things were done in an ugly/inaccurate way:

1. `Member.current_membership` returned the _latest_ membership, even if it hadn't begun yet.
2. Memberships created in august started on the 1st of september (so technically, sjaars were no members during intro).

But before 0f6488a2ed2973ce3ae8d2446f48359a88d3c7cf, we did not check for the `membership.since` date when checking if a membership is active. This meant that the above 2 things together gave the expected behaviour. So adding that check broke the expected but hacky behaviour.

In this PR, I got rid of both weird things. Memberships normally start at the date they're completed (typically i.e. paid). For memberships completed in august, that means that the last few days/weeks of august are given 'for free' as they were before, but just also stored that way. And the `current_membership` property and friends now do what one would expect: return only _current_ memberships.

### How to test
<!-- Steps to test the changes you made: -->
1. At least simulate introduction registrations as they will happen in a few days.
