### PR TITLE
Add spinner to hide error message when loading calendar

### DIFF
--- a/website/events/static/events/js/main.js
+++ b/website/events/static/events/js/main.js
@@ -58,6 +58,7 @@ function strip(html){
 document.addEventListener('DOMContentLoaded', function () {
     let lastKnownWidth = window.innerWidth;
     const calendarEl = document.getElementById('calendar');
+    const spinnerEl = document.getElementById('calendar-spinner');
 
     const showUnpublished = calendarEl.dataset.showUnpublished === 'true';
     let defaultDate = calendarEl.dataset.defaultDate;
@@ -162,6 +163,15 @@ document.addEventListener('DOMContentLoaded', function () {
                 } else {
                     checkViewState(calendar);
                 }
+            }
+        },
+        loading: function (isLoading) {
+            if (isLoading) {
+                calendarEl.hidden = true;
+                spinnerEl.hidden = false;
+            } else {
+                calendarEl.hidden = false;
+                spinnerEl.hidden = true;
             }
         }
     });

--- a/website/events/templates/events/index.html
+++ b/website/events/templates/events/index.html
@@ -40,6 +40,9 @@
 {% block section_tags %}id="events-index"{% endblock %}
 
 {% block page_content %}
+    <div class="spinner-border" role="status" id="calendar-spinner" hidden>
+        <span class="sr-only">Loading...</span>
+    </div>
     <div id="calendar" data-default-date="{% spaceless %}
             {% if upcoming_activity %}
                 {{ upcoming_activity.start|date:'Y-m-d' }}


### PR DESCRIPTION
Closes #2223.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Adds a spinner to events instead of "No events" message

### How to test
<!-- Steps to test the changes you made: -->
0. (Maybe slow down the internet speed in devtools)
1. Open events page
2. See that there is a spinner instead of the "No events" message.
