### PR TITLE
Fix deep links on android

### DIFF
--- a/infra/nginx/concrexit.conf.template
+++ b/infra/nginx/concrexit.conf.template
@@ -125,7 +125,7 @@ server {
     }
 
     location = /.well-known/assetlinks.json {
-        alias /resources/assetlinks.json;
+        alias /resources/assetlinks-${SITE_DOMAIN}.json;
         default_type application/json;
     }
 

--- a/infra/nginx/resources/assetlinks-staging.thalia.nu.json
+++ b/infra/nginx/resources/assetlinks-staging.thalia.nu.json
@@ -1,0 +1,26 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.thaliapp",
+      "sha256_cert_fingerprints": [
+        "39:E5:2D:0C:2E:29:03:5A:15:21:2A:85:20:58:78:DB:0B:12:AC:6D:6F:73:7B:7E:FA:8D:77:C9:8D:2C:08:21"
+      ]
+    }
+  },
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.thaliapp.staging",
+      "sha256_cert_fingerprints": [
+        "8B:17:6E:49:55:D7:04:A7:88:5A:91:B2:1B:E3:6F:B5:87:0F:BC:E2:44:8B:0A:7B:1B:E1:FF:8A:6F:E3:B2:2D"
+      ]
+    }
+  }
+]

--- a/infra/nginx/resources/assetlinks-thalia.nu.json
+++ b/infra/nginx/resources/assetlinks-thalia.nu.json
@@ -7,7 +7,7 @@
       "namespace": "android_app",
       "package_name": "com.thaliapp",
       "sha256_cert_fingerprints": [
-        "25:F7:06:CA:04:36:32:62:87:10:7C:59:84:5E:A0:E7:68:A4:DD:80:E1:CF:EB:30:96:3C:B1:CC:CF:E4:32:16"
+        "39:E5:2D:0C:2E:29:03:5A:15:21:2A:85:20:58:78:DB:0B:12:AC:6D:6F:73:7B:7E:FA:8D:77:C9:8D:2C:08:21"
       ]
     }
   }


### PR DESCRIPTION
Closes nothing.

### Summary
This should fix the app links not working on android, and allow the debug app to also open debug links

### How to test

1. Go to an events page
2. Click on open in app
