### PR TITLE
Add info page for iCal feed

### DIFF
--- a/website/events/templates/events/index.html
+++ b/website/events/templates/events/index.html
@@ -1,5 +1,5 @@
 {% extends "simple_page.html" %}
-{% load i18n static personal_feed %}}
+{% load i18n static %}
 {% get_current_language as LANGUAGE_CODE %}
 
 {% block title %}{% trans "Calendar"|capfirst %} —
@@ -16,26 +16,11 @@
 
 {% block page_title %}
     {% trans "Calendar" %}
-    <a href="{% url 'events:ical-'|add:LANGUAGE_CODE %}"
-       target="_blank"
+    <a href="{% url 'events:synchronize' %}"
        class="btn btn-primary first-right"
-       data-bs-toggle="tooltip"
-       data-bs-placement="top"
-       title="{% trans 'iCal feed (all events)' %}"
     >
-        <i class="fas fa-calendar-alt"></i>
+        <i class="fas fa-calendar-alt"></i> Synchronize calendar
     </a>
-    {% if request.user.is_authenticated %}
-        <a href="{% url 'events:ical-'|add:LANGUAGE_CODE %}?u={% personal_feed %}"
-           target="_blank"
-           data-bs-toggle="tooltip"
-           data-bs-placement="top"
-           class="btn btn-primary"
-           title="{% trans 'iCal feed (personal)' %}"
-        >
-            <i class="fas fa-calendar-check"></i>
-        </a>
-    {% endif %}
 {% endblock %}
 {% block section_tags %}id="events-index"{% endblock %}
 

--- a/website/events/templates/events/synchronize.html
+++ b/website/events/templates/events/synchronize.html
@@ -1,0 +1,73 @@
+{% extends "simple_page.html" %}
+{% load i18n static personal_feed %}
+{% get_current_language as LANGUAGE_CODE %}
+
+
+{% block title %}{% trans "Calendar synchronization"|capfirst %} —
+    {{ block.super }}{% endblock %}
+{% block opengraph_title %}{% trans "Calendar synchronization"|capfirst %} —
+    {{ block.super }}{% endblock %}
+
+{% block page_title %}
+{% trans "Calendar synchronization" %}
+{% endblock %}
+
+{% block page_content %}
+<p>
+    Our website exports an iCalendar feed, which enables you to import the event list into your own calendar! This does however require some setup.
+</p>
+
+<p>
+    To begin, in your calendar application find the button to add an (iCal) calendar via its URL. For example, in Google Calendar, this is "Other calendars" and then "Via URL". In the macOS Calendar the option is under the "File" menu and called "New calendar subscription".
+</p>
+
+<p>
+    Then, paste in the URL of the calendar variant you want. There are two versions, one with all events and one with only the events you are registered for.
+</p>
+
+<p>
+    <div class="input-group">
+        <button class="btn btn-primary btn-lg"><i class="fas fa-calendar-alt"></i> All events</button>
+        <input type="text" class="form-control" value="{% url 'events:ical-'|add:LANGUAGE_CODE %}" id="all-event" readonly>
+        <button
+            onclick="copyLink('all-event')"
+            type="button" class="btn btn-primary btn-lg">
+                <i class="fas fa-copy"></i> Copy to clipboard
+        </button>
+    </div>
+</p>
+
+{% if request.user.is_authenticated %}
+<p>
+    <div class="input-group">
+        <button class="btn btn-primary btn-lg"><i class="fas fa-calendar-check"></i> Personalised</button>
+        <input type="text" class="form-control" value="{% url 'events:ical-'|add:LANGUAGE_CODE %}?u={% personal_feed %}" id="personalised">
+        <button
+            onclick="copyLink('personalised')"
+            type="button" class="btn btn-primary btn-lg">
+            <i class="fas fa-copy"></i>Copy to clipboard
+        </button>
+    </div>
+</p>
+{% else %}
+<p>
+    <div class="input-group">
+        <button class="btn btn-primary btn-lg"> <i class="fas fa-calendar-check"></i> Personalised</button>
+    <a href="{% url 'login' %}" class="btn btn-primary"> Log in for personalised feed </a>
+    </div>
+</p>
+{% endif %}
+
+<p>
+    After this, you should be done! The events should now appear in your calendar.
+</p>
+{% endblock %}
+
+{% block js_body %}
+    {{ block.super }}
+    <script type="text/javascript">
+        function copyLink(el) {
+            navigator.clipboard.writeText(document.getElementById(el).value)
+        }
+    </script>
+{% endblock js_body %}

--- a/website/events/urls.py
+++ b/website/events/urls.py
@@ -1,5 +1,6 @@
 """Routes defined by the events package."""
 from django.urls import include, path
+from django.views.generic import TemplateView
 
 from events.feeds import EventFeed
 from events.views import (
@@ -22,6 +23,11 @@ urlpatterns = [
             [
                 path("<int:pk>/", EventDetail.as_view(), name="event"),
                 path("next/", NextEventView.as_view(), name="next"),
+                path(
+                    "sync/",
+                    TemplateView.as_view(template_name="events/synchronize.html"),
+                    name="synchronize",
+                ),
                 path("<slug:slug>/", EventDetail.as_view(), name="event"),
                 path(
                     "<int:pk>/registration/register/",


### PR DESCRIPTION
Closes #3812.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Adds an information page for the iCal feed, instead of the obscure buttons on the main events page.

Note: styling is currently still horrendous!

### How to test
<!-- Steps to test the changes you made: -->
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
