### PR TITLE
fixed the cancellation message

### DIFF
--- a/website/events/models/event.py
+++ b/website/events/models/event.py
@@ -235,9 +235,9 @@ class Event(models.Model):
     @property
     def cancel_too_late_message(self):
         return _(
-            "Cancellation isn't possible anymore without having to pay "
-            "the full costs of €" + str(self.fine) + ". Also note that "
-            "you will be unable to re-register."
+            "The deadline has passed, are you sure you want to cancel your registration "
+            "and pay the estimated full costs of" + str(self.fine) + "? "
+            "You will not be able to undo this!"
         )
 
     @property


### PR DESCRIPTION
Closes #3999.

### Summary
Changed the cancellation method and made it more clear what happens when you cancel after the deadline.

### How to test
1. Make an event and register for it
2. Let the cancellation deadline pass
3. Check the message if it is the same as:
```
"The deadline has passed, are you sure you want to cancel your registration and pay the estimated full costs of" + str(self.fine) + "?  You will not be able to undo this!"
```
