### PR TITLE
Improve ical discoverability

### DIFF
--- a/website/events/templates/events/ical_help.html
+++ b/website/events/templates/events/ical_help.html
@@ -1,0 +1,31 @@
+{% extends "simple_page.html" %}
+{% block page_title %}iCal feed instructions{% endblock %}
+
+{% block page_content %}
+    <p>This page provides information on how to use an iCal feed to stay updated with Thalia events.</p>
+    <h3>What is an iCal feed?</h3>
+    <p>
+        An iCal feed is a calendar format that allows you to subscribe to events and have them automatically appear in your calendar application.
+        We offer two different feeds: one with all Thalia events, and one that is personalized for you, with only the events that you've registered for.
+    </p>
+    <h3>How to subscribe to an iCal feed</h3>
+    <p>To subscribe to an iCal feed, follow these steps:</p>
+    <ol>
+        <li>Copy the iCal feed URL from below.</li>
+        <li>Open your calendar application (e.g., Google Calendar, Apple Calendar, Outlook).</li>
+        <li>Find the option to add a new calendar subscription by URL.</li>
+        <li>Paste the iCal feed URL into the provided field.</li>
+        <li>Save the new calendar.</li>
+    </ol>
+    <p>In some cases, simply opening the URL may navigate to your calendar application too.
+    <h3>iCal feed URLs</h3>
+    <p>There are two iCal feed URLs available:</p>
+    <ul>
+        <li>All events: <a href="{{ all_events_feed }}">{{ all_events_feed }}</a></li>
+        {% if user.is_authenticated %}
+            <li>Personal feed: <a href="{{ personal_feed }}">{{ personal_feed }}</a></li>
+        {% else %}
+            <li>Personal feed: <a href="{% url 'login' %}?next={% url 'events:ical-help' %}">Log in to access your personal iCal feed</a></li>
+        {% endif %}
+    </ul>
+{% endblock %}

--- a/website/events/templates/events/ical_help.html
+++ b/website/events/templates/events/ical_help.html
@@ -13,7 +13,11 @@
     <ol>
         <li>Copy the iCal feed URL from below.</li>
         <li>Open your calendar application (e.g., Google Calendar, Apple Calendar, Outlook).</li>
-        <li>Find the option to add a new calendar subscription by URL.</li>
+        <li>
+            In your calendar application find the button to add an (iCal) calendar via its URL.
+            For example, in Google Calendar, this is "Other calendars" and then "Via URL".
+            In the macOS Calendar the option is under the "File" menu and called "New calendar subscription".
+        </li>
         <li>Paste the iCal feed URL into the provided field.</li>
         <li>Save the new calendar.</li>
     </ol>

--- a/website/events/templates/events/ical_help.html
+++ b/website/events/templates/events/ical_help.html
@@ -16,12 +16,11 @@
         <li>
             In your calendar application find the button to add an (iCal) calendar via its URL.
             For example, in Google Calendar, this is "Other calendars" and then "Via URL".
-            In the macOS Calendar the option is under the "File" menu and called "New calendar subscription".
+            In the macOS Calendar the option is under the "File" menu and is called "New calendar subscription".
         </li>
         <li>Paste the iCal feed URL into the provided field.</li>
         <li>Save the new calendar.</li>
     </ol>
-    <p>In some cases, simply opening the URL may navigate to your calendar application too.
     <h3>iCal feed URLs</h3>
     <p>There are two iCal feed URLs available:</p>
     <ul>

--- a/website/events/templates/events/index.html
+++ b/website/events/templates/events/index.html
@@ -18,12 +18,12 @@
     {% trans "Calendar" %}
     <a href="{% url 'events:ical-help' %}"
        target="_blank"
-       class="btn btn-primary first-right align-items-center"
+       class="btn btn-primary first-right d-flex align-items-center"
        data-bs-toggle="tooltip"
        data-bs-placement="top"
        title="Configure iCal feed"
     >
-        <i class="fas fa-calendar-alt"></i>iCal feed
+        <i class="fas fa-calendar-alt me-2"></i>iCal feed
     </a>
 {% endblock %}
 {% block section_tags %}id="events-index"{% endblock %}

