### PR TITLE
Remove Career Central link

### DIFF
--- a/website/thaliawebsite/templates/base.html
+++ b/website/thaliawebsite/templates/base.html
@@ -166,9 +166,6 @@
             <a target="_blank" rel="noopener" href="https://github.com/svthalia/" title="GitHub page for Thalia">
                 <i aria-hidden="true" class="fab fa-github"></i>
             </a>
-            <a target="_blank" rel="noopener" href="https://ru.nxus.nl/student/group/0b242b79-01a4-4502-a582-8a0327676a2b" title="Career Central page for Thalia">
-                <i aria-hidden="true" class="fas fa-graduation-cap"></i>
-            </a>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Closes #3861

Revert "Add Career Central link to base.html (#2931)"

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Career Central seems dead, remove link from base.html

### How to test
1. Run server
2. See no link to career central in footer
