### PR TITLE
Change ratelimits to be more sensible

### DIFF
--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -62,14 +62,14 @@ class PagedView(ListView):
 
 
 class RateLimitedPasswordResetView(PasswordResetView):
-    @method_decorator(ratelimit(key="ip", rate="5/h"))
+    @method_decorator(ratelimit(key="ip", rate="20/d"))
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
 
 class RateLimitedLoginView(LoginView):
-    @method_decorator(ratelimit(key="ip", rate="100/h"))
-    @method_decorator(ratelimit(key="post:username", rate="30/h"))
+    @method_decorator(ratelimit(key="ip", rate="50/m"))
+    @method_decorator(ratelimit(key="post:username", rate="20/d"))
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 

--- a/website/thaliawebsite/views.py
+++ b/website/thaliawebsite/views.py
@@ -62,14 +62,13 @@ class PagedView(ListView):
 
 
 class RateLimitedPasswordResetView(PasswordResetView):
-    @method_decorator(ratelimit(key="ip", rate="20/d"))
+    @method_decorator(ratelimit(key="ip", rate="5/m"))
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
 
 class RateLimitedLoginView(LoginView):
     @method_decorator(ratelimit(key="ip", rate="50/m"))
-    @method_decorator(ratelimit(key="post:username", rate="20/d"))
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 


### PR DESCRIPTION
Closes #3955.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
Changed login attempt ratelimits and password reset ratelimits to a minute-maximum instead of hour-maximum.
Remove username ratelimits to prevent being able to DOS specific users.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
