### PR TITLE
Revoke SEPA mandates of minimized users

### DIFF
--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -276,5 +276,5 @@ def execute_data_minimisation(dry_run=False):
         queryset_payments.update(paid_by=None, processed_by=None)
         queryset_bankaccounts.delete()
         queryset_mandates.update(valid_until=timezone.now())
-        
+
     return queryset_payments

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -236,7 +236,7 @@ def send_tpay_batch_processing_emails(batch):
 
 
 def execute_data_minimisation(dry_run=False):
-    """Anonymizes payments older than 7 years."""
+    """Anonymize payments older than 7 years. Also revoke mandates of minimized users."""
     # Sometimes years are 366 days of course, but better delete 1 or 2 days early than late
     payment_deletion_period = timezone.now().date() - timezone.timedelta(days=365 * 7)
     bankaccount_deletion_period = timezone.now() - datetime.timedelta(days=31 * 13)
@@ -266,7 +266,15 @@ def execute_data_minimisation(dry_run=False):
         ),
     )
 
+    queryset_mandates = queryset_bankaccounts.filter(
+        mandate_no__isnull=False,
+        valid_until=None,
+        owner__profile__is_minimized=True,
+    )
+
     if not dry_run:
         queryset_payments.update(paid_by=None, processed_by=None)
         queryset_bankaccounts.delete()
+        queryset_mandates.update(valid_until=timezone.now())
+        
     return queryset_payments


### PR DESCRIPTION
Closes #3921.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
This sets the end date of validity of SEPA mandates of minimized users. Consequently, if previously minimized users become member again, they will not have a still-valid mandate. Next, creating a new moneybird contact does not fail, because the next time they make a mandate, it gets a new ID that does not conflict with the mandate linked to the old (now archived) contact on moneybird.

The reason to do this instead of remembering and unarchiving moneybird contacts is that the moneybird API doesn't seem to support unarchiving a contact. Making mandates invalid when a user is minimized also seems simply logical: no longer being a member also makes it sketchy to withdraw money.

### How to test
<!-- Steps to test the changes you made: -->
1. ?
