### PR TITLE
Fix invoice date for Registration and Renewal in Moneybird synchronization

### DIFF
--- a/website/moneybirdsynchronization/models.py
+++ b/website/moneybirdsynchronization/models.py
@@ -52,7 +52,9 @@ def date_for_payable_model(obj) -> datetime.datetime | datetime.date:
     if isinstance(obj, Order):
         return obj.shift.start
     if isinstance(obj, Registration | Renewal):
-        return obj.created_at.date()
+        # Registrations and Renewals are only pushed to Moneybird
+        # once they've been paid,, so a obj.payment always exists.
+        return obj.payment.created_at.date()
 
     raise ValueError(f"Unknown payable model {obj}")
 


### PR DESCRIPTION
Closes [CONCREXIT-1HE](https://thalia.sentry.io/issues/5839711534/).

Invoices were being pushed in september/october after locking the previous bookkeeping year, with invoice dates before sept 1, because registrations and renewals created before sept 1 had not been paid yet back then. To prevent this, we can just make them with the payment date as invoice date.

Oh and I tried doing this in a new copilot beta thing called Copilot Workspace. It didn't really do much for such a small change to fix a very specific issue. You can see what it did below, but it took quite some corrections and I gave it pretty specific instructions to start.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/svthalia/concrexit?shareId=bd67c9db-f8b2-406b-9340-567b18803e86).