### PR TITLE
Fix renewal moneybird invoice period for upgrages

### DIFF
--- a/website/moneybirdsynchronization/models.py
+++ b/website/moneybirdsynchronization/models.py
@@ -62,9 +62,10 @@ def date_for_payable_model(obj) -> datetime.datetime | datetime.date:
 
 def period_for_payable_model(obj) -> str | None:
     if isinstance(obj, Registration | Renewal):
-        if obj.membership is not None:
-            # Only bill for the start date, ignore the until date.
-            date = obj.membership.since
+        if obj.payment is not None:
+            date = obj.payment.created_at.date()
+            # Use the payment date, when the new membership normally starts,
+            # and don't bother with the 'until' date.
             return f"{date.strftime('%Y%m%d')}..{date.strftime('%Y%m%d')}"
     return None
 


### PR DESCRIPTION
Membership upgrades got pushed with the membership.since date as period, which can be a year ago, in a locked period. This changes it to the payment date, which is normally the start of when the renewal/registration takes effect.

For upgrades, this is the moment the upgrade happens. For renewals, this is still also the start of the new membership. For registrations, it's also the start of the membership.
