### PR TITLE
Add count/next/previous to announcement list

### DIFF
--- a/website/announcements/api/v2/views.py
+++ b/website/announcements/api/v2/views.py
@@ -1,5 +1,10 @@
 """API v2 views of the announcements app."""
 
+from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+from rest_framework import viewsets
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.response import Response
+
 from announcements.api.v2.serializers import (
     AnnouncementSerializer,
     FrontpageArticleSerializer,
@@ -8,10 +13,6 @@ from announcements.api.v2.serializers import (
 from announcements.context_processors import announcements
 from announcements.models import FrontpageArticle, Slide
 from announcements.services import close_announcement
-from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
-from rest_framework import viewsets
-from rest_framework.generics import ListAPIView, RetrieveAPIView
-from rest_framework.response import Response
 
 
 class AnnouncementsAPIViewMixin:
@@ -60,7 +61,14 @@ class AnnouncementListView(AnnouncementsAPIViewMixin, viewsets.ViewSet):
             announces["announcements"] + announces["persistent_announcements"],
             many=True,
         )
-        return Response(serializer.data)
+        data = {
+            "count": len(announces),
+            "next": None,
+            "previous": None,
+            "results": serializer.data,
+        }
+
+        return Response(data)
 
 
 class AnnouncementDetailView(AnnouncementsAPIViewMixin, viewsets.ViewSet):


### PR DESCRIPTION
Closes #3830.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Adds count/next/previous to announcement list api

### How to test
<!-- Steps to test the changes you made: -->
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
