### PR TITLE
Handle sending moneybird sync error with any object

### DIFF
--- a/website/moneybirdsynchronization/emails.py
+++ b/website/moneybirdsynchronization/emails.py
@@ -2,6 +2,7 @@
 import logging
 
 from django.conf import settings
+from django.db.models import Model
 from django.urls import reverse
 
 from utils.snippets import send_email
@@ -18,10 +19,14 @@ def send_sync_error(error, obj):
         context={
             "error": error,
             "obj": obj,
-            "url": settings.BASE_URL
-            + reverse(
-                f"admin:{obj._meta.app_label}_{obj._meta.model_name}_change",
-                args=(obj.pk,),
-            ),
+            "url": (
+                settings.BASE_URL
+                + reverse(
+                    f"admin:{obj._meta.app_label}_{obj._meta.model_name}_change",
+                    args=(obj.pk,),
+                )
+            )
+            if isinstance(obj, Model)
+            else None,
         },
     )


### PR DESCRIPTION
This solves an issue where an exception was raised during handling of another catchable exception. Should make the synchronization more robust if anything weird happens, rather than crashing it.

Closes https://thalia.sentry.io/issues/5732597819/.

