### PR TITLE
Fix buggy TinyMCE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       - dependency-name: "black"
       - dependency-name: "isort"
       - dependency-name: "ruff"
+      # This dependency doesn't have the most consistent versioning,
+      # and when updating it, we need to update the settings for cache busting.
+      - dependency-name: "django-tinymce"
     labels:
       - "dependency-update"
 

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -1101,7 +1101,7 @@ THUMBNAIL_SIZES = set(THUMBNAILS["SIZES"].keys())
 TINYMCE_DEFAULT_CONFIG = {
     "max_height": 500,
     "menubar": False,
-    "plugins": "autolink autoresize link image code media paste lists",
+    "plugins": "autolink autoresize link image code media lists",
     "toolbar": "h2 h3 | bold italic underline strikethrough | image media | link unlink "
     "| bullist numlist | undo redo | code",
     "contextmenu": "bold italic underline strikethrough | link",
@@ -1109,6 +1109,10 @@ TINYMCE_DEFAULT_CONFIG = {
     "relative_urls": False,
     "remove_script_host": False,
     "autoresize_bottom_margin": 50,
+    # Suffix for cache busting, because tinymce.min.js does not refer to the other
+    # files it loads with their hashed filenames. Change this when updating TinyMCE,
+    # to make sure everyone gets the correct version, and not a cached old one.
+    "cache_suffix": "?v=6.8.4",
 }
 TINYMCE_EXTRA_MEDIA = {
     "css": {


### PR DESCRIPTION

### Summary
Solves a problem where tinymce was loading the removed 'paste' plugin that was still stored/cached.
This caused cutting/copying/pasting to be buggy. This also adds a cache-busting suffix as a mitigation
for tinyMCEs lack of support for using hashed filenames. See e.g. https://github.com/jazzband/django-tinymce/issues/266. This number should be updated whenever the tinymce version changes.

