### PR TITLE
Optimize summaries page with queryable properties

### DIFF
--- a/website/education/models.py
+++ b/website/education/models.py
@@ -1,8 +1,12 @@
 import datetime
 
 from django.db import models
+from django.db.models import Count, Q
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+
+from queryable_properties.managers import QueryablePropertiesManager
+from queryable_properties.properties import AggregateProperty
 
 from members.models import Member
 from utils.snippets import datetime_to_lectureyear
@@ -29,6 +33,8 @@ class Category(models.Model):
 class Course(models.Model):
     """Describes a course."""
 
+    objects = QueryablePropertiesManager()
+
     name = models.CharField(max_length=255)
 
     categories = models.ManyToManyField(
@@ -51,6 +57,11 @@ class Course(models.Model):
 
     def get_absolute_url(self):
         return reverse("education:course", args=[str(self.pk)])
+
+    summary_count = AggregateProperty(
+        Count("summary", filter=Q(summary__accepted=True))
+    )
+    exam_count = AggregateProperty(Count("exam", filter=Q(exam__accepted=True)))
 
     class Meta:
         ordering = ["-pk"]

--- a/website/education/views.py
+++ b/website/education/views.py
@@ -12,6 +12,8 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DetailView, ListView, TemplateView
 
+from queryable_properties.utils import prefetch_queryable_properties
+
 from members.decorators import membership_required
 from utils.media.services import get_media_url
 
@@ -23,9 +25,17 @@ from .models import Category, Course, Exam, Summary
 class CourseIndexView(ListView):
     """Render an overview of the courses."""
 
-    queryset = Course.objects.filter(until=None).prefetch_related(
-        "categories", "old_courses"
-    )
+    def get_queryset(self):
+        queryset = (
+            Course.objects.filter(until=None)
+            .prefetch_related("categories", "old_courses")
+            .select_properties("summary_count", "exam_count")
+            .order_by("name")
+        )
+        prefetch_queryable_properties(queryset, "old_courses__summary_count")
+        prefetch_queryable_properties(queryset, "old_courses__exam_count")
+        return queryset
+
     template_name = "education/courses.html"
 
     def get_ordering(self) -> str:
@@ -42,12 +52,11 @@ class CourseIndexView(ListView):
                         "categories": x.categories.all(),
                         "document_count": sum(
                             [
-                                x.summary_set.filter(accepted=True).count(),
-                                x.exam_set.filter(accepted=True).count(),
+                                x.summary_count,
+                                x.exam_count,
                             ]
                             + [
-                                c.summary_set.filter(accepted=True).count()
-                                + c.exam_set.filter(accepted=True).count()
+                                c.summary_count + c.exam_count
                                 for c in x.old_courses.all()
                             ]
                         ),


### PR DESCRIPTION
Closes #ISSUE.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Adds queryable properties for summary and exam counts. Then, these are prefetched immediately, which should greatly speed up the summaries page.

### How to test
<!-- Steps to test the changes you made: -->
1. Open summaries page
2. See that results are the same
3. Observe that there are fewer queries to the database and that hopefully the page loads faster
