### PR TITLE
Made it so that the ordering also checks for last name and pk when or…

### DIFF
--- a/website/members/views.py
+++ b/website/members/views.py
@@ -102,7 +102,7 @@ class MembersIndex(PagedView):
             members_query &= Q(pk__in=memberships.values("user__pk"))
         members = (
             Member.objects.filter(members_query)
-            .order_by("first_name")
+            .order_by("first_name", "last_name", "pk")
             .select_related("profile")
         )
         return members


### PR DESCRIPTION
…dering the member list.

Closes #3916.

bug: some members were shown twice if they had the same name as other members

### Summary
By ordering the members with last name and pk seems to have fixed it.

### How to test
Make 30 users where they have the same first name but different last name. Then check in the member list if any of those members show up more then once.