--- a/website/events/templates/events/index.html
+++ b/website/events/templates/events/index.html
@@ -1,5 +1,5 @@
 {% extends "simple_page.html" %}
-{% load i18n static personal_feed %}}
+{% load i18n static %}
 {% get_current_language as LANGUAGE_CODE %}
 
 {% block title %}{% trans "Calendar"|capfirst %} —
@@ -16,26 +16,15 @@
 
 {% block page_title %}
     {% trans "Calendar" %}
-    <a href="{% url 'events:ical-'|add:LANGUAGE_CODE %}"
+    <a href="{% url 'events:ical-help' %}"
        target="_blank"
-       class="btn btn-primary first-right"
+       class="btn btn-primary first-right align-items-center"
        data-bs-toggle="tooltip"
        data-bs-placement="top"
-       title="{% trans 'iCal feed (all events)' %}"
+       title="Configure iCal feed"
     >
-        <i class="fas fa-calendar-alt"></i>
+        <i class="fas fa-calendar-alt"></i>iCal feed
     </a>
-    {% if request.user.is_authenticated %}
-        <a href="{% url 'events:ical-'|add:LANGUAGE_CODE %}?u={% personal_feed %}"
-           target="_blank"
-           data-bs-toggle="tooltip"
-           data-bs-placement="top"
-           class="btn btn-primary"
-           title="{% trans 'iCal feed (personal)' %}"
-        >
-            <i class="fas fa-calendar-check"></i>
-        </a>
-    {% endif %}
 {% endblock %}
 {% block section_tags %}id="events-index"{% endblock %}
 

--- a/website/events/urls.py
+++ b/website/events/urls.py
@@ -8,6 +8,7 @@ from events.views import (
     EventDetail,
     EventIndex,
     EventRegisterView,
+    ICalHelpView,
     MarkPresentView,
     NextEventView,
     RegistrationView,
@@ -46,6 +47,7 @@ urlpatterns = [
                 path("", EventIndex.as_view(), name="index"),
                 path("ical/nl.ics", EventFeed(), name="ical-nl"),
                 path("ical/en.ics", EventFeed(), name="ical-en"),
+                path("ical/help/", ICalHelpView.as_view(), name="ical-help"),
             ]
         ),
     ),

--- a/website/members/templates/members/email/welcome.html
+++ b/website/members/templates/members/email/welcome.html
@@ -13,4 +13,10 @@
 
     <p>Now that you're a member, you can join the official Thalia Promotion WhatsApp group.<br>
     Through this group you will be kept up to date with Thalia events and other matters in the association. You can join the group via the following link: <a href="https://thalia.nu/whatsapp/">https://thalia.nu/whatsapp/</a>.</p>
+
+    <p>And finally, there are some other optional next steps for you:</p>
+    <ul>
+        <li>Subscribe to a personalized calendar feed to see events in your calendar app: <a href="{{ base_url }}{% url "events:ical-help" %}">{{ base_url }}{% url "events:ical-help" %}</a></li>
+        <li>Upload a reference picture for face detection, to you get an overview of all the photos you're on: <a href="{{ base_url }}{% url 'facedetection:reference-faces' %}">{{ base_url }}{% url 'facedetection:reference-faces' %}</a></li>
+    </ul>
 {% endblock %}

--- a/website/members/templates/members/email/welcome.txt
+++ b/website/members/templates/members/email/welcome.txt
@@ -13,6 +13,12 @@ Now that you're a member, you can join the official Thalia Promotion WhatsApp gr
 Through this group you will be kept up to date with Thalia events and other matters
 in the association. You can join the group via the following link: {{ base_url }}/whatsapp/.
 
+And finally, there are some other optional next steps for you:
+- Subscribe to a personalized calendar feed to see events in your calendar app:
+  {{ base_url }}{% url "events:ical-help" %}
+- Upload a reference picture for face detection, to you get an overview of all the photos you're on:
+  {{ base_url }}{% url 'facedetection:reference-faces' %}
+
 With kind regards,
 
 The board of Study Association Thalia


### PR DESCRIPTION
Closes #3812.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Moves the iCal feed urls to a separate page with explanations.
Also adds some action points to the 'welcome' email.

# TODO:
- [x] Update welcome email txt variant.
- [x] Try out welcome email.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
