### PR TITLE
Add MoneybirdReceipt admin and update receipt API endpoints

### DIFF
--- a/website/moneybirdsynchronization/admin.py
+++ b/website/moneybirdsynchronization/admin.py
@@ -181,3 +181,12 @@ class MoneybirdReceiptAdmin(admin.ModelAdmin):
         )
 
     reimbursement_link.short_description = "Reimbursement"
+
+    def get_readonly_fields(self, request, obj=None):
+        if not obj:
+            return ()
+        return ("reimbursement",)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("reimbursement")

--- a/website/moneybirdsynchronization/admin.py
+++ b/website/moneybirdsynchronization/admin.py
@@ -8,6 +8,7 @@ from .models import (
     MoneybirdExternalInvoice,
     MoneybirdPayment,
     MoneybirdProject,
+    MoneybirdReceipt,
 )
 
 
@@ -152,3 +153,31 @@ class MoneybirdProjectAdmin(admin.ModelAdmin):
     )
 
     search_fields = ("name", "moneybird_id")
+
+
+@admin.register(MoneybirdReceipt)
+class MoneybirdReceiptAdmin(admin.ModelAdmin):
+    """Manage moneybird receipts."""
+
+    list_display = ("moneybird_receipt_id", "reimbursement_link")
+    search_fields = (
+        "moneybird_receipt_id",
+        "moneybird_attachment_id",
+        "reimbursement__date_incurred",
+        "reimbursement__owner__first_name",
+        "reimbursement__owner__last_name",
+        "reimbursement__description",
+    )
+    raw_id_fields = ("reimbursement",)
+
+    def reimbursement_link(self, obj):
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse(
+                "admin:reimbursements_reimbursement_change",
+                args=[obj.reimbursement.pk],
+            ),
+            obj.reimbursement,
+        )
+
+    reimbursement_link.short_description = "Reimbursement"

--- a/website/moneybirdsynchronization/moneybird.py
+++ b/website/moneybirdsynchronization/moneybird.py
@@ -54,11 +54,11 @@ class MoneybirdAPIService:
         return self._administration.delete(f"financial_statements/{statement_id}")
 
     def create_receipt(self, receipt_data):
-        return self._administration.post("receipts", receipt_data)
+        return self._administration.post("documents/receipts", receipt_data)
 
     def add_receipt_attachment(self, receipt_id, receipt_attachment):
         return self._administration.post(
-            f"receipts/{receipt_id}/attachments", receipt_attachment
+            f"documents/receipts/{receipt_id}/attachments", receipt_attachment
         )
 
     def link_mutation_to_booking(


### PR DESCRIPTION
Closes #3934.

Adds an admin, and fixes [CONCREXIT-1MN](https://thalia.sentry.io/issues/6598145706/events/e27a4cd6442e4eca9d5a84efc1f17157/)
