### PR TITLE
2099 centralise data minim times

### DIFF
--- a/website/events/services.py
+++ b/website/events/services.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from datetime import date, timedelta
 
+from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.formats import localize
@@ -495,7 +496,9 @@ def generate_category_statistics() -> dict:
 def execute_data_minimisation(dry_run=False):
     """Delete information about very old events."""
     # Sometimes years are 366 days of course, but better delete 1 or 2 days early than late
-    deletion_period = timezone.now().date() - timezone.timedelta(days=365 * 5)
+    deletion_period = timezone.now().date() - timezone.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["EVENTS"]
+    )
 
     queryset = EventRegistration.objects.filter(event__end__lte=deletion_period).filter(
         Q(payment__isnull=False) | Q(member__isnull=False) | ~Q(name__exact="<removed>")

--- a/website/events/tests/test_services.py
+++ b/website/events/tests/test_services.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import AnonymousUser, Permission
 from django.http import HttpRequest
 from django.test import TestCase, override_settings
 from django.utils import timezone
+from django.conf import settings
 
 from freezegun import freeze_time
 
@@ -13,6 +14,7 @@ from events import services
 from events.exceptions import RegistrationError
 from events.models import Event, EventRegistration, RegistrationInformationField
 from members.models import Member
+from payments.models import Payment
 
 
 @freeze_time("2017-01-01")
@@ -537,3 +539,56 @@ class ServicesTest(TestCase):
             # Test that the ordering is correct
             labels = [field["label"] for field in fields.values()]
             self.assertEqual(labels, sorted(labels))
+
+    def test_data_minimisation(self):
+        #sanity check for data retention
+        with self.subTest("EventRegistrations older than 5 years should be minimised"):
+            e1 = Event.objects.create(
+            pk=2,
+            title="testevent",
+            description="desc",
+            published=True,
+            start=(timezone.now() - timedelta(days=(settings.DATA_RETENTION_PERIODS["EVENTS"]) + 1)), #should be minimised
+            end=(timezone.now() - timedelta(days=(settings.DATA_RETENTION_PERIODS["EVENTS"]) + 2)),
+            location="test location",
+            map_location="test map location",
+            price=0.00,
+            fine=0.00,
+            )
+
+            registration = EventRegistration.objects.create(
+                event=e1,
+                member=self.member,
+            )
+
+            result = services.execute_data_minimisation(dry_run=True)
+
+            self.assertTrue(result.filter(pk=registration.pk).exists())
+
+        with self.subTest("EventRegistrartions younger than 5 years should not be minimised"):
+            e2 = Event.objects.create(
+            pk=3,
+            title="testevent",
+            description="desc",
+            published=True,
+            start=(timezone.now() - timedelta(days=(settings.DATA_RETENTION_PERIODS["EVENTS"] - 2))), #should not be minimised
+            end=(timezone.now() - timedelta(days=(settings.DATA_RETENTION_PERIODS["EVENTS"] - 1))),
+            location="test location",
+            map_location="test map location",
+            price=0.00,
+            fine=0.00,
+            )
+
+            registration2 = EventRegistration.objects.create(
+                event=e2,
+                member=self.member,
+            )
+
+            result = services.execute_data_minimisation(dry_run=True)
+
+            self.assertFalse(result.filter(pk=registration2.pk).exists())
+
+
+
+
+

--- a/website/events/tests/test_services.py
+++ b/website/events/tests/test_services.py
@@ -14,8 +14,6 @@ from events import services
 from events.exceptions import RegistrationError
 from events.models import Event, EventRegistration, RegistrationInformationField
 from members.models import Member
-from payments.models import Payment
-
 
 @freeze_time("2017-01-01")
 @override_settings(SUSPEND_SIGNALS=True)

--- a/website/facedetection/services.py
+++ b/website/facedetection/services.py
@@ -23,9 +23,11 @@ def execute_data_minimisation(dry_run=False):
     This deletes reference faces that have been marked for deletion by the user for
     some time, as well as reference faces of users that have not logged in for a year.
     """
-    delete_period_inactive_member = timezone.now() - timezone.timedelta(days=365)
+    delete_period_inactive_member = timezone.now() - timezone.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["FACEDETECTION_INACTIVE"]
+    )
     delete_period_marked_for_deletion = timezone.now() - timezone.timedelta(
-        days=settings.FACEDETECTION_REFERENCE_FACE_STORAGE_PERIOD_AFTER_DELETE_DAYS
+        days=settings.DATA_RETENTION_PERIODS["FACEDETECTION_MARKED"]
     )
 
     queryset = ReferenceFace.objects.filter(

--- a/website/members/services.py
+++ b/website/members/services.py
@@ -231,7 +231,11 @@ def execute_data_minimisation(dry_run=False, members=None) -> list[Member]:
         .distinct()
         .prefetch_related("membership_set", "profile")
     )
-    deletion_period = timezone.now().date() - timezone.timedelta(days=90)
+
+    deletion_period = timezone.now().date() - timezone.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["MEMBERS"]
+    )
+    
     processed_members = []
     for member in members:
         if (

--- a/website/members/services.py
+++ b/website/members/services.py
@@ -235,7 +235,7 @@ def execute_data_minimisation(dry_run=False, members=None) -> list[Member]:
     deletion_period = timezone.now().date() - timezone.timedelta(
         days=settings.DATA_RETENTION_PERIODS["MEMBERS"]
     )
-    
+
     processed_members = []
     for member in members:
         if (

--- a/website/payments/services.py
+++ b/website/payments/services.py
@@ -238,8 +238,12 @@ def send_tpay_batch_processing_emails(batch):
 def execute_data_minimisation(dry_run=False):
     """Anonymize payments older than 7 years. Also revoke mandates of minimized users."""
     # Sometimes years are 366 days of course, but better delete 1 or 2 days early than late
-    payment_deletion_period = timezone.now().date() - timezone.timedelta(days=365 * 7)
-    bankaccount_deletion_period = timezone.now() - datetime.timedelta(days=31 * 13)
+    payment_deletion_period = timezone.now().date() - timezone.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["PAYMENTS_PAYMENTS"]
+    )
+    bankaccount_deletion_period = timezone.now() - datetime.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["PAYMENTS_INVALID_BANKACCS"]
+    )
 
     queryset_payments = Payment.objects.filter(
         created_at__lte=payment_deletion_period

--- a/website/pizzas/services.py
+++ b/website/pizzas/services.py
@@ -1,5 +1,6 @@
 from django.db.models import Count
 from django.utils import timezone
+from django.conf import settings
 
 from events.services import is_organiser
 
@@ -43,7 +44,9 @@ def can_change_order(member, food_event):
 def execute_data_minimisation(dry_run=False):
     """Anonymizes pizzas orders older than 3 years."""
     # Sometimes years are 366 days of course, but better delete 1 or 2 days early than late
-    deletion_period = timezone.now().date() - timezone.timedelta(days=365 * 3)
+    deletion_period = timezone.now().date() - timezone.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["FOOD"]
+    )
 
     queryset = FoodOrder.objects.filter(food_event__end__lte=deletion_period).exclude(
         name="<removed>"

--- a/website/pizzas/tests.py
+++ b/website/pizzas/tests.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import ContentType, Permission
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.utils import timezone, translation
+from django.conf import settings
 
 from freezegun import freeze_time
 
@@ -11,7 +12,7 @@ from activemembers.models import Committee
 from events.models import Event
 from members.models import Member
 from pizzas import services
-from pizzas.models import FoodEvent, FoodOrder
+from pizzas.models import FoodEvent, FoodOrder, Product
 
 
 @freeze_time("2018-03-21")
@@ -151,3 +152,73 @@ class PizzaEventTestCase(TestCase):
         # refresh member to defeat cache
         member = Member.objects.get(pk=self.member.pk)
         self.assertTrue(services.can_change_order(member, self.food_event))
+
+    def test_data_minimisation(self):
+
+        p1 = Product.objects.create(
+            name="test",
+            description="test descr",
+            price=1.00
+        )
+        
+        with self.subTest("FoodOrders older than 3 years should be minimised"):
+            e1 = Event.objects.create(
+            pk=10,
+            title="testevent",
+            description="desc",
+            published=True,
+            start=(timezone.now() - datetime.timedelta(days=(settings.DATA_RETENTION_PERIODS["FOOD"]) + 1)), #should be minimised
+            end=(timezone.now() - datetime.timedelta(days=(settings.DATA_RETENTION_PERIODS["FOOD"]) + 2)),
+            location="test location",
+            map_location="test map location",
+            price=0.00,
+            fine=0.00,
+            )
+        
+            fo1 = FoodEvent.objects.create(
+                start=e1.start,
+                end=e1.end,
+                event=e1,
+            )
+
+            o1 = FoodOrder.objects.create(
+                member=self.member,
+                food_event=fo1,
+                product=p1,
+            )
+
+            result = services.execute_data_minimisation(dry_run=True)
+
+            self.assertTrue(result.filter(pk=o1.pk).exists())
+
+        with self.subTest("FoodOrders not older than 3 years should not be minimised"):
+            e2 = Event.objects.create(
+            pk=11,
+            title="testevent",
+            description="desc",
+            published=True,
+            start=(timezone.now() - datetime.timedelta(days=(settings.DATA_RETENTION_PERIODS["FOOD"]) -2)), #should not be minimised
+            end=(timezone.now() - datetime.timedelta(days=(settings.DATA_RETENTION_PERIODS["FOOD"]) - 1)),
+            location="test location",
+            map_location="test map location",
+            price=0.00,
+            fine=0.00,
+            )
+        
+            fo2 = FoodEvent.objects.create(
+                start=e2.start,
+                end=e2.end,
+                event=e2,
+            )
+            
+            o2 = FoodOrder.objects.create(
+                member=self.member,
+                food_event=fo2,
+                product=p1,
+            )
+
+            result = services.execute_data_minimisation(dry_run=True)
+
+            self.assertFalse(result.filter(pk=o2.pk).exists())
+        
+    

--- a/website/pizzas/tests.py
+++ b/website/pizzas/tests.py
@@ -160,7 +160,7 @@ class PizzaEventTestCase(TestCase):
             description="test descr",
             price=1.00
         )
-        
+
         with self.subTest("FoodOrders older than 3 years should be minimised"):
             e1 = Event.objects.create(
             pk=10,
@@ -174,7 +174,7 @@ class PizzaEventTestCase(TestCase):
             price=0.00,
             fine=0.00,
             )
-        
+
             fo1 = FoodEvent.objects.create(
                 start=e1.start,
                 end=e1.end,
@@ -204,13 +204,13 @@ class PizzaEventTestCase(TestCase):
             price=0.00,
             fine=0.00,
             )
-        
+
             fo2 = FoodEvent.objects.create(
                 start=e2.start,
                 end=e2.end,
                 event=e2,
             )
-            
+
             o2 = FoodOrder.objects.create(
                 member=self.member,
                 food_event=fo2,
@@ -220,5 +220,5 @@ class PizzaEventTestCase(TestCase):
             result = services.execute_data_minimisation(dry_run=True)
 
             self.assertFalse(result.filter(pk=o2.pk).exists())
-        
-    
+
+

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -2,6 +2,7 @@
 
 import secrets
 
+from django.conf import settings
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.admin.options import get_content_type_for_model
 from django.contrib.auth import get_user_model
@@ -386,7 +387,10 @@ def execute_data_minimisation(dry_run=False):
     :param dry_run: does not really remove data if True
     :return: number of removed objects.
     """
-    deletion_period = timezone.now() - timezone.timedelta(days=31)
+    deletion_period = timezone.now() - timezone.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["REGISTRATIONS"]
+    )
+    
     registrations = Registration.objects.filter(
         Q(status=Entry.STATUS_COMPLETED) | Q(status=Entry.STATUS_REJECTED),
         updated_at__lt=deletion_period,

--- a/website/registrations/services.py
+++ b/website/registrations/services.py
@@ -390,7 +390,7 @@ def execute_data_minimisation(dry_run=False):
     deletion_period = timezone.now() - timezone.timedelta(
         days=settings.DATA_RETENTION_PERIODS["REGISTRATIONS"]
     )
-    
+
     registrations = Registration.objects.filter(
         Q(status=Entry.STATUS_COMPLETED) | Q(status=Entry.STATUS_REJECTED),
         updated_at__lt=deletion_period,

--- a/website/reimbursements/services.py
+++ b/website/reimbursements/services.py
@@ -1,22 +1,21 @@
 import logging
 from datetime import timedelta
 
+from django.conf import settings
 from django.utils import timezone
 
 from .models import Reimbursement
 
 logger = logging.getLogger(__name__)
-YEAR = timedelta(days=365)
-
 
 def execute_data_minimisation(dry_run=False):
     def _delete_old_reimbursements(
         verdict: Reimbursement.Verdict,
-        years_until_deletion: int,
+        days_until_deletion: int,
     ):
         old_reimbursements = Reimbursement.objects.filter(
             verdict=verdict,
-            created__lt=timezone.now() - YEAR * years_until_deletion,
+            created__lt=timezone.now() - days_until_deletion,
         )
 
         logger.info(
@@ -25,5 +24,10 @@ def execute_data_minimisation(dry_run=False):
         if not dry_run:
             old_reimbursements.delete()
 
-    _delete_old_reimbursements(Reimbursement.Verdict.DENIED, years_until_deletion=2)
-    _delete_old_reimbursements(Reimbursement.Verdict.APPROVED, years_until_deletion=7)
+    _delete_old_reimbursements(Reimbursement.Verdict.DENIED, 
+        days_until_deletion=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_DENIED"]
+    )
+
+    _delete_old_reimbursements(Reimbursement.Verdict.APPROVED, 
+        days_until_deletion=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_APPROVED"]
+    )

--- a/website/reimbursements/services.py
+++ b/website/reimbursements/services.py
@@ -24,10 +24,10 @@ def execute_data_minimisation(dry_run=False):
         if not dry_run:
             old_reimbursements.delete()
 
-    _delete_old_reimbursements(Reimbursement.Verdict.DENIED, 
+    _delete_old_reimbursements(Reimbursement.Verdict.DENIED,
         days_until_deletion=timedelta(days=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_DENIED"])
     )
 
-    _delete_old_reimbursements(Reimbursement.Verdict.APPROVED, 
+    _delete_old_reimbursements(Reimbursement.Verdict.APPROVED,
         days_until_deletion=timedelta(days=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_APPROVED"])
     )

--- a/website/reimbursements/services.py
+++ b/website/reimbursements/services.py
@@ -25,9 +25,9 @@ def execute_data_minimisation(dry_run=False):
             old_reimbursements.delete()
 
     _delete_old_reimbursements(Reimbursement.Verdict.DENIED, 
-        days_until_deletion=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_DENIED"]
+        days_until_deletion=timedelta(days=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_DENIED"])
     )
 
     _delete_old_reimbursements(Reimbursement.Verdict.APPROVED, 
-        days_until_deletion=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_APPROVED"]
+        days_until_deletion=timedelta(days=settings.DATA_RETENTION_PERIODS["REIMBURSEMENTS_APPROVED"])
     )

--- a/website/sales/services.py
+++ b/website/sales/services.py
@@ -2,6 +2,7 @@ from django.db.models import Sum
 from django.utils import timezone
 
 from sales.models.order import Order, OrderItem
+from django.conf import settings
 
 
 def is_adult(member):
@@ -26,7 +27,9 @@ def is_manager(member, shift):
 def execute_data_minimisation(dry_run=False):
     """Anonymizes orders older than 3 years."""
     # Sometimes years are 366 days of course, but better delete 1 or 2 days early than late
-    deletion_period = timezone.now().date() - timezone.timedelta(days=365 * 3)
+    deletion_period = timezone.now().date() - timezone.timedelta(
+        days=settings.DATA_RETENTION_PERIODS["SALES_ORDERS"]
+    )
 
     queryset = Order.objects.filter(created_at__lte=deletion_period).exclude(
         payer__isnull=True

--- a/website/sales/tests/test_services.py
+++ b/website/sales/tests/test_services.py
@@ -1,6 +1,8 @@
 import datetime
 from unittest.mock import MagicMock
 
+from django.conf import settings
+
 from django.test import TestCase
 from django.utils import timezone
 
@@ -10,6 +12,7 @@ from activemembers.models import Committee, MemberGroupMembership
 from members.models import Member, Profile
 from sales import services
 from sales.models.product import Product, ProductList
+from sales.models.order import Order
 from sales.models.shift import Shift
 from sales.services import is_manager
 
@@ -71,3 +74,23 @@ class SalesServicesTest(TestCase):
         self.member.has_perm = MagicMock()
         self.member.has_perm.return_value = True
         self.assertTrue(is_manager(self.member, self.shift))
+
+    def test_data_retention(self):
+        self.sale_old = Order.objects.create( #should be minimised
+            created_at = timezone.now() - datetime.timedelta(days=settings.DATA_RETENTION_PERIODS["SALES_ORDERS"] + 1),
+            created_by = self.member,
+            shift = self.shift,
+            payer = self.member
+        )
+
+        self.sale_new = Order.objects.create( #should not be minimised
+            created_at = timezone.now() - datetime.timedelta(days=settings.DATA_RETENTION_PERIODS["SALES_ORDERS"] - 1),
+            created_by = self.member,
+            shift = self.shift,
+            payer = self.member
+        )
+
+        result = services.execute_data_minimisation(dry_run=True)
+
+        self.assertTrue(result.filter(pk=self.sale_old.pk).exists())
+        self.assertFalse(result.filter(pk=self.sale_new.pk).exists())

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -165,7 +165,7 @@ TREASURER_NOTIFICATION_ADDRESS = (
 )
 
 # Dictionary which stores data retention periods for each relevant situation in one central place
-# For this data, we assume that a year always consists of 365 days, which is wrong. 
+# For this data, we assume that a year always consists of 365 days, which is wrong.
 # If a year lasts 366 days instead, the data is simply minimised earlier (i.e. we don't care).
 
 DATA_RETENTION_PERIODS = {
@@ -173,7 +173,7 @@ DATA_RETENTION_PERIODS = {
     "FACEDETECTION_INACTIVE" : 365, #period for facedetection reference photos of users (for users that have not logged in for some time)
     "FACEDETECTION_MARKED" : 180, #period for facedetection reference photos of users (for photos that were marked for deletion for some time)
     "MEMBERS" : 90, #period for old members (how long since their membership ended)
-    "PAYMENTS_PAYMENTS" : 365 * 7, #period for payments older than 7 years 
+    "PAYMENTS_PAYMENTS" : 365 * 7, #period for payments older than 7 years
     "PAYMENTS_INVALID_BANKACCS" : 31 * 13, #period for invalid bank accounts (how long since they have been last used)
     "FOOD" : 365 * 3, #period for food orders (how long after they've been)
     "REGISTRATIONS" : 31, #period for completed AND rejected registrations (how long after they happened)

--- a/website/thaliawebsite/settings.py
+++ b/website/thaliawebsite/settings.py
@@ -164,9 +164,23 @@ TREASURER_NOTIFICATION_ADDRESS = (
     f"{os.environ.get('ADDRESS_TREASURER', 'treasurer')}@{SITE_DOMAIN}"
 )
 
+# Dictionary which stores data retention periods for each relevant situation in one central place
+# For this data, we assume that a year always consists of 365 days, which is wrong. 
+# If a year lasts 366 days instead, the data is simply minimised earlier (i.e. we don't care).
 
-# How many days to keep reference faces after a user marks them for deletion
-FACEDETECTION_REFERENCE_FACE_STORAGE_PERIOD_AFTER_DELETE_DAYS = 180
+DATA_RETENTION_PERIODS = {
+    "EVENTS" : 365 * 5, #period for old events (how long after they took place)
+    "FACEDETECTION_INACTIVE" : 365, #period for facedetection reference photos of users (for users that have not logged in for some time)
+    "FACEDETECTION_MARKED" : 180, #period for facedetection reference photos of users (for photos that were marked for deletion for some time)
+    "MEMBERS" : 90, #period for old members (how long since their membership ended)
+    "PAYMENTS_PAYMENTS" : 365 * 7, #period for payments older than 7 years 
+    "PAYMENTS_INVALID_BANKACCS" : 31 * 13, #period for invalid bank accounts (how long since they have been last used)
+    "FOOD" : 365 * 3, #period for food orders (how long after they've been)
+    "REGISTRATIONS" : 31, #period for completed AND rejected registrations (how long after they happened)
+    "REIMBURSEMENTS_DENIED" : 365 * 2, #period for denied reimbursement requests
+    "REIMBURSEMENTS_APPROVED" : 365 * 7, #period for approved reimbursement requests
+    "SALES_ORDERS" : 365 * 3 #period for orders older than a certain threshold
+}
 
 # How many reference faces a user can have at the same time
 FACEDETECTION_MAX_NUM_REFERENCE_FACES = 5


### PR DESCRIPTION
Closes #2099

<!-- Please link related issues above, and label this PR with one of:
- feature: something new.
- bug: something is fixed.
- chore: updating depencencies, tests, etc.
-->

### Summary
<!-- A clear and concise description of the changes that you made. What bug did you solve? Or what feature did you add? -->
The ```website/thaliawebsite/settings.py``` file now has a DATA_RETENTION_PERIODS constant array which stores the data retention periods for each relevant situation (in days). Tests have also been updated, with the exception of the ```facedetection``` and ```reimbursements``` apps.

### How to test
<!-- Steps to test the changes you made: -->
1. All the data retention related tests should still pass as they did previously.
2. Additionally, new tests for data retention have been added to the ```events```, ```pizzas``` and ```sales``` apps. These are more like sanity checks than sophisticated tests, and should always pass.
