### PR TITLE
Regenerates the list of announcements for API

### DIFF
--- a/website/announcements/api/v2/views.py
+++ b/website/announcements/api/v2/views.py
@@ -1,5 +1,10 @@
 """API v2 views of the announcements app."""
 
+from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+from rest_framework import viewsets
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.response import Response
+
 from announcements.api.v2.serializers import (
     AnnouncementSerializer,
     FrontpageArticleSerializer,
@@ -7,11 +12,7 @@ from announcements.api.v2.serializers import (
 )
 from announcements.context_processors import announcements
 from announcements.models import FrontpageArticle, Slide
-from announcements.services import close_announcement
-from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
-from rest_framework import viewsets
-from rest_framework.generics import ListAPIView, RetrieveAPIView
-from rest_framework.response import Response
+from announcements.services import close_announcement, get_announcements
 
 
 class AnnouncementsAPIViewMixin:
@@ -55,6 +56,7 @@ class AnnouncementListView(AnnouncementsAPIViewMixin, viewsets.ViewSet):
     serializer_class = AnnouncementSerializer
 
     def list(self, request):
+        request._announcements = get_announcements(request)
         announces = announcements(request)
         serializer = self.serializer_class(
             announces["announcements"] + announces["persistent_announcements"],

--- a/website/announcements/middleware.py
+++ b/website/announcements/middleware.py
@@ -1,4 +1,4 @@
-from django.apps import apps
+from announcements.services import get_announcements
 
 
 class AnnouncementMiddleware:
@@ -13,10 +13,6 @@ class AnnouncementMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        announcements = []
-        for app in apps.get_app_configs():
-            if hasattr(app, "announcements"):
-                announcements += app.announcements(request)
-        request._announcements = announcements
+        request._announcements = get_announcements(request)
 
         return self.get_response(request)

--- a/website/announcements/services.py
+++ b/website/announcements/services.py
@@ -1,3 +1,14 @@
+from django.apps import apps
+
+
+def get_announcements(request):
+    announcements = []
+    for app in apps.get_app_configs():
+        if hasattr(app, "announcements"):
+            announcements += app.announcements(request)
+    return announcements
+
+
 def close_announcement(request, pk):
     """Close an announcement."""
     if "closed_announcements" not in request.session:


### PR DESCRIPTION
Closes #3874.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
When in the API, this PR re-generates the announcement list so that it includes all announcements, hopefully?

It just does it twice now, but I think that is fine, even if it might be a little bit slower.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to `/api/v2/announcements/announcements`
2. Click on '....'
3. Scroll down to '....'
