### PR TITLE
Bug: Override BaseUserAdmin add_fieldsets

### DIFF
--- a/website/members/admin.py
+++ b/website/members/admin.py
@@ -180,6 +180,23 @@ class UserAdmin(BaseUserAdmin):
         "profile__starting_year",
     )
 
+    add_fieldsets = [
+        (
+            None,
+            {
+                "classes": ["wide"],
+                "fields": [
+                    "username",
+                    "first_name",
+                    "last_name",
+                    "email",
+                    "password1",
+                    "password2",
+                ],
+            },
+        ),
+    ]
+
     fieldsets = (
         (
             _("Personal"),


### PR DESCRIPTION
Closes #3826 .

Website crashed when trying to 'Add user' via the admin panel with FieldError. This was caused by updating to Django 5.1 where a new field 'usable_password' was added to BaseUserAdmin that our UserAdmin class inherited.

Fix was overriding the add_fieldsets attribute so that it didn't include 'usable_password' but did include the fields we want when we add a new user

How to test
1. Go to Admin on website
2. Click on 'Users' -> Add button
3. It should no longer crash and you should be able to save a new user with Username, First Name, Last Name, Password, Email
