### PR TITLE
Added event cards on frontpage with open registration

### DIFF
--- a/website/events/templates/events/registration_events.html
+++ b/website/events/templates/events/registration_events.html
@@ -1,0 +1,45 @@
+{% load i18n bleach_tags alert %}
+<section id="events-cards" class="page-section">
+    <div class="container">
+        <h1 class="section-title">{% trans "Registration now open" %}</h1>
+        <div class="row">
+            {% if not events %}
+                <div class="mt-4 col-12">
+                    {% trans 'There are currently no events planned' as info_text %}
+                    {% alert 'info' info_text dismissible=False %}
+                </div>
+            {% else %}
+                {% for next_event in events %}
+                <div class="col-md-6 col-lg-4">
+                    <a href="{{ next_event.event.get_absolute_url }}">
+                        <div class="card animated fadeIn">
+                            <div class="card-body">
+                                {% if next_event.current_user_registration is not None %}
+                                    {% if next_event.current_user_registration %}
+                                        <div class="event-indication"
+                                             data-bs-toggle="tooltip"
+                                             data-bs-placement="top"
+                                             title="{{ next_event.current_user_registration.text }}">
+                                            <div class="{{ next_event.current_user_registration.class }}"></div>
+                                        </div>
+                                    {% endif %}
+                                {% endif %}
+
+                                <h6 class="card-date">{{ next_event.event.start|date:"d F Y" }}</h6>
+                                <h5 class="card-title">{{ next_event.event.title }}</h5>
+                                <p class="card-text">{{ next_event.event.caption|striptags|bleach|truncatechars:110 }}</p>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                {% endfor %}
+            {% endif %}
+        </div>
+        <p>
+            {% url 'events:index' as events_index %}
+            {% blocktrans trimmed %}
+                Searching for another event? <a href="{{ events_index }}">Take a look at the entire agenda.</a>
+            {% endblocktrans %}
+        </p>
+    </div>
+</section>

--- a/website/events/templatetags/event_cards.py
+++ b/website/events/templatetags/event_cards.py
@@ -1,6 +1,7 @@
 from django import template
 
 from events.templatetags.frontpage_events import render_frontpage_events
+from events.templatetags.frontpage_events import render_frontpage_registration_events
 
 register = template.Library()
 
@@ -8,3 +9,8 @@ register = template.Library()
 @register.inclusion_tag("events/event_cards.html", takes_context=True)
 def render_event_cards(context, events=None):
     return render_frontpage_events(context, events)
+
+
+@register.inclusion_tag("events/registration_events.html", takes_context=True)
+def render_registration_event_cards(context, events=None):
+    return render_frontpage_registration_events(context, events)

--- a/website/thaliawebsite/templates/index.html
+++ b/website/thaliawebsite/templates/index.html
@@ -24,6 +24,8 @@
 
     {% render_event_cards %}
 
+    {% render_frontpage_registration_events %}
+
     <section class="page-section">
         <div class="container">
             <div class="row">


### PR DESCRIPTION
Closes #3047.

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Added a event cards bar on the frontpage of the site that displays events of which the registration opened in the last week:
<img width="1438" height="692" alt="Screenshot from 2025-10-08 19-48-56" src="https://github.com/user-attachments/assets/59e5e51d-0bce-4e7d-9414-31b3ad2ac7cb" />

