### PR TITLE
Removed www.

### DIFF
--- a/website/singlepages/templates/singlepages/sibling_associations.html
+++ b/website/singlepages/templates/singlepages/sibling_associations.html
@@ -16,7 +16,7 @@
                         <li><a href="https://www.desda.org/">DESDA ({% trans "Mathematics" %})</a></li>
                         <li><a href="https://www.leonardo.science.ru.nl/">Leonardo da Vinci ({% trans "Science" %})</a></li>
                         <li><a href="https://www.marie-curie.nl/">Marie Curie ({% trans "Physics and Astronomy" %})</a></li>
-                        <li><a href="https://www.olympus.science.ru.nl/">Olympus
+                        <li><a href="https://olympus.science.ru.nl/">Olympus
                             ({% trans "Science faculty umbrella association" %})</a></li>
                         <li><a href="https://www.vcmw-sigma.nl/home">Sigma ({% trans "Molecular Sciences" %})</a></li>
                         <li><a href="http://www.bbb-careerevent.com/">{% trans "BBB Career Event" %}</a></li>


### PR DESCRIPTION
Closes #3985

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? --> Removed www. to fix a security alert that gets raised when clicking on the Olympus link.

### How to test
<!-- Steps to test the changes you made: -->
1. Go to "association" -> "sibling associations"
2. Click on Olympus (Science faculty umbrella association)
3. See it work
