### PR TITLE
Fix crash processing tpay payment on unclaimed sales order

### DIFF
--- a/website/payments/views.py
+++ b/website/payments/views.py
@@ -204,7 +204,7 @@ class PaymentProcessView(SuccessMessageMixin, FormView):
         return context
 
     def _check_payment_allowed(self, request, payable_hash):
-        if (
+        if not self.payable.payment_payer or (
             self.payable.payment_payer.pk
             != PaymentUser.objects.get(pk=self.request.member.pk).pk
         ):


### PR DESCRIPTION
Closes https://thalia.sentry.io/issues/5731331792/.

The call that caused this crash seems to have gone like this:

1. Create a sales order. Keep it's admin changeview open.  
2. Open the paying page on the site, but don't pay it yet.
3. Save the open admin changeview (where the payer wasn't filled in yet), which clears the payer that was just set in (2).
4. Pay on the paying page and get the 500. 