### PR TITLE
Wrapped the links on the partners site

### DIFF
--- a/website/partners/static/partners/css/style.scss
+++ b/website/partners/static/partners/css/style.scss
@@ -116,7 +116,3 @@
         }
     }
 }
-
-.wrapped-link {
-    word-wrap:break-word;
-}

--- a/website/partners/static/partners/css/style.scss
+++ b/website/partners/static/partners/css/style.scss
@@ -116,3 +116,7 @@
         }
     }
 }
+
+.wrapped-link {
+    word-wrap:break-word;
+}

--- a/website/partners/templates/partners/partner.html
+++ b/website/partners/templates/partners/partner.html
@@ -38,7 +38,7 @@
                     {% if partner.link %}
                         <h4>{% trans "Website" %}</h4>
                         <p>
-                            <a href="{{ partner.link }}" rel="noopener" target="_blank" class="wrapped-link">{{ partner.link }}</a>
+                            <a href="{{ partner.link }}" rel="noopener" target="_blank" class="text-break">{{ partner.link }}</a>
                         </p>
                     {% endif %}
 

--- a/website/partners/templates/partners/partner.html
+++ b/website/partners/templates/partners/partner.html
@@ -38,7 +38,7 @@
                     {% if partner.link %}
                         <h4>{% trans "Website" %}</h4>
                         <p>
-                            <a href="{{ partner.link }}" rel="noopener" target="_blank">{{ partner.link }}</a>
+                            <a href="{{ partner.link }}" rel="noopener" target="_blank" class="wrapped-link">{{ partner.link }}</a>
                         </p>
                     {% endif %}
 


### PR DESCRIPTION
Closes #3925.

### Summary
Wrapped the links on the partner pages so that the links don't go over in the text to the left of it but stays underneath the website link.

### How to test
Go to the partner website in thalia.nu. Go to the link and make sure that the link is wrapped.
