### PR TITLE
Add email to treasurer when late queue entrant should not get fine.

### DIFF
--- a/website/events/emails.py
+++ b/website/events/emails.py
@@ -76,3 +76,17 @@ def notify_registration(registration):
             "base_url": settings.BASE_URL,
         },
     )
+
+
+def notify_late_queue_entry(event, first_waiting):
+    send_email(
+        to=[settings.TREASURER_NOTIFICATION_ADDRESS],
+        subject=f"Notification about late entry from queue for {event.title}",
+        txt_template="events/email/late_queue_entry_email.txt",
+        html_template="events/email/late_queue_entry_email.html",
+        context={
+            "event": event,
+            "registration": first_waiting,
+            "base_url": settings.BASE_URL,
+        },
+    )

--- a/website/events/services.py
+++ b/website/events/services.py
@@ -339,6 +339,8 @@ def cancel_registration(member, event):
                     date_cancelled=None
                 ).order_by("date")[event.max_participants]
                 emails.notify_first_waiting(event, first_waiting)
+                if first_waiting.would_cancel_after_deadline:
+                    emails.notify_late_queue_entry(event, first_waiting)
                 signals.user_left_queue.send(
                     sender=None, event=event, first_waiting=first_waiting
                 )

--- a/website/events/templates/events/email/late_queue_entry_email.html
+++ b/website/events/templates/events/email/late_queue_entry_email.html
@@ -1,0 +1,12 @@
+{% extends "email/board_email.html" %}
+
+{% block content %}
+  Hi,<br>
+
+  <p>A member that was registered for the event '{{ event.title }}' has cancelled their registration after the deadline.</p>
+  <p>The first waiting queue member can now attend the event, but they should not receive a fine for non-attendance as the cancellation deadline has passed.</p>
+
+  <p>Name: {{ registration.member.profile.display_name }}</p>
+
+  <p>~ With love, from Techie</p>
+{% endblock %}

--- a/website/events/templates/events/email/late_queue_entry_email.txt
+++ b/website/events/templates/events/email/late_queue_entry_email.txt
@@ -1,0 +1,9 @@
+Hi,
+
+A member that was registered for the event '{{ event.title }}' has cancelled their registration after the deadline.
+
+The first waiting queue member can now attend the event, but they should not receive a fine for non-attendance as the cancellation deadline has passed.
+
+Name: {{ registration.member.profile.display_name|safe }}
+
+~ With love, from Techie


### PR DESCRIPTION
Closes #3995 


### Summary
- Added emails to notify treasurer that a queue member can now attend the event but should not be fined if they don't attend because the registration deadline has passed.
- Added check to trigger this email to the cancel_registration service

### How to test
1. Create an event with registration and max participants
2. Add max participants+1
3. Cancel registration of 1 participant (via the user's own 'Cancel registration' button)
4. Wow check out that email!
