### PR TITLE
Remove email if a membergroup is inactive

### DIFF
--- a/website/activemembers/templates/activemembers/membergroup_detail.html
+++ b/website/activemembers/templates/activemembers/membergroup_detail.html
@@ -31,11 +31,11 @@
             <p>
                 {{ membergroup.description|safe }}
             </p>
-            {% if membergroup.committee or membergroup.society %}
-            <p>
-                    <strong>{% trans 'contact email address'|capfirst %}:</strong>
-                <a href="mailto:{{ membergroup.contact_address }}">{{ membergroup.contact_address }}</a>
-            </p>
+            {% if (membergroup.committee or membergroup.society) and membergroup.active %}
+                <p>
+                        <strong>{% trans 'contact email address'|capfirst %}:</strong>
+                    <a href="mailto:{{ membergroup.contact_address }}">{{ membergroup.contact_address }}</a>
+                </p>
             {% endif %}
         </div>
     </section>


### PR DESCRIPTION
Closes #3969

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
Only shows email if a committee or society is active.

