### PR TITLE
Add announcements list API and refactor persistent announcements

### DIFF
--- a/website/announcements/api/v2/serializers.py
+++ b/website/announcements/api/v2/serializers.py
@@ -1,10 +1,15 @@
-from rest_framework import serializers
-
 from announcements.models import Slide
+from rest_framework import serializers
 from thaliawebsite.api.v2.serializers import CleanedHTMLSerializer, ThumbnailSerializer
 from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
     CleanedModelSerializer,
 )
+
+
+class AnnouncementSerializer(serializers.Serializer):
+    content = CleanedHTMLSerializer(read_only=True)
+    closeable = serializers.BooleanField(read_only=True)
+    icon = serializers.CharField(read_only=True)
 
 
 class SlideSerializer(CleanedModelSerializer):

--- a/website/announcements/api/v2/serializers.py
+++ b/website/announcements/api/v2/serializers.py
@@ -1,5 +1,6 @@
-from announcements.models import Slide
 from rest_framework import serializers
+
+from announcements.models import Slide
 from thaliawebsite.api.v2.serializers import CleanedHTMLSerializer, ThumbnailSerializer
 from thaliawebsite.api.v2.serializers.cleaned_model_serializer import (
     CleanedModelSerializer,
@@ -10,6 +11,7 @@ class AnnouncementSerializer(serializers.Serializer):
     content = CleanedHTMLSerializer(read_only=True)
     closeable = serializers.BooleanField(read_only=True)
     icon = serializers.CharField(read_only=True)
+    id = serializers.IntegerField(read_only=True, default=None)
 
 
 class SlideSerializer(CleanedModelSerializer):

--- a/website/announcements/api/v2/urls.py
+++ b/website/announcements/api/v2/urls.py
@@ -1,12 +1,12 @@
-from django.urls import include, path
-
 from announcements.api.v2.views import (
+    AnnouncementDetailView,
     AnnouncementListView,
     FrontpageArticleDetailView,
     FrontpageArticleListView,
     SlideDetailView,
     SlideListView,
 )
+from django.urls import include, path
 
 app_name = "announcements"
 
@@ -18,7 +18,12 @@ urlpatterns = [
                 path(
                     "announcements/",
                     AnnouncementListView.as_view(actions={"get": "list"}),
-                    name="list",
+                    name="announcement-list",
+                ),
+                path(
+                    "announcements/<int:pk>/",
+                    AnnouncementDetailView.as_view(actions={"delete": "hide"}),
+                    name="announcement-detail",
                 ),
                 path("slides/", SlideListView.as_view(), name="slide-list"),
                 path(

--- a/website/announcements/api/v2/urls.py
+++ b/website/announcements/api/v2/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 
 from announcements.api.v2.views import (
+    AnnouncementListView,
     FrontpageArticleDetailView,
     FrontpageArticleListView,
     SlideDetailView,
@@ -14,6 +15,11 @@ urlpatterns = [
         "announcements/",
         include(
             [
+                path(
+                    "announcements/",
+                    AnnouncementListView.as_view(actions={"get": "list"}),
+                    name="list",
+                ),
                 path("slides/", SlideListView.as_view(), name="slide-list"),
                 path(
                     "slides/<int:pk>/",

--- a/website/announcements/api/v2/views.py
+++ b/website/announcements/api/v2/views.py
@@ -1,10 +1,16 @@
 """API v2 views of the announcements app."""
 
-from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
-from rest_framework.generics import ListAPIView, RetrieveAPIView
-
-from announcements.api.v2.serializers import FrontpageArticleSerializer, SlideSerializer
+from announcements.api.v2.serializers import (
+    AnnouncementSerializer,
+    FrontpageArticleSerializer,
+    SlideSerializer,
+)
+from announcements.context_processors import announcements
 from announcements.models import FrontpageArticle, Slide
+from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+from rest_framework import viewsets
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.response import Response
 
 
 class AnnouncementsAPIViewMixin:
@@ -40,3 +46,17 @@ class FrontpageArticleDetailView(AnnouncementsAPIViewMixin, RetrieveAPIView):
 
     serializer_class = FrontpageArticleSerializer
     queryset = FrontpageArticle.visible_objects.all()
+
+
+class AnnouncementListView(AnnouncementsAPIViewMixin, viewsets.ViewSet):
+    """Returns a list of announcements."""
+
+    serializer_class = AnnouncementSerializer
+
+    def list(self, request):
+        announces = announcements(request)
+        serializer = self.serializer_class(
+            announces["announcements"] + announces["persistent_announcements"],
+            many=True,
+        )
+        return Response(serializer.data)

--- a/website/announcements/api/v2/views.py
+++ b/website/announcements/api/v2/views.py
@@ -7,6 +7,7 @@ from announcements.api.v2.serializers import (
 )
 from announcements.context_processors import announcements
 from announcements.models import FrontpageArticle, Slide
+from announcements.services import close_announcement
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import viewsets
 from rest_framework.generics import ListAPIView, RetrieveAPIView
@@ -60,3 +61,11 @@ class AnnouncementListView(AnnouncementsAPIViewMixin, viewsets.ViewSet):
             many=True,
         )
         return Response(serializer.data)
+
+
+class AnnouncementDetailView(AnnouncementsAPIViewMixin, viewsets.ViewSet):
+    serializer_class = AnnouncementSerializer
+
+    def hide(self, request, pk):
+        close_announcement(request, pk)
+        return Response(status=204)

--- a/website/announcements/context_processors.py
+++ b/website/announcements/context_processors.py
@@ -19,6 +19,9 @@ def announcements(request):
 
     # Announcements set by AnnouncementMiddleware.
     persistent_announcements = getattr(request, "_announcements", [])
+    for persistent_announcement in persistent_announcements:
+        persistent_announcement["closeable"] = False
+
     return {
         "announcements": announcements_list,
         "persistent_announcements": persistent_announcements,

--- a/website/announcements/services.py
+++ b/website/announcements/services.py
@@ -1,0 +1,9 @@
+def close_announcement(request, pk):
+    """Close an announcement."""
+    if "closed_announcements" not in request.session:
+        request.session["closed_announcements"] = []  # cannot use sets here :(
+    # duplicates should never occur anyway, but it does not hurt to check
+    if pk not in request.session["closed_announcements"]:
+        request.session["closed_announcements"].append(pk)
+    # needs to be explicitly marked since we only edited an existing object
+    request.session.modified = True

--- a/website/announcements/tests.py
+++ b/website/announcements/tests.py
@@ -1,10 +1,9 @@
+from announcements.views import close_announcement_view
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
-
-from announcements.views import close_announcement
 
 
 @override_settings(SUSPEND_SIGNALS=True)
@@ -24,14 +23,14 @@ class AnnouncementCloseTestCase(TestCase):
             self.middleware.process_request(request)
             with self.subTest(user=user):
                 request.user = user
-                response = close_announcement(request)
+                response = close_announcement_view(request)
                 self.assertEqual(response.status_code, 405)
 
     def test_post_no_id(self):
         request = self.factory.post(reverse("announcements:close-announcement"))
         self.middleware.process_request(request)
         request.user = AnonymousUser()
-        response = close_announcement(request)
+        response = close_announcement_view(request)
         self.assertEqual(response.status_code, 400)
 
     def test_post_id_string(self):
@@ -40,7 +39,7 @@ class AnnouncementCloseTestCase(TestCase):
         )
         self.middleware.process_request(request)
         request.user = AnonymousUser()
-        response = close_announcement(request)
+        response = close_announcement_view(request)
         self.assertEqual(response.status_code, 400)
 
     def test_valid_request_anonymous(self):
@@ -49,7 +48,7 @@ class AnnouncementCloseTestCase(TestCase):
         )
         self.middleware.process_request(request)
         request.user = AnonymousUser()
-        response = close_announcement(request)
+        response = close_announcement_view(request)
 
         self.assertEqual(response.status_code, 204)
         self.assertIn("closed_announcements", request.session)
@@ -63,7 +62,7 @@ class AnnouncementCloseTestCase(TestCase):
         )
         self.middleware.process_request(request)
         request.user = self.user
-        response = close_announcement(request)
+        response = close_announcement_view(request)
 
         self.assertEqual(response.status_code, 204)
         self.assertIn("closed_announcements", request.session)
@@ -77,7 +76,7 @@ class AnnouncementCloseTestCase(TestCase):
         self.middleware.process_request(request)
         request.session["closed_announcements"] = [3]
         request.user = AnonymousUser()
-        response = close_announcement(request)
+        response = close_announcement_view(request)
 
         self.assertEqual(response.status_code, 204)
         self.assertIn("closed_announcements", request.session)

--- a/website/announcements/urls.py
+++ b/website/announcements/urls.py
@@ -1,6 +1,5 @@
-from django.urls import include, path
-
 from announcements import views
+from django.urls import include, path
 
 #: the name of this app
 app_name = "announcements"
@@ -13,7 +12,7 @@ urlpatterns = [
             [
                 path(
                     "close-announcement",
-                    views.close_announcement,
+                    views.close_announcement_view,
                     name="close-announcement",
                 )
             ]

--- a/website/announcements/views.py
+++ b/website/announcements/views.py
@@ -1,9 +1,10 @@
+from announcements.services import close_announcement
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.http import require_POST
 
 
 @require_POST
-def close_announcement(request):
+def close_announcement_view(request):
     """Close an announcement.
 
     :param: request
@@ -16,12 +17,5 @@ def close_announcement(request):
     except ValueError:
         return HttpResponseBadRequest("no integer id specified")
 
-    # if we do not have a list of closed announcements yet:
-    if "closed_announcements" not in request.session:
-        request.session["closed_announcements"] = []  # cannot use sets here :(
-    # duplicates should never occur anyway, but it does not hurt to check
-    if announcement_id not in request.session["closed_announcements"]:
-        request.session["closed_announcements"].append(announcement_id)
-    # needs to be explicitly marked since we only edited an existing object
-    request.session.modified = True
+    close_announcement(request, announcement_id)
     return HttpResponse(status=204)  # 204: No Content

--- a/website/members/apps.py
+++ b/website/members/apps.py
@@ -64,15 +64,19 @@ class MembersConfig(AppConfig):
         if request.member and not request.member.has_active_membership():
             announcements.append(
                 {
-                    "rich_text": render_to_string(
+                    "content": render_to_string(
                         "members/announcement_not_member.html",
                         context={"member": request.member},
-                    )
-                },
+                    ),
+                    "icon": "id-card",
+                }
             )
         if request.member and request.member.profile.event_permissions != "all":
             announcements.append(
-                {"rich_text": render_to_string("members/announcement_no_events.html")}
+                {
+                    "content": render_to_string("members/announcement_no_events.html"),
+                    "icon": "exclamation",
+                }
             )
         if (
             request.member
@@ -80,6 +84,9 @@ class MembersConfig(AppConfig):
             and not request.member.profile.photo
         ):
             announcements.append(
-                {"rich_text": render_to_string("members/announcement_no_pfp.html")}
+                {
+                    "content": render_to_string("members/announcement_no_pfp.html"),
+                    "icon": "address-card",
+                }
             )
         return announcements

--- a/website/members/templates/members/announcement_no_pfp.html
+++ b/website/members/templates/members/announcement_no_pfp.html
@@ -1,5 +1,4 @@
 <p>
-    <i class="fas fa-address-card me-2"></i>
     You don't have a profile picture yet! Upload one on your
     <a href="{% url "members:edit-profile" %}">profile page</a> so that the other members know who you are.
 </p>

--- a/website/members/templates/members/announcement_not_member.html
+++ b/website/members/templates/members/announcement_not_member.html
@@ -1,5 +1,4 @@
 <p>
-    <i class="fas fa-id-card me-2"></i>
     {% if member.latest_membership.study_long and not member.profile.is_minimized %}
         You're currently not a member of Thalia. <a href="{% url 'registrations:renew-studylong' %}">Extend your membership</a> if you are still studying and get access to all parts of the website.
     {% else %}

--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -80,11 +80,7 @@
 
 <section id="announcements-alerts">
     {% include "announcements/announcement.html" with announcements=announcements %}
-    {% for announcement in persistent_announcements %}
-        <div class="announcement">
-            {{ announcement.rich_text | safe }}
-        </div>
-    {% endfor %}
+    {% include "announcements/announcement.html" with announcements=persistent_announcements %}
 </section>
 
 <div id="accentbar"></div>


### PR DESCRIPTION
Closes #3830.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Adds an announcement API and refactors persistent announcements to fit into it more easily by being more like normal announcements.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to `/api/v2/announcements/announcements/`
2. Check that all announcements are in there

### TODO
We should maybe add an API endpoint to close an announcement (in addition to `/announcements/close-announcement`).