### PR TITLE
Validate that BIC is required for foreign bank account at registration

### DIFF
--- a/website/registrations/models.py
+++ b/website/registrations/models.py
@@ -451,31 +451,22 @@ class Registration(Entry):
 
         if self.direct_debit:
             if not self.iban:
-                errors.update(
-                    {
-                        "iban": _(
-                            "This field is required to add a bank account mandate for Thalia Pay."
-                        )
-                    }
+                errors["iban"] = _(
+                    "This field is required to add a bank account mandate for Thalia Pay."
                 )
 
             if not self.initials:
-                errors.update(
-                    {
-                        "initials": _(
-                            "This field is required to add a bank account mandate for Thalia Pay."
-                        )
-                    }
+                errors["initials"] = _(
+                    "This field is required to add a bank account mandate for Thalia Pay."
                 )
 
             if not self.signature:
-                errors.update(
-                    {
-                        "signature": _(
-                            "This field is required to add a bank account mandate for Thalia Pay."
-                        )
-                    }
+                errors["signature"] = _(
+                    "This field is required to add a bank account mandate for Thalia Pay."
                 )
+
+            if self.iban and self.iban[0:2] != "NL" and not self.bic:
+                errors["bic"] = _("This field is required for foreign bank accounts.")
 
         if errors:
             raise ValidationError(errors)

--- a/website/registrations/tests/test_models.py
+++ b/website/registrations/tests/test_models.py
@@ -267,7 +267,7 @@ class RegistrationTest(TestCase):
         with self.assertRaises(ValidationError):
             self.registration.clean()
 
-        self.registration.iban = "NL91ABNA0417164300"
+        self.registration.iban = "BE91ABNA0417164300"
 
         with self.assertRaises(ValidationError):
             self.registration.clean()
@@ -278,6 +278,11 @@ class RegistrationTest(TestCase):
             self.registration.clean()
 
         self.registration.signature = "base64,png"
+
+        with self.assertRaises(ValidationError):
+            self.registration.clean()
+
+        self.registration.bic = "ADSGBEBZ"
 
         self.registration.clean()
 
@@ -381,6 +386,13 @@ class RegistrationTest(TestCase):
         registration.username = "unique_username"
 
         self.assertEqual(registration.check_user_is_unique(), True)
+
+    def test_foreign_bankaccount_without_bic(self):
+        self.registration.initials = "J"
+        self.registration.signature = "base64,png"
+        self.registration.iban = "XX91ABNA0123456789"
+        self.registration.bic = ""
+        self.registration.clean()
 
 
 @override_settings(SUSPEND_SIGNALS=True)


### PR DESCRIPTION
Mitigates https://thalia.sentry.io/issues/5736947915/.

### Summary
Adds validation that is present on BankAccount but was missing in Registration.
