### PR TITLE
Add inline for group memberships (active member)

### DIFF
--- a/website/members/admin.py
+++ b/website/members/admin.py
@@ -1,4 +1,5 @@
 """Register admin pages for the models."""
+
 import csv
 import datetime
 
@@ -10,10 +11,26 @@ from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from activemembers.models import MemberGroupMembership
 from members import services
 from members.models import EmailChange, Member
 
 from . import forms, models
+
+
+class ActiveMemberInline(admin.TabularInline):
+    model = MemberGroupMembership
+    classes = ["collapse"]
+    extra = 0
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 class MembershipInline(admin.StackedInline):
@@ -148,6 +165,7 @@ class UserAdmin(BaseUserAdmin):
     inlines = (
         ProfileInline,
         MembershipInline,
+        ActiveMemberInline,
     )
     list_filter = (
         MembershipTypeListFilter,


### PR DESCRIPTION
Closes #3436 

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Adds an inline that shows group memberships:
![image](https://github.com/user-attachments/assets/13e6d715-4ba8-4b4e-aa44-4fa1c82654d8)
It is also read-only as requested.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to a user admin
2. See that all group memberships are shown correctly.
