### PR TITLE
Fix to show the earliest member since in profile

### DIFF
--- a/website/members/templates/members/user/profile.html
+++ b/website/members/templates/members/user/profile.html
@@ -37,7 +37,7 @@
             <h4>{% trans "Personal information" %}</h4>
             <ul class="list-unstyled">
                 <li>
-                    <strong>{% trans "Membership type" %}: </strong> {{ membership_type }} (since {{ member.latest_membership.since }})<br>
+                    <strong>{% trans "Membership type" %}: </strong> {{ membership_type }} (since {{ member.earliest_membership.since }})<br>
                 </li>
 
                 {% if member.profile.starting_year %}


### PR DESCRIPTION
Closes #1929.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Makes it so that the earliest membership since is shown instead of the latest.


### How to test
<!-- Steps to test the changes you made: -->
1. Make a member
2. check public profile
