### PR TITLE
Fix album processed email warnings

### DIFF
--- a/website/photos/services.py
+++ b/website/photos/services.py
@@ -71,6 +71,8 @@ def extract_archive(album, archive) -> tuple[dict[str, str], int]:
         archive.seek(0)
         with ZipFile(archive) as zip_file:
             for photo in sorted(zip_file.namelist()):
+                if zip_file.getinfo(photo).is_dir():
+                    continue
                 if not _has_photo_extension(photo):
                     warnings[photo] = "has an unknown extension."
                     continue
@@ -87,6 +89,9 @@ def extract_archive(album, archive) -> tuple[dict[str, str], int]:
     try:
         with tarfile.open(fileobj=archive) as tar_file:
             for photo in sorted(tar_file.getnames()):
+                if not tar_file.getmember(photo).isfile():
+                    continue
+
                 if not _has_photo_extension(photo):
                     warnings[photo] = "has an unknown extension."
                     continue

--- a/website/photos/tasks.py
+++ b/website/photos/tasks.py
@@ -41,24 +41,24 @@ def process_album_upload(
             album.is_processing = False
             album.save()
 
-            # Send signal to notify that an album has been uploaded. This is used
-            # by facedetection, and possibly in the future to notify the uploader.
-            album_uploaded.send(sender=None, album=album)
+        # Send signal to notify that an album has been uploaded. This is used
+        # by facedetection, and possibly in the future to notify the uploader.
+        album_uploaded.send(sender=None, album=album)
 
-            if uploader is not None:
-                # Notify uploader of the upload result.
-                send_email(
-                    to=get_member_email_addresses(uploader),
-                    subject=("Album upload processed completed."),
-                    txt_template="photos/email/upload-processed.txt",
-                    context={
-                        "name": uploader.first_name,
-                        "album": album,
-                        "upload_name": upload.file.name,
-                        "warnings": warnings,
-                        "num_processed": count,
-                    },
-                )
+        if uploader is not None:
+            # Notify uploader of the upload result.
+            send_email(
+                to=get_member_email_addresses(uploader),
+                subject=("Album upload processed completed."),
+                txt_template="photos/email/upload-processed.txt",
+                context={
+                    "name": uploader.first_name,
+                    "album": album,
+                    "upload_name": upload.file.name,
+                    "warnings": warnings,
+                    "num_processed": count,
+                },
+            )
     except Exception as e:
         logger.exception(f"Failed to process album upload: {e}", exc_info=e)
 

--- a/website/photos/templates/photos/email/upload-processed.txt
+++ b/website/photos/templates/photos/email/upload-processed.txt
@@ -5,7 +5,7 @@ You can see it here: {% url "photos:album" album.slug %}
 
 {{ num_processed }} photos were successfully processed.
 {% if warnings %}
-The following warnings occurred while processing the upload:{% for file, warning in warnings%}
+The following warnings occurred while processing the upload:{% for file, warning in warnings.items %}
 {{ file }}: {{ warning }}
 {% endfor %}{% else %}
 There were no issues while processing the upload.</p>


### PR DESCRIPTION
This prevents warning about directories existing in the uploaded archive, and fixes  crash because of a bug in the email template.

Closes [CONCREXIT-1GZ](https://thalia.sentry.io/issues/5810557399/).

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary

- Ignores directories inside the upload (these are zipinfo/tarinfo objects that only indicate directories existing, regardless of their content).
- Fixes the template to loop over warnings correctly (which makes it possible to send warnings now instead of crash)
- Reorganizes the email and uploaded signal to outside of the transaction, so crashing during the email or while doing facedetection does not cancel the saving of the album.

### How to test
<!-- Steps to test the changes you made: -->
1. Upload an album with some non-photos in it as well as a directory.
2. See an email being sent (to your console if you do it locally) with warnings about the non-photos, and not about the directory.
