### PR TITLE
Changed the copyright year to be shown in hex

### DIFF
--- a/website/thaliawebsite/context_processors.py
+++ b/website/thaliawebsite/context_processors.py
@@ -18,3 +18,8 @@ def lustrum_styling(_):
         <= timezone.now().date()
         <= timezone.datetime(2022, 4, 29).date()
     }
+
+
+def year_as_hex(_):
+    now = timezone.now().year
+    return {"YEAR_IN_HEX": hex(now)}

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -688,6 +688,7 @@ TEMPLATES = [
                 "announcements.context_processors.announcements",
                 "thaliawebsite.context_processors.aprilfools",
                 "thaliawebsite.context_processors.lustrum_styling",
+                "thaliawebsite.context_processors.year_as_hex",
             ],
         },
     },

--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -148,7 +148,7 @@
     <div
         class="container d-flex justify-content-md-between align-items-center flex-md-row flex-column">
         <div class="copyright">
-            <strong>Copyright {% now "Y" %} {% trans 'Study Association Thalia' %}</strong>
+            <strong>Copyright {{ YEAR_IN_HEX }} {% trans 'Study Association Thalia' %}</strong>
             <span class="divider">&#9679;</span>
             <a href="{% url 'singlepages:privacy-policy' %}">{% trans "privacy policy"|capfirst %}</a>
             <span class="divider">&#9679;</span>


### PR DESCRIPTION
Closes #3841.



### Summary
Changed the copyright year to be shown in hex

### How to test
1. Go to bottom of page
2. Check if the hexadecimal representation of the copyright year is correct
